### PR TITLE
resolve #204, #206: support option keys with multi rows

### DIFF
--- a/src/actions/actions.ts
+++ b/src/actions/actions.ts
@@ -215,7 +215,7 @@ export const APP_REMAPS_SET_KEY = `${APP_ACTIONS}/RemapsSetKey`;
 export const APP_REMAPS_REMOVE_KEY = `${APP_ACTIONS}/RemapsRemoveKey`;
 export const APP_REMAPS_CLEAR = `${APP_ACTIONS}/Clear`;
 export const APP_PACKAGE_INIT = `${APP_ACTIONS}/PackageInit`;
-export const APP_UPDATE_KEYBOARD_HEIGHT = `${APP_ACTIONS}/UpdateKeyboardHeight`;
+export const APP_UPDATE_KEYBOARD_SIZE = `${APP_ACTIONS}/UpdateKeyboardSize`;
 export const AppActions = {
   updateSetupPhase: (setupPhase: ISetupPhase) => {
     return {
@@ -265,10 +265,10 @@ export const AppActions = {
       },
     };
   },
-  updateKeyboardHeight: (height: number) => {
+  updateKeyboardSize: (width: number, height: number) => {
     return {
-      type: APP_UPDATE_KEYBOARD_HEIGHT,
-      value: height,
+      type: APP_UPDATE_KEYBOARD_SIZE,
+      value: { height, width },
     };
   },
 };

--- a/src/actions/actions.ts
+++ b/src/actions/actions.ts
@@ -268,7 +268,7 @@ export const AppActions = {
   updateKeyboardSize: (width: number, height: number) => {
     return {
       type: APP_UPDATE_KEYBOARD_SIZE,
-      value: { height, width },
+      value: { width, height },
     };
   },
 };

--- a/src/components/configure/keyboards/Keyboards.container.ts
+++ b/src/components/configure/keyboards/Keyboards.container.ts
@@ -24,8 +24,8 @@ const mapDispatchToProps = (_dispatch: any) => {
       _dispatch(KeyboardsActions.clearSelectedPos());
       _dispatch(KeyboardsActions.updateSelectedLayer(layer));
     },
-    setKeyboardHeight: (height: number) => {
-      _dispatch(AppActions.updateKeyboardHeight(height));
+    setKeyboardSize: (width: number, height: number) => {
+      _dispatch(AppActions.updateKeyboardSize(width, height));
     },
   };
 };

--- a/src/components/configure/keyboards/Keyboards.tsx
+++ b/src/components/configure/keyboards/Keyboards.tsx
@@ -40,11 +40,6 @@ export default class Keyboards extends React.Component<
     };
   }
 
-  componentDidUpdate() {
-    console.log(this.state.keyboard);
-    this.props.setKeyboardHeight!(this.state.keyboard.height);
-  }
-
   onClickLayer = (layer: number) => {
     this.props.onClickLayerNumber!(layer);
   };
@@ -88,6 +83,10 @@ export default class Keyboards extends React.Component<
         }
       });
     }
+    const { keymaps, width, height, left } = this.state.keyboard.getKeymap(
+      layoutOptions
+    );
+    this.props.setKeyboardSize!(width, height);
     return (
       <React.Fragment>
         <div className="layer-wrapper">
@@ -139,29 +138,21 @@ export default class Keyboards extends React.Component<
           <div
             className="keyboard-root"
             style={{
-              width:
-                this.state.keyboard.width + (BORDER_WIDTH + LAYOUT_PADDING) * 2,
-              height:
-                this.state.keyboard.height +
-                (BORDER_WIDTH + LAYOUT_PADDING) * 2,
+              width: width + (BORDER_WIDTH + LAYOUT_PADDING) * 2,
+              height: height + (BORDER_WIDTH + LAYOUT_PADDING) * 2,
             }}
           >
             <div
               className="keyboard-frame"
-              style={{
-                width: this.state.keyboard.width,
-                height: this.state.keyboard.height,
-              }}
+              style={{ width: width, height: height, marginLeft: -left }}
             >
-              {this.state.keyboard
-                .getKeymap(layoutOptions)
-                .map((model: KeyModel) => {
-                  return model.isDecal ? (
-                    ''
-                  ) : (
-                    <Keycap key={model.pos} model={model} />
-                  );
-                })}
+              {keymaps.map((model: KeyModel) => {
+                return model.isDecal ? (
+                  ''
+                ) : (
+                  <Keycap key={model.pos} model={model} />
+                );
+              })}
             </div>
           </div>
         </div>

--- a/src/components/configure/keycodes/Keycodes.container.ts
+++ b/src/components/configure/keycodes/Keycodes.container.ts
@@ -20,6 +20,7 @@ const mapStateToProps = (state: RootState) => {
     category: state.keycodes.category,
     draggingKey: state.keycodeKey.draggingKey,
     keys: state.keycodes.keys,
+    keyboardWidth: state.app.keyboardWidth,
     selectedKey: state.keycodeKey.selectedKey,
     macroText,
   };

--- a/src/components/configure/keycodes/Keycodes.scss
+++ b/src/components/configure/keycodes/Keycodes.scss
@@ -7,6 +7,8 @@
 .keycodes {
   display: flex;
   flex-wrap: wrap;
+  max-width: 1280px;
+  margin: 0 auto;
 }
 .key-categories {
   display: flex;

--- a/src/components/configure/keycodes/Keycodes.tsx
+++ b/src/components/configure/keycodes/Keycodes.tsx
@@ -69,7 +69,13 @@ export default class Keycodes extends React.Component<KeycodesProps, {}> {
             );
           })}
         </div>
-        <div className="keycodes">
+        <div
+          className="keycodes"
+          style={{
+            minWidth:
+              this.props.keyboardWidth! + 144 /* = (PADDING + KeycodeKey)*2 */,
+          }}
+        >
           {keys.map((key, index) => {
             return (
               <KeycodeKey
@@ -107,7 +113,7 @@ type MacroType = {
   selectedKey?: Key | null;
   macroText?: string | null;
 
-  // eslint-disable-next-line no-unused-vars
+  // eslint-disable-next-line no-undef
   onChangeMacroText: (event: React.ChangeEvent<HTMLTextAreaElement>) => void;
 };
 function Macro(props: MacroType) {

--- a/src/components/configure/keycodes/Keycodes.tsx
+++ b/src/components/configure/keycodes/Keycodes.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable no-undef */
 import React from 'react';
 import './Keycodes.scss';
 import { Button } from '@material-ui/core';
@@ -113,7 +114,7 @@ type MacroType = {
   selectedKey?: Key | null;
   macroText?: string | null;
 
-  // eslint-disable-next-line no-undef
+  // eslint-disable-next-line no-unused-vars
   onChangeMacroText: (event: React.ChangeEvent<HTMLTextAreaElement>) => void;
 };
 function Macro(props: MacroType) {

--- a/src/components/configure/remap/Remap.tsx
+++ b/src/components/configure/remap/Remap.tsx
@@ -31,16 +31,17 @@ export default class Remap extends React.Component<RemapPropType, {}> {
         >
           <Keycodes />
         </div>
-        {this.props.hoverKey && <Desc keymap={this.props.hoverKey.keymap} />}
+        <Desc keymap={this.props.hoverKey?.keymap} />
       </React.Fragment>
     );
   }
 }
 
 type DescType = {
-  keymap: IKeymap;
+  keymap?: IKeymap;
 };
 function Desc(props: DescType) {
+  if (!props.keymap) return <div></div>;
   if (props.keymap.keycodeInfo) {
     const info = props.keymap.keycodeInfo!;
     const long = info.name.long;

--- a/src/models/KeyboardModel.ts
+++ b/src/models/KeyboardModel.ts
@@ -1,5 +1,6 @@
 import { KeyOp } from '../gen/types/KeyboardDefinition';
 import KeyModel, { OPTION_DEFAULT } from './KeyModel';
+import { hasProperty } from '../utils/ObjectUtils';
 
 class Current {
   x = 0;
@@ -97,7 +98,11 @@ class KeymapItem {
   }
 
   get isDefault(): boolean {
-    return this.option == OPTION_DEFAULT;
+    return this.option == OPTION_DEFAULT || this.choice == '0';
+  }
+
+  get isOrigin(): boolean {
+    return this.choice == '0';
   }
 
   get current(): Current {
@@ -154,47 +159,59 @@ class KeymapItem {
 
 export default class KeyboardModel {
   private keymap: KeyModel[];
-  readonly width: number;
-  readonly height: number;
 
   constructor(km: ((string | KeyOp)[] | { name: string })[]) {
     const _km = km.filter((item) => Array.isArray(item)) as (
       | string
       | KeyOp
     )[][];
-    const { keymap, width, height } = this.parseKeyMap(_km);
+    const keymap = this.parseKeyMap(_km);
     this.keymap = keymap;
-    this.width = width;
-    this.height = height;
   }
 
-  getKeymap(options?: { option: string; optionChoice: string }[]): KeyModel[] {
-    if (!options) return this.keymap;
+  getKeymap(
+    options?: { option: string; optionChoice: string }[]
+  ): { keymaps: KeyModel[]; width: number; height: number; left: number } {
+    let keymaps = this.keymap;
+    if (options) {
+      keymaps = this.keymap.filter((item) => {
+        return (
+          item.isDefault ||
+          0 <=
+            options.findIndex(
+              (op) =>
+                op.option == item.option && op.optionChoice == item.optionChoice
+            )
+        );
+      });
+    }
 
-    return this.keymap.filter((item) => {
-      return (
-        item.isDefault ||
-        0 <=
-          options.findIndex(
-            (op) =>
-              op.option == item.option && op.optionChoice == item.optionChoice
-          )
-      );
+    let right = 0;
+    let left = Infinity;
+    let bottom = 0;
+    keymaps.forEach((model) => {
+      right = Math.max(right, model.endRight);
+      left = Math.min(left, model.left);
+      bottom = Math.max(bottom, model.endBottom);
     });
+
+    const width = right;
+    const height = bottom;
+    return { keymaps, width, height, left };
   }
 
   private parseKeyMap(keymap: (string | KeyOp)[][]) {
-    const optionKeymaps: {
-      [row: string]: { [option: string]: { [choice: string]: KeymapItem[] } };
-    } = {};
     const keymapsList: KeymapItem[][] = [];
+    const optionKeymaps: {
+      [option: string]: { [choice: string]: { [row: string]: KeymapItem[] } };
+    } = {};
+    const origKeymaps: { [row: string]: { [option: string]: KeymapItem } } = {};
 
     // STEP1: build  optionKeymaps
     const curr = new Current();
     for (let row = 0; row < keymap.length; row++) {
       const keyRow = keymap[row];
       keymapsList.push([]);
-      optionKeymaps[row] = {};
 
       curr.nextRow();
       for (let col = 0; col < keyRow.length; col++) {
@@ -212,19 +229,28 @@ export default class KeyboardModel {
         curr.next(keymapItem.w);
 
         keymapsList[row].push(keymapItem);
-        if (!keymapItem.isDefault && keymapItem.choice != '0') {
+        if (!keymapItem.isDefault) {
           const option = keymapItem.option;
           const choice = keymapItem.choice;
-          if (!Object.prototype.hasOwnProperty.call(optionKeymaps[row], option))
-            optionKeymaps[row][option] = {};
-          if (
-            !Object.prototype.hasOwnProperty.call(
-              optionKeymaps[row][option],
-              choice
-            )
-          )
-            optionKeymaps[row][option][choice] = [];
-          optionKeymaps[row][option][choice].push(keymapItem);
+          if (!hasProperty(optionKeymaps, option)) {
+            optionKeymaps[option] = {};
+          }
+          if (!hasProperty(optionKeymaps[option], choice)) {
+            optionKeymaps[option][choice] = {};
+          }
+
+          if (!hasProperty(optionKeymaps[option][choice], row)) {
+            optionKeymaps[option][choice][row] = [];
+          }
+          optionKeymaps[option][choice][row].push(keymapItem);
+        } else if (keymapItem.isOrigin) {
+          if (!hasProperty(origKeymaps, row)) {
+            origKeymaps[row] = {};
+          }
+          const option = keymapItem.option;
+          if (!hasProperty(origKeymaps[row], option)) {
+            origKeymaps[row][option] = keymapItem;
+          }
         }
       }
     }
@@ -241,66 +267,54 @@ export default class KeyboardModel {
       keymaps.forEach((item) => item.align(minX, minY));
     });
 
-    const searchOriginalPosition = (targetRow: number, option: string) => {
-      // search same row
-      const findOrigin = (keymaps: KeymapItem[]): KeymapItem | undefined => {
-        return keymaps.find(
-          (item: KeymapItem) => item.option == option && item.choice == '0'
-        );
-      };
+    /** STEP3: relocate option keys' position
+     * 3.1. relocate for row direction
+     * 3.2. relocate for col direction
+     */
+    // 3.1
+    Object.keys(origKeymaps).forEach((row) => {
+      Object.keys(origKeymaps[row]).forEach((option) => {
+        const origCurr = origKeymaps[row][option].current;
+        delete origKeymaps[row].option;
+        Object.keys(optionKeymaps[option]).forEach((choice) => {
+          if (hasProperty(optionKeymaps[option][choice], row)) {
+            const choices = optionKeymaps[option][choice][row];
+            const diffX =
+              choices[0].x + choices[0].x2 - origCurr!.x + origCurr!.x2;
+            choices.forEach((item: KeymapItem) => {
+              item.align(diffX, 0);
+            });
+            delete optionKeymaps[option].choice;
+          }
+        });
+      });
+    });
 
-      let targetItem: KeymapItem | undefined = findOrigin(
-        keymapsList[targetRow]
+    // 3.2
+    Object.keys(optionKeymaps).forEach((option: string) => {
+      const origRow = Object.keys(origKeymaps).find((row) =>
+        hasProperty(origKeymaps[row], option)
       );
-      if (targetItem) return targetItem.current;
-
-      // search below row
-      for (let i = targetRow + 1; i < keymapsList.length; i++) {
-        targetItem = findOrigin(keymapsList[i]);
-        if (targetItem) break;
-      }
-      if (targetItem) return targetItem.current;
-
-      // search above row
-      for (let i = targetRow - 1; i >= 0; i--) {
-        targetItem = findOrigin(keymapsList[i]);
-        if (targetItem) break;
-      }
-      if (targetItem) return targetItem.current;
-    };
-
-    // STEP3: relocate option keys' position
-    Object.keys(optionKeymaps).forEach((row: string) => {
-      Object.keys(optionKeymaps[row]).forEach((option: string) => {
-        Object.keys(optionKeymaps[row][option]).forEach((choice: string) => {
-          const choices: KeymapItem[] = optionKeymaps[row][option][choice];
-          const origCurr = searchOriginalPosition(Number(row), option);
-          const diffX =
-            choices[0].x + choices[0].x2 - origCurr!.x + origCurr!.x2;
-          const diffY =
-            choices[0].y + choices[0].y2 - origCurr!.y + origCurr!.y2;
-          choices.forEach((item: KeymapItem) => {
-            item.align(diffX, diffY);
+      const origCurr = origKeymaps[origRow!][option].current;
+      Object.keys(optionKeymaps[option]).forEach((choice: string) => {
+        const firstRow = Object.keys(optionKeymaps[option][choice])[0];
+        const optionOrigItem = optionKeymaps[option][choice][firstRow][0];
+        const diffY =
+          optionOrigItem.y + optionOrigItem.y2 - origCurr!.y + origCurr!.y2;
+        Object.keys(optionKeymaps[option][choice]).forEach((row: string) => {
+          const rows: KeymapItem[] = optionKeymaps[option][choice][row];
+          rows.forEach((item: KeymapItem) => {
+            item.align(0, diffY);
           });
         });
       });
     });
 
-    let width = 0;
-    let height = 0;
     const list: KeyModel[] = [];
     keymapsList.flat().forEach((item: KeymapItem) => {
       let model = new KeyModel(item.op, item.label, item.x, item.y, item.c, item.r, item.rx, item.ry); // prettier-ignore
       list.push(model);
-      if (model.isDefault || model.optionChoice == '0') {
-        width = Math.max(width, model.endRight);
-        height = Math.max(height, model.endBottom);
-      }
     });
-    return {
-      keymap: list,
-      width: width,
-      height: height,
-    };
+    return list;
   }
 }

--- a/src/models/KeyboardModel.ts
+++ b/src/models/KeyboardModel.ts
@@ -98,7 +98,7 @@ class KeymapItem {
   }
 
   get isDefault(): boolean {
-    return this.option == OPTION_DEFAULT || this.choice == '0';
+    return this.option == OPTION_DEFAULT || this.isOrigin;
   }
 
   get isOrigin(): boolean {

--- a/src/store/reducers.ts
+++ b/src/store/reducers.ts
@@ -38,7 +38,7 @@ import {
   LAYOUT_OPTIONS_ACTIONS,
   LAYOUT_OPTIONS_UPDATE_SELECTED_OPTION,
   LAYOUT_OPTIONS_INIT_SELECTED_OPTION,
-  APP_UPDATE_KEYBOARD_HEIGHT,
+  APP_UPDATE_KEYBOARD_SIZE,
 } from '../actions/actions';
 import {
   HID_ACTIONS,
@@ -129,8 +129,9 @@ const appReducer = (action: Action, draft: WritableDraft<RootState>) => {
       draft.app.package.version = action.value.version;
       break;
     }
-    case APP_UPDATE_KEYBOARD_HEIGHT: {
-      draft.app.keyboardHeight = action.value;
+    case APP_UPDATE_KEYBOARD_SIZE: {
+      draft.app.keyboardHeight = action.value.height;
+      draft.app.keyboardWidth = action.value.width;
       break;
     }
   }

--- a/src/store/state.ts
+++ b/src/store/state.ts
@@ -62,6 +62,7 @@ export type RootState = {
     }[];
     notifications: NotificationItem[];
     keyboardHeight: number;
+    keyboardWidth: number;
   };
   header: {
     flashing: boolean;
@@ -123,7 +124,8 @@ export const INIT_STATE: RootState = {
     setupPhase: SetupPhase.init,
     remaps: [],
     notifications: [],
-    keyboardHeight: 295,
+    keyboardHeight: 0,
+    keyboardWidth: 0,
   },
   header: {
     flashing: false,

--- a/src/utils/ObjectUtils.ts
+++ b/src/utils/ObjectUtils.ts
@@ -1,0 +1,3 @@
+export function hasProperty(obj: Object, name: string | number): boolean {
+  return Object.prototype.hasOwnProperty.call(obj, name);
+}


### PR DESCRIPTION
Support multi rows optional keys and set max-width/min-width to keycodes' area.
<img width="1515" alt="スクリーンショット 2021-01-21 1 52 05" src="https://user-images.githubusercontent.com/316463/105207863-664f8000-5b8b-11eb-8afb-46753cc645e1.png">
<img width="1515" alt="スクリーンショット 2021-01-21 1 52 18" src="https://user-images.githubusercontent.com/316463/105207871-68194380-5b8b-11eb-8d50-d592ceb3ef1f.png">
