### PR TITLE
fix the top-margin of the keycode area

### DIFF
--- a/src/components/configure/remap/Remap.tsx
+++ b/src/components/configure/remap/Remap.tsx
@@ -27,7 +27,7 @@ export default class Remap extends React.Component<RemapPropType, {}> {
         </div>
         <div
           className="keycode"
-          style={{ marginTop: 206 + this.props.keyboardHeight! }}
+          style={{ marginTop: 182 + this.props.keyboardHeight! }}
         >
           <Keycodes />
         </div>


### PR DESCRIPTION
The blank appeared because I changed the padding of keyboard view.
I fix the top-margin of the keycode area.
The value of top-margin is calculated as below:
- HEADER + DIFF + KEYBOARD + BOTTOM_SPACE
- HEADER is fixed at 56px.
- DIFF is fixed at 78px.
- KEYBOARD = Keyboard Height + 8px padding * 2
- Keyboard Height is calculated the connected device.
- BOTTOM_SPACE is fixed at 32px.

Then, the value of top-margin is 182px(56 + 78 + 8*2 + 32) + Keyboard Height.

<img width="1277" alt="スクリーンショット 2021-03-02 11 31 51" src="https://user-images.githubusercontent.com/316463/109588193-b555e100-7b4b-11eb-966e-b575bdd91ec9.png">
