### PR TITLE
resolve #183: refine phase transition behavior

### DIFF
--- a/src/actions/actions.ts
+++ b/src/actions/actions.ts
@@ -208,17 +208,6 @@ export const HeaderActions = {
   },
 };
 
-export const KEYBOARD_DEFINITION_FORM_ACTIONS = '@KeyboardDefinitionForm';
-export const KEYBOARD_DEFINITION_FORM_UPDATE_DRAGGING = `${KEYBOARD_DEFINITION_FORM_ACTIONS}/UpdateDragging`;
-export const KeyboardDefinitionFormActions = {
-  updateDragging: (dragging: boolean) => {
-    return {
-      type: KEYBOARD_DEFINITION_FORM_UPDATE_DRAGGING,
-      value: dragging,
-    };
-  },
-};
-
 export const APP_ACTIONS = '@App';
 export const APP_UPDATE_SETUP_PHASE = `${APP_ACTIONS}/UpdateSetupPhase`;
 export const APP_REMAPS_INIT = `${APP_ACTIONS}/RemapsInit`;

--- a/src/actions/hid.action.ts
+++ b/src/actions/hid.action.ts
@@ -85,26 +85,23 @@ export const hidActionsThunk = {
 
     const result = await hid.instance.connect();
     if (!result.success) {
-      // do nothing
+      // cancel: do nothing
       return;
     }
 
     const keyboard: IKeyboard = result.keyboard!;
 
-    // Opened keyboard MUST had been authorized
-    if (keyboard.isOpened()) {
-      /**
-       * If the connected device has opened by this app, do nothing.
-       * We should NOT do something except showing a message if another application has opened the device.
-       */
-      const listedKbd = keyboards.find((kbd) => kbd.isSameDevice(keyboard));
-      if (listedKbd) {
-        // do nothing
+    if (0 < keyboards.length) {
+      // If the connecting keyboard had already added Remap state, do nothing
+      const listed = keyboards.find((kbd) => kbd.isSameDevice(keyboard));
+      if (listed) {
         return;
       }
+    }
 
+    // Opened keyboard MUST had been authorized
+    if (keyboard.isOpened()) {
       const msg = 'This device has already opened by another application';
-      console.log(msg);
       dispatch(NotificationActions.addWarn(msg));
       return;
     }
@@ -113,7 +110,6 @@ export const hidActionsThunk = {
      * If the connected device has already included in state, use the keyboard object in state in order not to effect the keyboard list state.
      * Unless the connected device has included in state, use it and add to the keyboard list in state.
      */
-    //console.log(keyboard);
     dispatch(AppActions.updateSetupPhase(SetupPhase.connectingKeyboard));
     await dispatch(hidActionsThunk.closeOpenedKeyboard());
     const listedKbd = keyboards.find((kbd) => kbd.isSameDevice(keyboard));

--- a/src/components/configure/Configure.container.ts
+++ b/src/components/configure/Configure.container.ts
@@ -1,6 +1,6 @@
 import { connect } from 'react-redux';
 import Configure from './Configure';
-import { RootState } from '../../store/state';
+import { RootState, SetupPhase } from '../../store/state';
 import { HidActions, hidActionsThunk } from '../../actions/hid.action';
 import { AppActions, NotificationActions } from '../../actions/actions';
 import { IKeyboard } from '../../services/hid/Hid';
@@ -13,6 +13,7 @@ const mapStateToProps = (state: RootState) => {
     auth: state.auth.instance,
     storage: state.storage.instance,
     draggingKey: state.keycodeKey.draggingKey,
+    keyboard: state.entities.keyboard,
   };
 };
 export type ConfigureStateType = ReturnType<typeof mapStateToProps>;
@@ -22,19 +23,38 @@ const mapDispatchToProps = (_dispatch: any) => {
     initAppPackage: (name: string, version: string) => {
       _dispatch(AppActions.initAppPackage(name, version));
     },
+
     updateAuthorizedKeyboardList: () =>
       _dispatch(hidActionsThunk.updateAuthorizedKeyboardList()),
-    test: () => _dispatch(NotificationActions.addWarn('hoge')),
+
     removeNotification: (key: string) => {
       _dispatch(NotificationActions.removeNotification(key));
     },
+
     onConnectKeyboard: (keyboard: IKeyboard) => {
       _dispatch(HidActions.connectKeyboard(keyboard));
     },
-    onDisconnectKeyboard: (keyboard: IKeyboard) => {
-      _dispatch(hidActionsThunk.closeKeyboard(keyboard));
+
+    onDisconnectKeyboard: (keyboard: IKeyboard, managedKeyboard: IKeyboard) => {
+      if (keyboard.isOpened()) {
+        _dispatch(hidActionsThunk.closeKeyboard(keyboard));
+      } else {
+        if (keyboard.isSameDevice(managedKeyboard)) {
+          /**
+           * In case of at KeyboardDefinitionForm page,
+           * the keyboard is NOT opened but set on state.entities.keyboard.
+           * Switch to Keyboard selection page.
+           */
+          _dispatch(HidActions.updateKeyboard(null));
+          _dispatch(
+            AppActions.updateSetupPhase(SetupPhase.keyboardNotSelected)
+          );
+        }
+      }
+
       _dispatch(HidActions.disconnectKeyboard(keyboard));
     },
+
     onCloseKeyboard: (keyboard: IKeyboard) => {
       _dispatch(hidActionsThunk.closeKeyboard(keyboard));
     },

--- a/src/components/configure/Configure.tsx
+++ b/src/components/configure/Configure.tsx
@@ -85,7 +85,10 @@ class Configure extends React.Component<ConfigureProps, OwnState> {
         this.props.onConnectKeyboard!(connectedKeyboard);
       },
       disconnect: (disconnectedKeyboard: IKeyboard) => {
-        this.props.onDisconnectKeyboard!(disconnectedKeyboard);
+        this.props.onDisconnectKeyboard!(
+          disconnectedKeyboard,
+          this.props.keyboard!
+        );
       },
       close: (keyboard: IKeyboard) => {
         this.props.onCloseKeyboard!(keyboard);

--- a/src/components/configure/content/Content.container.ts
+++ b/src/components/configure/content/Content.container.ts
@@ -4,11 +4,7 @@ import { RootState } from '../../../store/state';
 
 const mapStateToProps = (state: RootState) => {
   return {
-    hoverKey: state.keycodeKey.hoverKey,
-    keyboard: state.entities.keyboard,
     setupPhase: state.app.setupPhase,
-    keyboards: state.entities.keyboards,
-    keyboardHeight: state.app.keyboardHeight,
   };
 };
 export type ContentStateType = ReturnType<typeof mapStateToProps>;

--- a/src/components/configure/content/Content.scss
+++ b/src/components/configure/content/Content.scss
@@ -6,71 +6,14 @@
   min-width: 780px;
   height: 100vh;
 
-  .keyboard-wrapper {
-    position: fixed;
-    width: 100%;
-    margin-top: calc(var(--key-height));
-    z-index: 1;
-    .controller {
-      display: flex;
-      flex-direction: row;
-      padding: $space-l;
-      background-color: white;
-      .switch {
-        display: flex;
-        margin-left: auto;
-      }
-    }
-    .keymap {
-      display: flex;
-      flex-direction: column;
-      padding-bottom: 32px;
-      background-color: white;
-      min-height: 400px;
-    }
-    .in-progress {
-      position: absolute;
-      width: 100%;
-      height: 100%;
-      background-color: rgba(255, 255, 255, 0.8);
-      z-index: 1;
-      .progress {
-        position: absolute;
-        top: 50%;
-        left: 50%;
-        margin-top: -12px;
-        margin-left: -12px;
-      }
-    }
-  }
-  .keycode {
-    display: flex;
+  .phase-processing-wrapper {
     position: relative;
-    flex-direction: column;
-    padding: $space-m $space-m $space-xl $space-m;
-    background-color: #f3f3f3;
-    flex: 1;
-    overflow-y: scroll;
-
-    .disable {
-      position: absolute;
-      width: 100%;
-      height: 100%;
-      background: rgba(255, 255, 255, 0.8);
-      margin-left: -16px;
-      margin-top: -16px;
-    }
-  }
-
-  .keycode-desc {
     display: flex;
-    width: 100%;
-    padding: $space-s $space-l;
-
-    background-color: rgba(0, 0, 0, 0.4);
-    position: fixed;
-    bottom: 0;
-    color: white;
-    z-index: 3;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    padding-top: $space-xl;
+    background-color: white;
+    flex: 1 1;
   }
 }

--- a/src/components/configure/header/Header.container.ts
+++ b/src/components/configure/header/Header.container.ts
@@ -1,9 +1,9 @@
 import { connect } from 'react-redux';
 import Header from './Header';
-import { RootState, SetupPhase } from '../../../store/state';
+import { RootState } from '../../../store/state';
 import { hidActionsThunk } from '../../../actions/hid.action';
 import { IKeyboard } from '../../../services/hid/Hid';
-import { AppActions, HeaderActions } from '../../../actions/actions';
+import { HeaderActions } from '../../../actions/actions';
 
 const mapStateToProps = (state: RootState) => {
   const kbd = state.entities.keyboard;
@@ -12,7 +12,7 @@ const mapStateToProps = (state: RootState) => {
     draggingKey: state.keycodeKey.draggingKey,
     flashing: state.header.flashing,
     keyboards: state.entities.keyboards,
-    openedKeyboard: kbd,
+    openedKeyboard: state.entities.keyboard,
     productId: info?.productId || NaN,
     productName: info?.productName || '',
     vendorId: info?.vendorId || NaN,
@@ -25,11 +25,9 @@ export type HeaderStateType = ReturnType<typeof mapStateToProps>;
 const mapDispatchToProps = (_dispatch: any) => {
   return {
     onClickKeyboardMenuItem: (kbd: IKeyboard) => {
-      _dispatch(AppActions.updateSetupPhase(SetupPhase.connectingKeyboard));
       _dispatch(hidActionsThunk.connectKeyboard(kbd));
     },
     onClickAnotherKeyboard: () => {
-      _dispatch(AppActions.updateSetupPhase(SetupPhase.connectingKeyboard));
       _dispatch(hidActionsThunk.connectAnotherKeyboard());
     },
     onClickFlashButton: () => {

--- a/src/components/configure/header/Header.scss
+++ b/src/components/configure/header/Header.scss
@@ -84,6 +84,7 @@
   flex-direction: row;
   border-bottom: 1px solid rgba(0, 0, 0, 0.2);
   align-items: center;
+  width: 100%;
 
   .link-icon {
     margin-right: $space-m;

--- a/src/components/configure/header/Header.tsx
+++ b/src/components/configure/header/Header.tsx
@@ -1,12 +1,13 @@
+/* eslint-disable no-undef */
 import React from 'react';
 import './Header.scss';
 import logo from '../../../assets/images/logo.png';
 import { hexadecimal } from '../../../utils/StringUtils';
 import { Button, Menu, MenuItem } from '@material-ui/core';
-import { ArrowDropDown, Link, LinkOff } from '@material-ui/icons';
+import { ArrowDropDown, Link } from '@material-ui/icons';
 import ConnectionModal from '../modals/connection/ConnectionModal';
 import { HeaderActionsType, HeaderStateType } from './Header.container';
-import { IKeymap } from '../../../services/hid/Hid';
+import { IKeyboard, IKeymap } from '../../../services/hid/Hid';
 
 type HeaderState = {
   connectionStateEl: any;
@@ -20,15 +21,25 @@ type HeaderProps = OwnProps &
 
 export default class Header extends React.Component<HeaderProps, HeaderState> {
   private hasKeysToFlash: boolean = false;
-  // eslint-disable-next-line no-undef
   flashButtonRef: React.RefObject<HTMLButtonElement>;
+  deviceMenuRef: React.RefObject<HTMLDivElement>;
   constructor(props: HeaderProps | Readonly<HeaderProps>) {
     super(props);
     this.state = {
       connectionStateEl: null,
     };
-    // eslint-disable-next-line no-undef
     this.flashButtonRef = React.createRef<HTMLButtonElement>();
+    this.deviceMenuRef = React.createRef<HTMLDivElement>();
+  }
+
+  shouldComponentUpdate(nextProps: HeaderProps) {
+    if (
+      this.props.showKeyboardList &&
+      this.props.keyboards!.length < nextProps.keyboards!.length
+    ) {
+      this.onClickDevice();
+    }
+    return true;
   }
 
   get openConnectionStateMenu() {
@@ -39,8 +50,8 @@ export default class Header extends React.Component<HeaderProps, HeaderState> {
     this.setState({ connectionStateEl: null });
   };
 
-  onClickDevice = (event: React.MouseEvent) => {
-    this.setState({ connectionStateEl: event.currentTarget });
+  onClickDevice = () => {
+    this.setState({ connectionStateEl: this.deviceMenuRef.current });
   };
 
   onClickConnectionMenuItemNewDevice = () => {
@@ -51,6 +62,11 @@ export default class Header extends React.Component<HeaderProps, HeaderState> {
     if (this.hasKeysToFlash) {
       this.props.onClickFlashButton!();
     }
+  }
+
+  private onClickKeyboardMenuItem(kbd: IKeyboard) {
+    this.onCloseConnectionStateMenu();
+    this.props.onClickKeyboardMenuItem!(kbd);
   }
 
   render() {
@@ -81,6 +97,7 @@ export default class Header extends React.Component<HeaderProps, HeaderState> {
       <header className="header">
         <img src={logo} alt="logo" className="logo" />
         <div
+          ref={this.deviceMenuRef}
           className={[
             'kbd-select',
             this.props.showKeyboardList ? '' : 'hidden',
@@ -118,18 +135,13 @@ export default class Header extends React.Component<HeaderProps, HeaderState> {
                   onClick={
                     isOpenedKbd
                       ? undefined
-                      : this.props.onClickKeyboardMenuItem!.bind(this, kbd)
+                      : this.onClickKeyboardMenuItem!.bind(this, kbd)
                   }
                   disabled={isOpenedKbd}
                 >
                   <div className="device-item">
-                    {isOpenedKbd ? (
+                    {isOpenedKbd && (
                       <Link fontSize="small" className="link-icon link-on" />
-                    ) : (
-                      <LinkOff
-                        fontSize="small"
-                        className="link-icon link-off"
-                      />
                     )}
                     <div className={['device-name', linking].join(' ')}>
                       {info.productName}
@@ -154,7 +166,7 @@ export default class Header extends React.Component<HeaderProps, HeaderState> {
                   className="another-device"
                   onClick={this.props.onClickAnotherKeyboard?.bind(this)}
                 >
-                  + Connect another device
+                  + KEYBOARD
                 </Button>
               </div>
             </MenuItem>

--- a/src/components/configure/keyboarddefform/KeyboardDefinitionForm.container.ts
+++ b/src/components/configure/keyboarddefform/KeyboardDefinitionForm.container.ts
@@ -1,15 +1,17 @@
 import { connect } from 'react-redux';
-import { KeyboardDefinitionFormActions } from '../../../actions/actions';
+import { NotificationActions } from '../../../actions/actions';
 import { RootState } from '../../../store/state';
 import KeyboardDefinitionForm from './KeyboardDefinitionForm';
 import { storageActionsThunk } from '../../../actions/storage.action';
+import { KeyboardDefinitionSchema } from '../../../gen/types/KeyboardDefinition';
+import { IKeyboard } from '../../../services/hid/Hid';
 
 const mapStateToProps = (state: RootState) => {
   const kbd = state.entities.keyboard;
   const info = kbd?.getInformation();
 
   return {
-    dragging: state.keyboardDefinitionForm.dragging,
+    keyboard: state.entities.keyboard,
     productName: info?.productName,
   };
 };
@@ -19,16 +21,12 @@ export type KeyboardDefinitionFormStateType = ReturnType<
 
 const mapDispatchToProps = (_dispatch: any) => {
   return {
-    onDragOverFile: () => {
-      _dispatch(KeyboardDefinitionFormActions.updateDragging(true));
+    warn: (msg: string) => {
+      _dispatch(NotificationActions.addWarn(msg));
     },
     // eslint-disable-next-line no-undef
-    onDropFile: (file: File) => {
-      _dispatch(KeyboardDefinitionFormActions.updateDragging(false));
-      _dispatch(storageActionsThunk.uploadKeyboardDefinition(file));
-    },
-    onDragLeaveFile: () => {
-      _dispatch(KeyboardDefinitionFormActions.updateDragging(false));
+    onDropFile: (def: KeyboardDefinitionSchema) => {
+      _dispatch(storageActionsThunk.uploadKeyboardDefinition(def));
     },
   };
 };
@@ -40,3 +38,50 @@ export default connect(
   mapStateToProps,
   mapDispatchToProps
 )(KeyboardDefinitionForm);
+
+// eslint-disable-next-line no-undef
+export const isJsonFile = (file: File): boolean => {
+  return file.type.endsWith('/json');
+};
+
+// eslint-disable-next-line no-undef
+export const loadDefinitionFile = async (file: File): Promise<string> => {
+  // eslint-disable-next-line no-undef
+  const loadTextFile = (file: File): Promise<string> => {
+    return new Promise<string>((resolve) => {
+      // eslint-disable-next-line no-undef
+      const fileReader = new FileReader();
+      fileReader.addEventListener('load', () => {
+        resolve(fileReader.result as string);
+      });
+      fileReader.readAsText(file);
+    });
+  };
+  const json = await loadTextFile(file);
+  return json;
+};
+
+export const validateIds = (
+  keyboardDefinition: KeyboardDefinitionSchema,
+  keyboard: IKeyboard
+): string | null => {
+  const getNumber = (source: string): number => {
+    if (!source) {
+      return NaN;
+    } else if (source.startsWith('0x')) {
+      const target = source.substring(2);
+      return Number.parseInt(target, 16);
+    } else {
+      return Number.parseInt(source);
+    }
+  };
+  const vendorId = getNumber(keyboardDefinition.vendorId);
+  const productId = getNumber(keyboardDefinition.productId);
+  if (vendorId !== keyboard.getInformation().vendorId) {
+    return `Invalid the vendor ID: ${vendorId}`;
+  }
+  if (productId !== keyboard.getInformation().productId) {
+    return `Invalid the product ID: ${productId}`;
+  }
+  return null;
+};

--- a/src/components/configure/keyboarddefform/KeyboardDefinitionForm.scss
+++ b/src/components/configure/keyboarddefform/KeyboardDefinitionForm.scss
@@ -7,6 +7,8 @@
   align-items: center;
   justify-content: center;
   padding-top: $space-xl;
+  background-color: white;
+  flex: 1 1;
 
   .message {
     padding: $space-m 0;
@@ -14,6 +16,7 @@
   }
 
   .upload-form {
+    position: relative;
     width: 320px;
     border: 1px solid rgba(0, 0, 0, 0.2);
     padding: 8px;
@@ -40,6 +43,16 @@
         border: 2px dashed rgba(0, 0, 0, 0.2);
         font-weight: bold;
       }
+    }
+    .keyboarddefinitionform-loading {
+      position: absolute;
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      justify-content: center;
+      height: 100%;
+      width: 100%;
+      background-color: rgba(255, 255, 255, 0.9);
     }
   }
 }

--- a/src/components/configure/keyboardlist/KeyboardList.container.ts
+++ b/src/components/configure/keyboardlist/KeyboardList.container.ts
@@ -1,7 +1,7 @@
 import { connect } from 'react-redux';
 import KeyboardList from './KeyboardList';
-import { RootState, SetupPhase } from '../../../store/state';
-import { AppActions, KeycodesActions } from '../../../actions/actions';
+import { RootState } from '../../../store/state';
+import { KeycodesActions } from '../../../actions/actions';
 import { hidActionsThunk } from '../../../actions/hid.action';
 import { IKeyboard, IKeycodeCategory } from '../../../services/hid/Hid';
 
@@ -15,12 +15,10 @@ export type KeyboardListStateType = ReturnType<typeof mapStateToProps>;
 const mapDispatchToProps = (_dispatch: any) => {
   return {
     onClickItem: (keyboard: IKeyboard) => {
-      _dispatch(AppActions.updateSetupPhase(SetupPhase.connectingKeyboard));
       _dispatch(hidActionsThunk.connectKeyboard(keyboard));
       _dispatch(KeycodesActions.updateCategory(IKeycodeCategory.BASIC)); // init keycode category
     },
     onClickConnectAnotherKeyboard: () => {
-      _dispatch(AppActions.updateSetupPhase(SetupPhase.connectingKeyboard));
       _dispatch(hidActionsThunk.connectAnotherKeyboard());
       _dispatch(KeycodesActions.updateCategory(IKeycodeCategory.BASIC)); // init keycode category
     },

--- a/src/components/configure/keyboardlist/KeyboardList.scss
+++ b/src/components/configure/keyboardlist/KeyboardList.scss
@@ -7,6 +7,8 @@
   align-items: center;
   justify-content: center;
   padding-top: $space-xl;
+  background: white;
+  flex: 1 1;
   .message {
     padding: $space-m 0;
     font-size: 1rem;

--- a/src/components/configure/keyboardlist/KeyboardList.tsx
+++ b/src/components/configure/keyboardlist/KeyboardList.tsx
@@ -48,17 +48,10 @@ export default class KeyboardList extends React.Component<
           >
             <h3 className="another">+ KEYBOARD</h3>
             <div className="device-ids">
-              Please add a new Web HID access permitted device
+              Add a Web HID access permitted device
             </div>
           </div>
         </div>
-        {/* {this.props.openingKeyboard && (
-          <div className="opening-keyboard">
-            <div className="progress">
-              <CircularProgress size={24} />
-            </div>
-          </div>
-        )} */}
       </div>
     );
   }

--- a/src/components/configure/keyboards/Keyboards.tsx
+++ b/src/components/configure/keyboards/Keyboards.tsx
@@ -94,14 +94,15 @@ export default class Keyboards extends React.Component<
             <div className="layer">
               <span>LAYER</span>
               {this.props.layers!.map((layer) => {
+                const invisible =
+                  this.props.remaps![layer] == undefined ||
+                  0 == Object.values(this.props.remaps![layer]).length;
                 return (
                   <StyledBadge
                     key={layer}
                     color="primary"
                     variant="dot"
-                    invisible={
-                      0 == Object.values(this.props.remaps![layer]).length
-                    }
+                    invisible={invisible}
                   >
                     <Chip
                       key={layer}

--- a/src/components/configure/remap/Remap.container.ts
+++ b/src/components/configure/remap/Remap.container.ts
@@ -1,0 +1,17 @@
+import { connect } from 'react-redux';
+import Remap from './Remap';
+import { RootState } from '../../../store/state';
+
+const mapStateToProps = (state: RootState) => {
+  return {
+    hoverKey: state.keycodeKey.hoverKey,
+    keyboard: state.entities.keyboard,
+    keyboardHeight: state.app.keyboardHeight,
+  };
+};
+export type RemapStateType = ReturnType<typeof mapStateToProps>;
+
+const mapDispatchToProps = {};
+export type RemapActionsType = typeof mapDispatchToProps;
+
+export default connect(mapStateToProps, mapDispatchToProps)(Remap);

--- a/src/components/configure/remap/Remap.scss
+++ b/src/components/configure/remap/Remap.scss
@@ -1,0 +1,55 @@
+@import '../../../variables';
+
+.keyboard-wrapper {
+  position: fixed;
+  width: 100%;
+  margin-top: calc(var(--key-height));
+  z-index: 1;
+  .controller {
+    display: flex;
+    flex-direction: row;
+    padding: $space-l;
+    background-color: white;
+    .switch {
+      display: flex;
+      margin-left: auto;
+    }
+  }
+  .keymap {
+    display: flex;
+    flex-direction: column;
+    padding-bottom: 32px;
+    background-color: white;
+    min-height: 400px;
+  }
+}
+.keycode {
+  display: flex;
+  position: relative;
+  flex-direction: column;
+  padding: $space-m $space-m $space-xl $space-m;
+  background-color: #f3f3f3;
+  flex: 1;
+  overflow-y: scroll;
+
+  .disable {
+    position: absolute;
+    width: 100%;
+    height: 100%;
+    background: rgba(255, 255, 255, 0.8);
+    margin-left: -16px;
+    margin-top: -16px;
+  }
+}
+
+.keycode-desc {
+  display: flex;
+  width: 100%;
+  padding: $space-s $space-l;
+
+  background-color: rgba(0, 0, 0, 0.4);
+  position: fixed;
+  bottom: 0;
+  color: white;
+  z-index: 3;
+}

--- a/src/components/configure/remap/Remap.tsx
+++ b/src/components/configure/remap/Remap.tsx
@@ -1,0 +1,59 @@
+import React from 'react';
+import './Remap.scss';
+import KEY_DESCRIPTIONS from '../../../assets/files/key_descriptions';
+import { IKeymap } from '../../../services/hid/Hid';
+import { hexadecimal } from '../../../utils/StringUtils';
+import Keycodes from '../keycodes/Keycodes.container';
+import Keymap from '../keymap/Keymap.container';
+import { RemapActionsType, RemapStateType } from './Remap.container';
+
+type OwnProp = {};
+type RemapPropType = OwnProp &
+  Partial<RemapStateType> &
+  Partial<RemapActionsType>;
+
+export default class Remap extends React.Component<RemapPropType, {}> {
+  constructor(props: RemapPropType | Readonly<RemapPropType>) {
+    super(props);
+  }
+
+  render() {
+    return (
+      <React.Fragment>
+        <div className="keyboard-wrapper">
+          <div className="keymap">
+            <Keymap />
+          </div>
+        </div>
+        <div
+          className="keycode"
+          style={{ marginTop: 200 + this.props.keyboardHeight! }}
+        >
+          <Keycodes />
+        </div>
+        {this.props.hoverKey && <Desc keymap={this.props.hoverKey.keymap} />}
+      </React.Fragment>
+    );
+  }
+}
+
+type DescType = {
+  keymap: IKeymap;
+};
+function Desc(props: DescType) {
+  if (props.keymap.keycodeInfo) {
+    const info = props.keymap.keycodeInfo!;
+    const long = info.name.long;
+    const desc =
+      long in KEY_DESCRIPTIONS
+        ? KEY_DESCRIPTIONS[long]
+        : hexadecimal(info.code);
+    return (
+      <div className="keycode-desc">
+        {long}: {desc}
+      </div>
+    );
+  } else {
+    return <div className="keycode-desc">Any</div>;
+  }
+}

--- a/src/store/reducers.ts
+++ b/src/store/reducers.ts
@@ -30,8 +30,6 @@ import {
   NOTIFICATION_ADD_INFO,
   NOTIFICATION_ADD_SUCCESS,
   APP_UPDATE_SETUP_PHASE,
-  KEYBOARD_DEFINITION_FORM_UPDATE_DRAGGING,
-  KEYBOARD_DEFINITION_FORM_ACTIONS,
   APP_REMAPS_CLEAR,
   KEYCODEKEY_CLEAR,
   ANYKEYCODEKEY_ACTIONS,
@@ -89,21 +87,8 @@ const reducers = (state: RootState = INIT_STATE, action: Action) =>
       appReducer(action, draft);
     } else if (action.type.startsWith(STORAGE_ACTIONS)) {
       storageReducer(action, draft);
-    } else if (action.type.startsWith(KEYBOARD_DEFINITION_FORM_ACTIONS)) {
-      keyboardDefinitionFormReducer(action, draft);
     }
   });
-
-const keyboardDefinitionFormReducer = (
-  action: Action,
-  draft: WritableDraft<RootState>
-) => {
-  switch (action.type) {
-    case KEYBOARD_DEFINITION_FORM_UPDATE_DRAGGING:
-      draft.keyboardDefinitionForm.dragging = action.value;
-      break;
-  }
-};
 
 const storageReducer = (action: Action, draft: WritableDraft<RootState>) => {
   switch (action.type) {

--- a/src/store/state.ts
+++ b/src/store/state.ts
@@ -13,6 +13,7 @@ import { IAuth } from '../services/auth/Auth';
 import { KeyboardDefinitionSchema } from '../gen/types/KeyboardDefinition';
 
 export type ISetupPhase =
+  | 'init'
   | 'keyboardNotSelected'
   | 'connectingKeyboard'
   | 'fetchingKeyboardDefinition'
@@ -20,6 +21,7 @@ export type ISetupPhase =
   | 'openingKeyboard'
   | 'openedKeyboard';
 export const SetupPhase: { [p: string]: ISetupPhase } = {
+  init: 'init',
   keyboardNotSelected: 'keyboardNotSelected',
   connectingKeyboard: 'connectingKeyboard',
   fetchingKeyboardDefinition: 'fetchingKeyboardDefinition',
@@ -90,9 +92,6 @@ export type RootState = {
     origin: IKeymap | null;
     destination: IKeymap | null;
   };
-  keyboardDefinitionForm: {
-    dragging: boolean;
-  };
   layoutOptions: {
     selectedOptions: string[];
   };
@@ -121,7 +120,7 @@ export const INIT_STATE: RootState = {
       name: '',
       version: '',
     },
-    setupPhase: SetupPhase.keyboardNotSelected,
+    setupPhase: SetupPhase.init,
     remaps: [],
     notifications: [],
     keyboardHeight: 295,
@@ -154,9 +153,6 @@ export const INIT_STATE: RootState = {
   keydiff: {
     origin: null,
     destination: null,
-  },
-  keyboardDefinitionForm: {
-    dragging: false,
   },
   layoutOptions: {
     selectedOptions: [],


### PR DESCRIPTION
Show a processing animation when connecting, loading and opening a keyboard.
<img width="331" alt="スクリーンショット 2021-01-18 19 02 06" src="https://user-images.githubusercontent.com/316463/104900964-1bcdd800-59c0-11eb-88dc-370488017438.png">

Show a processing animation in the Keyboard Definition File Form in order to avoid flickering of DOM rendering.
<img width="437" alt="スクリーンショット 2021-01-18 19 04 08" src="https://user-images.githubusercontent.com/316463/104901222-6ea78f80-59c0-11eb-8843-7ab90e995fe8.png">


Open the keyboard list in the header when a new keyboard connected.
<img width="453" alt="スクリーンショット 2021-01-18 19 01 35" src="https://user-images.githubusercontent.com/316463/104900908-03f65400-59c0-11eb-9837-684e91991dcd.png">
