### PR TITLE
Remove the check logic whether the user is in closed beta users.

### DIFF
--- a/src/components/keyboards/KeyboardDefinitionManagement.container.ts
+++ b/src/components/keyboards/KeyboardDefinitionManagement.container.ts
@@ -9,7 +9,6 @@ const mapStateToProps = (state: RootState) => {
   return {
     notifications: state.app.notifications,
     auth: state.auth.instance,
-    storage: state.storage.instance,
   };
 };
 export type KeyboardDefinitionManagementStateType = ReturnType<

--- a/src/components/keyboards/KeyboardDefinitionManagement.tsx
+++ b/src/components/keyboards/KeyboardDefinitionManagement.tsx
@@ -76,21 +76,15 @@ class KeyboardDefinitionManagement extends React.Component<
   componentDidMount() {
     this.props.auth!.subscribeAuthStatus((user) => {
       if (user) {
-        this.props.storage!.fetchClosedBetaUsers().then((users) => {
-          if (users.includes(user.email!)) {
-            this.setState({
-              signedIn: true,
-            });
-            this.updateNotifications();
-            this.props.updateKeyboards!();
-            const definitionId = this.props.match.params.definitionId;
-            if (definitionId) {
-              this.props.updateKeyboard!(definitionId);
-            }
-          } else {
-            this.setState({ signedIn: false });
-          }
+        this.setState({
+          signedIn: true,
         });
+        this.updateNotifications();
+        this.props.updateKeyboards!();
+        const definitionId = this.props.match.params.definitionId;
+        if (definitionId) {
+          this.props.updateKeyboard!(definitionId);
+        }
       } else {
         this.props.auth!.signInWithGitHub().then(() => {
           // N/A

--- a/src/services/provider/Firebase.ts
+++ b/src/services/provider/Firebase.ts
@@ -357,18 +357,6 @@ export class FirebaseProvider implements IStorage, IAuth {
     }
   }
 
-  async fetchClosedBetaUsers(): Promise<string[]> {
-    const documentSnapshot = await this.db
-      .collection('configurations')
-      .doc('closedbeta')
-      .get();
-    if (documentSnapshot.exists) {
-      return documentSnapshot.data()!.users;
-    } else {
-      return [];
-    }
-  }
-
   signInWithGitHub(): Promise<void> {
     const provider = new firebase.auth.GithubAuthProvider();
     return this.auth.signInWithRedirect(provider);

--- a/src/services/storage/Storage.ts
+++ b/src/services/storage/Storage.ts
@@ -66,7 +66,6 @@ export interface IStorage {
     productId: number,
     productName: string
   ): Promise<IFetchKeyboardDefinitionDocumentResult>;
-  fetchClosedBetaUsers(): Promise<string[]>;
   fetchMyKeyboardDefinitionDocuments(): Promise<IFetchMyKeyboardDefinitionDocumentsResult>;
   createKeyboardDefinitionDocument(
     authorUid: string,


### PR DESCRIPTION
Before the official release of Remap, we need to remove the check logic whether the authenticated user is in Closed Beta users or not.