### PR TITLE
Fix the command queue issue mainly on Windows 10.

### DIFF
--- a/src/services/hid/Commands.ts
+++ b/src/services/hid/Commands.ts
@@ -4,6 +4,7 @@ import {
   ICommandResponseHandler,
 } from './WebHid';
 import { ICommand } from './Hid';
+import { outputUint8Array } from '../../utils/ArrayUtils';
 
 export abstract class AbstractCommand<
   TRequest extends ICommandRequest,
@@ -39,6 +40,7 @@ export abstract class AbstractCommand<
   async sendReport(device: any): Promise<void> {
     try {
       const outputReport = this.createReport();
+      outputUint8Array('Send data', outputReport);
       await device.sendReport(AbstractCommand.OUTPUT_REPORT_ID, outputReport);
     } catch (error) {
       await this.getResponseHandler()({

--- a/src/services/hid/WebHid.ts
+++ b/src/services/hid/WebHid.ts
@@ -32,6 +32,7 @@ import {
   IKeycodeCompositionFactory,
   KeycodeCompositionFactory,
 } from './Composition';
+import { outputUint8Array } from '../../utils/ArrayUtils';
 
 export class Keyboard implements IKeyboard {
   private readonly hid: IHid;
@@ -108,12 +109,12 @@ export class Keyboard implements IKeyboard {
   }
 
   handleInputReport = async (e: any): Promise<void> => {
-    this.outputUint8Array(new Uint8Array(e.data.buffer));
+    outputUint8Array('Received data', new Uint8Array(e.data.buffer));
     if (this.commandQueue.length > 0) {
       const command = this.commandQueue[0];
       if (command!.canHandleInputReport(e)) {
-        this.commandQueue.shift();
         await command!.handleInputReport(e);
+        this.commandQueue.shift();
         if (this.commandQueue.length > 0) {
           await this.commandQueue[0].sendReport(this.getDevice());
           return;
@@ -132,41 +133,11 @@ export class Keyboard implements IKeyboard {
     }
   };
 
-  protected outputUint8Array(array: Uint8Array) {
-    let lines = '';
-    let out = '';
-    let ascii = '';
-    for (let i = 0; i < array.length; i++) {
-      // out += String.fromCharCode(array[i]);
-      let value = Number(array[i]).toString(16).toUpperCase();
-      if (value.length === 1) {
-        value = '0' + value;
-      }
-      out += value;
-      if (i % 2 !== 0) {
-        out += ' ';
-      }
-      if (0x20 <= array[i] && array[i] <= 0x7e) {
-        ascii += String.fromCharCode(array[i]);
-      } else {
-        ascii += '.';
-      }
-      if ((i + 1) % 16 === 0) {
-        lines += out + ' ' + ascii + '\n';
-        out = '';
-        ascii = '';
-      }
-    }
-    if (out) {
-      lines += out + ' ' + ascii + '\n';
-    }
-    console.log(lines);
-  }
-
   async enqueue(command: ICommand): Promise<IResult> {
     if (this.isOpened()) {
       this.commandQueue.push(command);
       if (this.commandQueue.length === 1) {
+        console.log('sendReport from enqueue');
         await this.commandQueue[0].sendReport(this.getDevice());
       }
       return {

--- a/src/services/hid/WebHid.ts
+++ b/src/services/hid/WebHid.ts
@@ -137,7 +137,6 @@ export class Keyboard implements IKeyboard {
     if (this.isOpened()) {
       this.commandQueue.push(command);
       if (this.commandQueue.length === 1) {
-        console.log('sendReport from enqueue');
         await this.commandQueue[0].sendReport(this.getDevice());
       }
       return {

--- a/src/utils/ArrayUtils.ts
+++ b/src/utils/ArrayUtils.ts
@@ -1,0 +1,31 @@
+export const outputUint8Array = (title: string, array: Uint8Array) => {
+  console.log(`[${title}]`);
+  let lines = '';
+  let out = '';
+  let ascii = '';
+  for (let i = 0; i < array.length; i++) {
+    // out += String.fromCharCode(array[i]);
+    let value = Number(array[i]).toString(16).toUpperCase();
+    if (value.length === 1) {
+      value = '0' + value;
+    }
+    out += value;
+    if (i % 2 !== 0) {
+      out += ' ';
+    }
+    if (0x20 <= array[i] && array[i] <= 0x7e) {
+      ascii += String.fromCharCode(array[i]);
+    } else {
+      ascii += '.';
+    }
+    if ((i + 1) % 16 === 0) {
+      lines += out + ' ' + ascii + '\n';
+      out = '';
+      ascii = '';
+    }
+  }
+  if (out) {
+    lines += out + ' ' + ascii + '\n';
+  }
+  console.log(lines);
+};


### PR DESCRIPTION
Remap has a command queue mechanism. The behavior on Windows 10 is different from other OS. For instance, multiple command requests are sent invalidly. The reason is that the queue sends duplicate command request before finishing the response handler logic. To fix this issue, I change the logic order (As is: 1. remove first command 2. call response handler To be: 1. call response handler 2. remove first command).