### PR TITLE
Refactor the state structure for each component under the Configure component

### DIFF
--- a/src/components/configure/Configure.container.ts
+++ b/src/components/configure/Configure.container.ts
@@ -12,7 +12,7 @@ const mapStateToProps = (state: RootState) => {
     hid: state.hid,
     auth: state.auth.instance,
     storage: state.storage.instance,
-    draggingKey: state.keycodeKey.draggingKey,
+    draggingKey: state.configure.keycodeKey.draggingKey,
     keyboard: state.entities.keyboard,
   };
 };

--- a/src/components/configure/header/Header.container.ts
+++ b/src/components/configure/header/Header.container.ts
@@ -9,8 +9,8 @@ const mapStateToProps = (state: RootState) => {
   const kbd = state.entities.keyboard;
   const info = kbd?.getInformation();
   return {
-    draggingKey: state.keycodeKey.draggingKey,
-    flashing: state.header.flashing,
+    draggingKey: state.configure.keycodeKey.draggingKey,
+    flashing: state.configure.header.flashing,
     keyboards: state.entities.keyboards,
     openedKeyboard: state.entities.keyboard,
     productId: info?.productId || NaN,

--- a/src/components/configure/keyboards/Keyboards.container.ts
+++ b/src/components/configure/keyboards/Keyboards.container.ts
@@ -6,8 +6,8 @@ import { AppActions, KeyboardsActions } from '../../../actions/actions';
 const mapStateToProps = (state: RootState) => {
   return {
     layerCount: state.entities.device.layerCount,
-    selectedLayer: state.keyboards.selectedLayer,
-    selectedKeyboardOptions: state.layoutOptions.selectedOptions,
+    selectedLayer: state.configure.keyboards.selectedLayer,
+    selectedKeyboardOptions: state.configure.layoutOptions.selectedOptions,
     remaps: state.app.remaps,
     keyboardKeymap: state.entities.keyboardDefinition?.layouts.keymap,
     keyboardLabels: state.entities.keyboardDefinition?.layouts.labels,

--- a/src/components/configure/keycap/Keycap.container.ts
+++ b/src/components/configure/keycap/Keycap.container.ts
@@ -7,12 +7,13 @@ import {
   AppActions,
 } from '../../../actions/actions';
 import { Key } from '../keycodekey/KeycodeKey.container';
+import { RootState } from '../../../store/state';
 
-const mapStateToProps = (state: any) => {
+const mapStateToProps = (state: RootState) => {
   return {
-    draggingKey: state.keycodeKey.draggingKey,
-    selectedPos: state.keyboards.selectedPos,
-    selectedLayer: state.keyboards.selectedLayer,
+    draggingKey: state.configure.keycodeKey.draggingKey,
+    selectedPos: state.configure.keyboards.selectedPos,
+    selectedLayer: state.configure.keyboards.selectedLayer,
     keymaps: state.entities.device.keymaps,
     remaps: state.app.remaps,
   };

--- a/src/components/configure/keycodekey/KeycodeKey.container.ts
+++ b/src/components/configure/keycodekey/KeycodeKey.container.ts
@@ -51,15 +51,15 @@ export class KeycodeInfo implements IKeycodeInfo {
 }
 
 const mapStateToProps = (state: RootState, ownProps: KeycodeKeyOwnProps) => {
-  const keys = state.keycodes.keys[IKeycodeCategory.MACRO];
+  const keys = state.configure.keycodes.keys[IKeycodeCategory.MACRO];
   const clickable: boolean = !!(
     keys && keys.find((key) => key.keymap.code === ownProps.value.keymap.code)
   );
   return {
     keymaps: state.entities.device.keymaps,
-    selectedLayer: state.keyboards.selectedLayer,
-    selected: state.keycodeKey.selectedKey == ownProps.value,
-    selectedKeycapPosition: state.keyboards.selectedPos,
+    selectedLayer: state.configure.keyboards.selectedLayer,
+    selected: state.configure.keycodeKey.selectedKey == ownProps.value,
+    selectedKeycapPosition: state.configure.keyboards.selectedPos,
     clickable,
   };
 };

--- a/src/components/configure/keycodes/Keycodes.container.ts
+++ b/src/components/configure/keycodes/Keycodes.container.ts
@@ -5,9 +5,9 @@ import { KeycodeKeyActions, KeycodesActions } from '../../../actions/actions';
 import { IHid, IKeycodeCategory } from '../../../services/hid/Hid';
 
 const mapStateToProps = (state: RootState) => {
-  const code = state.keycodeKey.selectedKey?.keymap.code;
+  const code = state.configure.keycodeKey.selectedKey?.keymap.code;
   let macroText: string | null;
-  const keys = state.keycodes.keys[IKeycodeCategory.MACRO];
+  const keys = state.configure.keycodes.keys[IKeycodeCategory.MACRO];
   if (keys) {
     const key = keys.find((key) => key.keymap.code === code);
     macroText = key ? state.entities.device.macros[key.keymap.code] : null;
@@ -17,11 +17,11 @@ const mapStateToProps = (state: RootState) => {
 
   return {
     _hidInstance: state.hid.instance,
-    category: state.keycodes.category,
-    draggingKey: state.keycodeKey.draggingKey,
-    keys: state.keycodes.keys,
+    category: state.configure.keycodes.category,
+    draggingKey: state.configure.keycodeKey.draggingKey,
+    keys: state.configure.keycodes.keys,
     keyboardWidth: state.app.keyboardWidth,
-    selectedKey: state.keycodeKey.selectedKey,
+    selectedKey: state.configure.keycodeKey.selectedKey,
     macroText,
   };
 };

--- a/src/components/configure/keydiff/Keydiff.container.ts
+++ b/src/components/configure/keydiff/Keydiff.container.ts
@@ -9,9 +9,9 @@ import {
 
 const mapStateToProps = (state: RootState) => {
   return {
-    keydiff: state.keydiff,
-    selectedLayer: state.keyboards.selectedLayer,
-    selectedPos: state.keyboards.selectedPos,
+    keydiff: state.configure.keydiff,
+    selectedLayer: state.configure.keyboards.selectedLayer,
+    selectedPos: state.configure.keyboards.selectedPos,
   };
 };
 export type KeydiffStateType = ReturnType<typeof mapStateToProps>;

--- a/src/components/configure/keymap/Keymap.container.ts
+++ b/src/components/configure/keymap/Keymap.container.ts
@@ -4,7 +4,7 @@ import { RootState } from '../../../store/state';
 
 const mapStateToProps = (state: RootState) => {
   return {
-    draggingKey: state.keycodeKey.draggingKey,
+    draggingKey: state.configure.keycodeKey.draggingKey,
   };
 };
 export type KeymapStateType = ReturnType<typeof mapStateToProps>;

--- a/src/components/configure/layoutoptions/LayoutOptionsDialog.container.ts
+++ b/src/components/configure/layoutoptions/LayoutOptionsDialog.container.ts
@@ -5,7 +5,7 @@ import { LayoutOptionsActions } from '../../../actions/actions';
 
 const mapStateToProps = (state: RootState) => {
   return {
-    selectedKeyboardOptions: state.layoutOptions.selectedOptions,
+    selectedKeyboardOptions: state.configure.layoutOptions.selectedOptions,
     keyboardLayoutOptions: state.entities.keyboardDefinition?.layouts.labels,
   };
 };

--- a/src/components/configure/remap/Remap.container.ts
+++ b/src/components/configure/remap/Remap.container.ts
@@ -4,7 +4,7 @@ import { RootState } from '../../../store/state';
 
 const mapStateToProps = (state: RootState) => {
   return {
-    hoverKey: state.keycodeKey.hoverKey,
+    hoverKey: state.configure.keycodeKey.hoverKey,
     keyboard: state.entities.keyboard,
     keyboardHeight: state.app.keyboardHeight,
     package: state.app.package,

--- a/src/store/reducers.ts
+++ b/src/store/reducers.ts
@@ -178,15 +178,15 @@ const keyboardsReducer = (action: Action, draft: WritableDraft<RootState>) => {
   // TODO: type-safe
   switch (action.type) {
     case KEYBOARDS_CLEAR_SELECTED_POS: {
-      draft.keyboards.selectedPos = '';
+      draft.configure.keyboards.selectedPos = '';
       break;
     }
     case KEYBOARDS_UPDATE_SELECTED_LAYER: {
-      draft.keyboards.selectedLayer = action.value;
+      draft.configure.keyboards.selectedLayer = action.value;
       break;
     }
     case KEYBOARDS_UPDATE_SELECTED_POS: {
-      draft.keyboards.selectedPos = action.value;
+      draft.configure.keyboards.selectedPos = action.value;
       break;
     }
   }
@@ -196,7 +196,7 @@ const keycodesReducer = (action: Action, draft: WritableDraft<RootState>) => {
   // TODO: type-safe
   switch (action.type) {
     case KEYCODES_UPDATE_CATEGORY: {
-      draft.keycodes.category = action.value;
+      draft.configure.keycodes.category = action.value;
       break;
     }
     case KEYCODES_UPDATE_MACRO: {
@@ -205,7 +205,7 @@ const keycodesReducer = (action: Action, draft: WritableDraft<RootState>) => {
       break;
     }
     case KEYCODES_LOAD_KEYCODE_INFO_FOR_ALL_CATEGORIES: {
-      draft.keycodes.keys = action.value;
+      draft.configure.keycodes.keys = action.value;
       break;
     }
   }
@@ -215,13 +215,13 @@ const keydiffReducer = (action: Action, draft: WritableDraft<RootState>) => {
   // TODO: type-safe
   switch (action.type) {
     case KEYDIFF_UPDATE_KEYDIFF: {
-      draft.keydiff.origin = action.value.origin;
-      draft.keydiff.destination = action.value.destination;
+      draft.configure.keydiff.origin = action.value.origin;
+      draft.configure.keydiff.destination = action.value.destination;
       break;
     }
     case KEYDIFF_CLEAR_KEYDIFF: {
-      draft.keydiff.origin = null;
-      draft.keydiff.destination = null;
+      draft.configure.keydiff.origin = null;
+      draft.configure.keydiff.destination = null;
       break;
     }
   }
@@ -244,8 +244,8 @@ const keycodeAddKeyReducer = (
           keycodeInfo: new KeycodeInfo(anyKey.label, anyKey.code),
         },
       };
-      draft.keycodes.keys[IKeycodeCategory.ANY] = [
-        ...draft.keycodes.keys[IKeycodeCategory.ANY],
+      draft.configure.keycodes.keys[IKeycodeCategory.ANY] = [
+        ...draft.configure.keycodes.keys[IKeycodeCategory.ANY],
         key,
       ];
       break;
@@ -261,13 +261,13 @@ const keycodeAddKeyReducer = (
           keycodeInfo: new KeycodeInfo(anyKey.label, anyKey.code),
         },
       };
-      console.log(draft.keycodes.keys[IKeycodeCategory.ANY]);
-      draft.keycodes.keys[IKeycodeCategory.ANY] = draft.keycodes.keys[
+      console.log(draft.configure.keycodes.keys[IKeycodeCategory.ANY]);
+      draft.configure.keycodes.keys[
         IKeycodeCategory.ANY
-      ].map((k, i) => {
+      ] = draft.configure.keycodes.keys[IKeycodeCategory.ANY].map((k, i) => {
         return i == index ? key : k;
       });
-      console.log(draft.keycodes.keys[IKeycodeCategory.ANY]);
+      console.log(draft.configure.keycodes.keys[IKeycodeCategory.ANY]);
 
       break;
     }
@@ -278,21 +278,21 @@ const keycodekeyReducer = (action: Action, draft: WritableDraft<RootState>) => {
   // TODO: type-safe
   switch (action.type) {
     case KEYCODEKEY_UPDATE_DRAGGING_KEY: {
-      draft.keycodeKey.draggingKey = action.value;
+      draft.configure.keycodeKey.draggingKey = action.value;
       break;
     }
     case KEYCODEKEY_UPDATE_SELECTED_KEY: {
-      draft.keycodeKey.selectedKey = action.value;
+      draft.configure.keycodeKey.selectedKey = action.value;
       break;
     }
     case KEYCODEKEY_UPDATE_HOVER_KEY: {
-      draft.keycodeKey.hoverKey = action.value;
+      draft.configure.keycodeKey.hoverKey = action.value;
       break;
     }
     case KEYCODEKEY_CLEAR: {
-      draft.keycodeKey.draggingKey = null;
-      draft.keycodeKey.selectedKey = null;
-      draft.keycodeKey.hoverKey = null;
+      draft.configure.keycodeKey.draggingKey = null;
+      draft.configure.keycodeKey.selectedKey = null;
+      draft.configure.keycodeKey.hoverKey = null;
       break;
     }
   }
@@ -305,7 +305,7 @@ const layoutOptionsReducer = (
   switch (action.type) {
     case LAYOUT_OPTIONS_UPDATE_SELECTED_OPTION: {
       const { optionIndex, option } = action.value;
-      draft.layoutOptions.selectedOptions = draft.layoutOptions.selectedOptions.map(
+      draft.configure.layoutOptions.selectedOptions = draft.configure.layoutOptions.selectedOptions.map(
         (value, index) => {
           return index == optionIndex ? option : value;
         }
@@ -313,7 +313,7 @@ const layoutOptionsReducer = (
       break;
     }
     case LAYOUT_OPTIONS_INIT_SELECTED_OPTION: {
-      draft.layoutOptions.selectedOptions = action.value;
+      draft.configure.layoutOptions.selectedOptions = action.value;
       break;
     }
   }
@@ -383,7 +383,7 @@ const headerReducer = (action: Action, draft: WritableDraft<RootState>) => {
   // TODO: type-safe
   switch (action.type) {
     case HEADER_UPDATE_FLASHING: {
-      draft.header.flashing = action.value;
+      draft.configure.header.flashing = action.value;
       break;
     }
   }

--- a/src/store/state.ts
+++ b/src/store/state.ts
@@ -64,8 +64,30 @@ export type RootState = {
     keyboardHeight: number;
     keyboardWidth: number;
   };
-  header: {
-    flashing: boolean;
+  configure: {
+    header: {
+      flashing: boolean;
+    };
+    keyboards: {
+      selectedPos: string;
+      selectedLayer: number;
+    };
+    keycodes: {
+      category: string;
+      keys: { [category: string]: Key[] };
+    };
+    keycodeKey: {
+      selectedKey: Key | null;
+      hoverKey: Key | null;
+      draggingKey: Key | null;
+    };
+    keydiff: {
+      origin: IKeymap | null;
+      destination: IKeymap | null;
+    };
+    layoutOptions: {
+      selectedOptions: string[];
+    };
   };
   hid: {
     instance: IHid;
@@ -75,26 +97,6 @@ export type RootState = {
   };
   auth: {
     instance: IAuth;
-  };
-  keyboards: {
-    selectedPos: string;
-    selectedLayer: number;
-  };
-  keycodes: {
-    category: string;
-    keys: { [category: string]: Key[] };
-  };
-  keycodeKey: {
-    selectedKey: Key | null;
-    hoverKey: Key | null;
-    draggingKey: Key | null;
-  };
-  keydiff: {
-    origin: IKeymap | null;
-    destination: IKeymap | null;
-  };
-  layoutOptions: {
-    selectedOptions: string[];
   };
 };
 
@@ -127,8 +129,30 @@ export const INIT_STATE: RootState = {
     keyboardHeight: 0,
     keyboardWidth: 0,
   },
-  header: {
-    flashing: false,
+  configure: {
+    header: {
+      flashing: false,
+    },
+    keyboards: {
+      selectedLayer: NaN,
+      selectedPos: '',
+    },
+    keycodes: {
+      category: IKeycodeCategory.BASIC,
+      keys: {},
+    },
+    keycodeKey: {
+      selectedKey: null,
+      hoverKey: null,
+      draggingKey: null,
+    },
+    keydiff: {
+      origin: null,
+      destination: null,
+    },
+    layoutOptions: {
+      selectedOptions: [],
+    },
   },
   hid: {
     instance: new WebHid(),
@@ -138,25 +162,5 @@ export const INIT_STATE: RootState = {
   },
   auth: {
     instance: firebaseProvider,
-  },
-  keyboards: {
-    selectedLayer: NaN,
-    selectedPos: '',
-  },
-  keycodes: {
-    category: IKeycodeCategory.BASIC,
-    keys: {},
-  },
-  keycodeKey: {
-    selectedKey: null,
-    hoverKey: null,
-    draggingKey: null,
-  },
-  keydiff: {
-    origin: null,
-    destination: null,
-  },
-  layoutOptions: {
-    selectedOptions: [],
   },
 };


### PR DESCRIPTION
Refactor the state structure. For instance, state properties used by each component under the Configure components are moved from `state.***` to `state.configure.***`.