### PR TITLE
Support vusb keyboards

### DIFF
--- a/src/services/hid/Commands.ts
+++ b/src/services/hid/Commands.ts
@@ -14,6 +14,7 @@ export abstract class AbstractCommand<
   private readonly responseHandler: ICommandResponseHandler<TResponse>;
 
   static OUTPUT_REPORT_ID: number = 0x00;
+  static RAW_BUFFER_SIZE: number = 32;
 
   constructor(
     request: TRequest,
@@ -39,7 +40,8 @@ export abstract class AbstractCommand<
 
   async sendReport(device: any): Promise<void> {
     try {
-      const outputReport = this.createReport();
+      const outputReport = new Uint8Array(AbstractCommand.RAW_BUFFER_SIZE);
+      outputReport.set(this.createReport());
       outputUint8Array('Send data', outputReport);
       await device.sendReport(AbstractCommand.OUTPUT_REPORT_ID, outputReport);
     } catch (error) {


### PR DESCRIPTION
The vusb protocol in qmk (used by atmega328p mcu keyboards) only processes
raw hid messages after RAW_BUFFER_SIZE (32) bytes have been received. See
https://github.com/qmk/qmk_firmware/blob/master/tmk_core/protocol/vusb/vusb.c#L160.

This change ensures that all commands are set padding to 32 bytes.