### PR TITLE
resolve #76: show app version number on the bottom of all pages

### DIFF
--- a/src/components/configure/content/Content.container.ts
+++ b/src/components/configure/content/Content.container.ts
@@ -4,6 +4,7 @@ import { RootState } from '../../../store/state';
 
 const mapStateToProps = (state: RootState) => {
   return {
+    package: state.app.package,
     setupPhase: state.app.setupPhase,
   };
 };

--- a/src/components/configure/content/Content.scss
+++ b/src/components/configure/content/Content.scss
@@ -16,4 +16,14 @@
     background-color: white;
     flex: 1 1;
   }
+
+  .app-version {
+    position: absolute;
+    bottom: 0px;
+    right: 0px;
+    color: $color-gray-400;
+    font-size: 0.7rem;
+    margin-right: $space-s;
+    margin-bottom: $space-s;
+  }
 }

--- a/src/components/configure/content/Content.tsx
+++ b/src/components/configure/content/Content.tsx
@@ -27,6 +27,9 @@ export default class Content extends React.Component<
     return (
       <div className="content">
         <Contents setupPhase={this.props.setupPhase!} />
+        <div className="app-version">
+          {this.props.package!.name}: {this.props.package!.version}
+        </div>
       </div>
     );
   }

--- a/src/components/configure/keycodekey/KeycodeKey.scss
+++ b/src/components/configure/keycodekey/KeycodeKey.scss
@@ -11,6 +11,7 @@
   color: #333;
   margin-right: 8px;
   margin-top: 8px;
+  z-index: 1;
   &.grabbable {
     cursor: grab;
   }

--- a/src/components/configure/remap/Remap.container.ts
+++ b/src/components/configure/remap/Remap.container.ts
@@ -7,6 +7,7 @@ const mapStateToProps = (state: RootState) => {
     hoverKey: state.keycodeKey.hoverKey,
     keyboard: state.entities.keyboard,
     keyboardHeight: state.app.keyboardHeight,
+    package: state.app.package,
   };
 };
 export type RemapStateType = ReturnType<typeof mapStateToProps>;


### PR DESCRIPTION
Show the app name and its version number on the bottom of all pages.
<img width="256" alt="スクリーンショット 2021-01-19 9 14 00" src="https://user-images.githubusercontent.com/316463/104973150-3a22ea80-5a37-11eb-99aa-afd19832ab40.png">


The text does not get in the way of keycodes.
<img width="256" alt="スクリーンショット 2021-01-19 9 14 07" src="https://user-images.githubusercontent.com/316463/104973224-663e6b80-5a37-11eb-8222-6732e313f920.png">
