### PR TITLE
enabled to remove all changes

### DIFF
--- a/src/components/configure/keymapToolbar/KeymapToolbar.container.ts
+++ b/src/components/configure/keymapToolbar/KeymapToolbar.container.ts
@@ -1,6 +1,7 @@
 import { connect } from 'react-redux';
 import KeymapToolbar from './KeymapToolbar';
 import { RootState } from '../../../store/state';
+import { AppActions, KeydiffActions } from '../../../actions/actions';
 
 const mapStateToProps = (state: RootState) => {
   return {
@@ -10,13 +11,19 @@ const mapStateToProps = (state: RootState) => {
     layerCount: state.entities.device.layerCount,
     selectedKeyboardOptions: state.configure.layoutOptions.selectedOptions,
     labelLang: state.app.labelLang,
+    remaps: state.app.remaps,
   };
 };
 export type KeymapMenuStateType = ReturnType<typeof mapStateToProps>;
 
 // eslint-disable-next-line no-unused-vars
 const mapDispatchToProps = (_dispatch: any) => {
-  return {};
+  return {
+    clearAllRemaps: (layerCount: number) => {
+      _dispatch(AppActions.remapsInit(layerCount));
+      _dispatch(KeydiffActions.clearKeydiff());
+    },
+  };
 };
 
 export type KeymapMenuActionsType = ReturnType<typeof mapDispatchToProps>;

--- a/src/components/configure/keymapToolbar/KeymapToolbar.tsx
+++ b/src/components/configure/keymapToolbar/KeymapToolbar.tsx
@@ -25,11 +25,9 @@ export default class KeymapMenu extends React.Component<
   KeymapMenuPropsType,
   OwnKeymapMenuStateType
 > {
-  private menuRef: React.RefObject<HTMLDivElement>;
   constructor(props: KeymapMenuPropsType | Readonly<KeymapMenuPropsType>) {
     super(props);
     this.state = {};
-    this.menuRef = React.createRef<HTMLDivElement>();
   }
 
   get hasChanges(): boolean {
@@ -44,7 +42,7 @@ export default class KeymapMenu extends React.Component<
     return false;
   }
 
-  private onClickClearAllRemaps() {
+  private onClickClearAllChanges() {
     this.props.clearAllRemaps!(this.props.layerCount!);
   }
 
@@ -85,7 +83,7 @@ export default class KeymapMenu extends React.Component<
                 <IconButton
                   disabled={!this.hasChanges}
                   size="small"
-                  onClick={this.onClickClearAllRemaps.bind(this)}
+                  onClick={this.onClickClearAllChanges.bind(this)}
                 >
                   <ClearAllIcon
                     color={this.hasChanges ? undefined : 'disabled'}

--- a/src/components/configure/keymapToolbar/KeymapToolbar.tsx
+++ b/src/components/configure/keymapToolbar/KeymapToolbar.tsx
@@ -3,6 +3,7 @@ import React from 'react';
 import './KeymapToolbar.scss';
 import { IconButton, Tooltip } from '@material-ui/core';
 import PictureAsPdfRoundedIcon from '@material-ui/icons/PictureAsPdfRounded';
+import ClearAllIcon from '@material-ui/icons/ClearAll';
 import {
   KeymapMenuActionsType,
   KeymapMenuStateType,
@@ -30,6 +31,23 @@ export default class KeymapMenu extends React.Component<
     this.state = {};
     this.menuRef = React.createRef<HTMLDivElement>();
   }
+
+  get hasChanges(): boolean {
+    for (let i = 0; i < this.props.remaps!.length; i++) {
+      const remap: { [pos: string]: IKeymap } = this.props.remaps![i];
+      const item = Object.values(remap).find(
+        (value) => typeof value === 'object' && typeof value.code === 'number'
+      );
+      if (item != undefined) return true;
+    }
+
+    return false;
+  }
+
+  private onClickClearAllRemaps() {
+    this.props.clearAllRemaps!(this.props.layerCount!);
+  }
+
   private onClickGetCheatsheet() {
     const keymaps: { [pos: string]: IKeymap }[] = this.props.keymaps!;
     const keys: { [pos: string]: Key }[] = [];
@@ -62,7 +80,27 @@ export default class KeymapMenu extends React.Component<
       <React.Fragment>
         <div className="keymap-menu">
           <div className="keymap-menu-item">
-            <Tooltip title="Get keymap cheat sheet (PDF)">
+            <Tooltip arrow={true} placement="top" title="Clear all changes">
+              <span>
+                <IconButton
+                  disabled={!this.hasChanges}
+                  size="small"
+                  onClick={this.onClickClearAllRemaps.bind(this)}
+                >
+                  <ClearAllIcon
+                    color={this.hasChanges ? undefined : 'disabled'}
+                  />
+                </IconButton>
+              </span>
+            </Tooltip>
+          </div>
+
+          <div className="keymap-menu-item">
+            <Tooltip
+              arrow={true}
+              placement="top"
+              title="Get keymap cheat sheet (PDF)"
+            >
               <IconButton
                 size="small"
                 onClick={this.onClickGetCheatsheet.bind(this)}
@@ -71,7 +109,6 @@ export default class KeymapMenu extends React.Component<
               </IconButton>
             </Tooltip>
           </div>
-          <div className="keymap-menu-item"></div>
         </div>
       </React.Fragment>
     );


### PR DESCRIPTION
It's annoying to clear all keymap changes if it's so many.
I developed clear all key changes. If there is at least one key change, this feature is active.
In other words, this feature is disabled when there are is no change.
<img width="1279" alt="スクリーンショット 2021-03-04 14 20 17" src="https://user-images.githubusercontent.com/316463/109915582-6a77cd00-7cf5-11eb-954a-991fd76868d0.png">

<img width="1278" alt="スクリーンショット 2021-03-04 14 20 40" src="https://user-images.githubusercontent.com/316463/109915591-6cda2700-7cf5-11eb-87b0-901589259a2f.png">

The tooltip text is as below.
<img width="121" alt="スクリーンショット 2021-03-04 14 26 01" src="https://user-images.githubusercontent.com/316463/109915695-97c47b00-7cf5-11eb-964e-0588f5203cb9.png">
