### PR TITLE
resolve #190: text styling of keycode and keycap

### DIFF
--- a/src/components/configure/keycap/Keycap.scss
+++ b/src/components/configure/keycap/Keycap.scss
@@ -102,6 +102,7 @@
         font-size: 0.76rem;
         line-height: 1.1;
         width: 100%;
+        overflow-wrap: anywhere;
       }
       .left {
         text-align: left;

--- a/src/components/configure/keycodekey/KeycodeKey.scss
+++ b/src/components/configure/keycodekey/KeycodeKey.scss
@@ -41,8 +41,8 @@
     justify-content: center;
     align-items: center;
     text-align: center;
-    line-height: 16px;
-    font-size: 0.76rem;
+    line-height: 1.1;
+    font-size: 0.72rem;
     overflow-wrap: anywhere;
     overflow: hidden;
     padding: $space-xs;


### PR DESCRIPTION
<img width="427" alt="スクリーンショット_2021-01-19_9_46_46" src="https://user-images.githubusercontent.com/316463/104974462-79ebd100-5a3b-11eb-9f24-587207085934.png">
