### PR TITLE
put the lighting button in the toolbar

### DIFF
--- a/src/components/configure/configuration/ConfigurationDialog.stories.tsx
+++ b/src/components/configure/configuration/ConfigurationDialog.stories.tsx
@@ -107,7 +107,6 @@ class ConfigurationDialogAdapter extends React.Component<any, {}> {
       selectedMenuIndex: 1,
       keyboardDefinition: {} as KeyboardDefinitionSchema,
       keyboardDefinitionFile: 'keyboard_def.json',
-      needToInit: false,
     };
   }
   render() {

--- a/src/components/configure/keymap/Keymap.scss
+++ b/src/components/configure/keymap/Keymap.scss
@@ -9,7 +9,6 @@
     display: flex;
     justify-content: flex-start;
     align-items: center;
-    padding: 8px 16px;
   }
 
   .label-lang,

--- a/src/components/configure/keymapToolbar/KeymapToolbar.scss
+++ b/src/components/configure/keymapToolbar/KeymapToolbar.scss
@@ -8,6 +8,6 @@
   align-items: flex-start;
   padding: 8px 16px;
   .keymap-menu-item {
-    margin-left: $space-m;
+    margin-bottom: $space-m;
   }
 }

--- a/src/components/configure/keymapToolbar/KeymapToolbar.tsx
+++ b/src/components/configure/keymapToolbar/KeymapToolbar.tsx
@@ -2,8 +2,10 @@
 import React from 'react';
 import './KeymapToolbar.scss';
 import { IconButton, Tooltip } from '@material-ui/core';
+import ClearAllRoundedIcon from '@material-ui/icons/ClearAllRounded';
+import FlareRoundedIcon from '@material-ui/icons/FlareRounded';
 import PictureAsPdfRoundedIcon from '@material-ui/icons/PictureAsPdfRounded';
-import ClearAllIcon from '@material-ui/icons/ClearAll';
+
 import {
   KeymapMenuActionsType,
   KeymapMenuStateType,
@@ -12,6 +14,7 @@ import { IKeymap } from '../../../services/hid/Hid';
 import { genKey, Key } from '../keycodekey/KeyGen';
 import { KeymapPdfGenerator } from '../../../services/pdf/KeymapPdfGenerator';
 import Keymap from '../keymap/Keymap';
+import LightingDialog from '../../lighting/LightingDialog';
 
 type OwnProp = {};
 
@@ -19,7 +22,9 @@ type KeymapMenuPropsType = OwnProp &
   Partial<KeymapMenuStateType> &
   Partial<KeymapMenuActionsType>;
 
-type OwnKeymapMenuStateType = {};
+type OwnKeymapMenuStateType = {
+  openLightingDialog: boolean;
+};
 
 export default class KeymapMenu extends React.Component<
   KeymapMenuPropsType,
@@ -27,7 +32,9 @@ export default class KeymapMenu extends React.Component<
 > {
   constructor(props: KeymapMenuPropsType | Readonly<KeymapMenuPropsType>) {
     super(props);
-    this.state = {};
+    this.state = {
+      openLightingDialog: false,
+    };
   }
 
   get hasChanges(): boolean {
@@ -74,6 +81,9 @@ export default class KeymapMenu extends React.Component<
   }
 
   render() {
+    const isLightingAvailable = LightingDialog.isLightingAvailable(
+      this.props.keyboardDefinition!.lighting
+    );
     return (
       <React.Fragment>
         <div className="keymap-menu">
@@ -85,8 +95,26 @@ export default class KeymapMenu extends React.Component<
                   size="small"
                   onClick={this.onClickClearAllChanges.bind(this)}
                 >
-                  <ClearAllIcon
+                  <ClearAllRoundedIcon
                     color={this.hasChanges ? undefined : 'disabled'}
+                  />
+                </IconButton>
+              </span>
+            </Tooltip>
+          </div>
+
+          <div className="keymap-menu-item">
+            <Tooltip arrow={true} placement="top" title="Lighting">
+              <span>
+                <IconButton
+                  disabled={!isLightingAvailable}
+                  size="small"
+                  onClick={() => {
+                    this.setState({ openLightingDialog: true });
+                  }}
+                >
+                  <FlareRoundedIcon
+                    color={isLightingAvailable ? undefined : 'disabled'}
                   />
                 </IconButton>
               </span>
@@ -108,6 +136,14 @@ export default class KeymapMenu extends React.Component<
             </Tooltip>
           </div>
         </div>
+        <LightingDialog
+          open={this.state.openLightingDialog}
+          keyboard={this.props.keyboard!}
+          lightingDef={this.props.keyboardDefinition!.lighting}
+          onClose={() => {
+            this.setState({ openLightingDialog: false });
+          }}
+        />
       </React.Fragment>
     );
   }

--- a/src/components/lighting/Lighting.scss
+++ b/src/components/lighting/Lighting.scss
@@ -1,4 +1,4 @@
-@import '../../../variables';
+@import '../../variables';
 
 .lighting-settings {
   h4 {

--- a/src/components/lighting/Lighting.tsx
+++ b/src/components/lighting/Lighting.tsx
@@ -1,7 +1,7 @@
 /* eslint-disable no-undef */
 import React from 'react';
-import './TabLighting.scss';
-import '../../../../node_modules/reinvented-color-wheel/css/reinvented-color-wheel.min.css';
+import './Lighting.scss';
+import '../../../node_modules/reinvented-color-wheel/css/reinvented-color-wheel.min.css';
 import {
   Grid,
   MenuItem,
@@ -11,7 +11,7 @@ import {
   TextField,
 } from '@material-ui/core';
 import ReinventedColorWheel from 'reinvented-color-wheel';
-import { IKeyboard } from '../../../services/hid/Hid';
+import { IKeyboard } from '../../services/hid/Hid';
 
 export type Hsv = {
   h: number;
@@ -45,7 +45,7 @@ type State = {
   backlightBrightness: number; // 0-255
 };
 
-export default class TabLighting extends React.Component<Props, State> {
+export default class Lighting extends React.Component<Props, State> {
   private readonly UPDATE_VALUE_DURATION = 400;
   private colorWheelRef: React.RefObject<HTMLDivElement>;
   private colorWheel: ReinventedColorWheel | null = null;

--- a/src/components/lighting/LightingDialog.scss
+++ b/src/components/lighting/LightingDialog.scss
@@ -1,0 +1,20 @@
+@import '../../variables';
+
+.lighting-dialog {
+  .close-dialog {
+    position: absolute;
+    top: 20px;
+    right: 20px;
+
+    &:hover {
+      color: $primary-light;
+      cursor: pointer;
+    }
+  }
+
+  .lighting-dialog-content {
+    display: flex;
+    flex-direction: row;
+    padding-left: 24px;
+  }
+}

--- a/src/components/lighting/LightingDialog.tsx
+++ b/src/components/lighting/LightingDialog.tsx
@@ -1,0 +1,200 @@
+/* eslint-disable no-undef */
+import React from 'react';
+import './LightingDialog.scss';
+import {
+  Dialog,
+  DialogContent,
+  DialogTitle,
+  Paper,
+  PaperProps,
+} from '@material-ui/core';
+import CloseIcon from '@material-ui/icons/Close';
+import Draggable from 'react-draggable';
+import Lighting, { defaultUnderglowEffects, Hsv } from './Lighting';
+import { IKeyboard } from '../../services/hid/Hid';
+
+type LightingType =
+  | undefined
+  | (
+      | 'none'
+      | 'qmk_backlight'
+      | 'qmk_rgblight'
+      | 'qmk_backlight_rgblight'
+      | 'wt_rgb_backlight'
+      | 'wt_mono_backlight'
+    )
+  | {
+      extends?: string;
+      effects?: [] | [[] | [string] | [string, number]];
+      keycodes?: 'qmk' | 'wt';
+      supportedBacklightValues?: number[];
+      supportedLightingValues?: number[];
+      underglowEffects?: [] | [string] | [string, number][];
+      [k: string]: unknown;
+    };
+
+type OwnProps = {
+  open: boolean;
+  onClose: () => void;
+  keyboard: IKeyboard;
+  lightingDef: LightingType | undefined;
+};
+
+type OwnState = {};
+
+export default class LightingDialog extends React.Component<
+  OwnProps,
+  OwnState
+> {
+  private showUnderglow: boolean = true;
+  private showBacklight: boolean = true;
+  private underglowEffects: [string, number][] = [];
+  constructor(props: OwnProps | Readonly<OwnProps>) {
+    super(props);
+    this.state = {};
+  }
+
+  shouldComponentUpdate(
+    // eslint-disable-next-line no-unused-vars
+    nextProps: OwnProps,
+    // eslint-disable-next-line no-unused-vars
+    nextState: OwnState
+  ) {
+    this.initLighting();
+    return true;
+  }
+
+  static isLightingAvailable(lighting: LightingType | undefined): boolean {
+    if (!lighting) return false;
+
+    if (typeof lighting === 'string') {
+      return (
+        0 <= lighting.indexOf('rgblight') || 0 <= lighting.indexOf('backlight')
+      );
+    }
+
+    if (!lighting.extends) {
+      return false;
+    }
+
+    return true;
+  }
+
+  private initLighting() {
+    const lighting: LightingType = this.props.lightingDef;
+    this.showUnderglow = false;
+    if (!lighting) {
+      this.showUnderglow = false;
+      this.showBacklight = false;
+      return;
+    }
+
+    if (typeof lighting === 'string') {
+      this.showUnderglow = 0 <= lighting.indexOf('rgblight');
+      this.showBacklight = 0 <= lighting.indexOf('backlight');
+      this.underglowEffects = defaultUnderglowEffects;
+      return;
+    }
+
+    if (!lighting.extends) {
+      /**
+       * lighting object MUST be contains 'extends' property.
+       * ref. https://caniusevia.com/docs/optional#lighting
+       */
+      throw new Error(
+        `lighting properties whose type is NOT 'string' MUST contain 'extends'.`
+      );
+    }
+    this.showUnderglow = 0 <= lighting.extends.indexOf('rgblight');
+    this.showBacklight = 0 <= lighting.extends.indexOf('backlight');
+
+    if (!lighting.underglowEffects || lighting.underglowEffects.length === 0) {
+      // use default effects if no overridden effects
+      this.underglowEffects = defaultUnderglowEffects;
+      return;
+    }
+
+    if (typeof lighting.underglowEffects[0] === 'string') {
+      const label: string = lighting.underglowEffects[0];
+      this.underglowEffects = [[label, 0]];
+    } else {
+      this.underglowEffects = lighting.underglowEffects as [string, number][];
+    }
+  }
+
+  private onChangeBacklight(backlight: {
+    isBreathing?: boolean;
+    brightness?: number /* 0-100 */;
+  }) {
+    if (backlight.isBreathing != undefined) {
+      this.props.keyboard!.updateBacklightEffect(backlight.isBreathing);
+    }
+
+    if (backlight.brightness != undefined) {
+      const brightness = Math.round(255 * (backlight.brightness / 100));
+      this.props.keyboard!.updateBacklightBrightness(brightness);
+    }
+  }
+
+  private onChangeUnderglow(underglow: {
+    mode?: number;
+    color?: Hsv; // h: 0-360, s: 0-100, v: 0-100
+  }) {
+    if (underglow.mode != undefined) {
+      this.props.keyboard!.updateRGBLightEffect(underglow.mode);
+    }
+
+    if (underglow.color != undefined) {
+      const hsv: Hsv = underglow.color;
+      const hue = Math.round(255 * (hsv.h / 360));
+      const sat = Math.round(255 * (hsv.s / 100));
+      const brightness = Math.round(255 * (hsv.v / 100));
+
+      this.props.keyboard!.updateRGBLightColor(hue, sat);
+      this.props.keyboard!.updateRGBLightBrightness(brightness);
+    }
+  }
+
+  render() {
+    return (
+      <Dialog
+        open={this.props.open}
+        maxWidth={'sm'}
+        PaperComponent={PaperComponent}
+        className="lighting-dialog"
+      >
+        <DialogTitle id="lighting-dialog-title" style={{ cursor: 'move' }}>
+          Lighting
+          <div className="close-dialog">
+            <CloseIcon onClick={this.props.onClose} />
+          </div>
+        </DialogTitle>
+        <DialogContent dividers className="lighting-dialog-content">
+          <Lighting
+            underglowEffects={this.underglowEffects}
+            keyboard={this.props.keyboard}
+            showBacklight={this.showBacklight}
+            showUnderglow={this.showUnderglow}
+            onChangeUnderglow={(underglow) => {
+              this.onChangeUnderglow(underglow);
+            }}
+            onChangeBacklight={(backlight) => {
+              this.onChangeBacklight(backlight);
+            }}
+          />
+        </DialogContent>
+      </Dialog>
+    );
+  }
+}
+
+function PaperComponent(props: PaperProps) {
+  return (
+    <Draggable
+      handle="#lighting-dialog-title"
+      cancel={'[class*="MuiDialogContent-root"]'}
+    >
+      <Paper {...props} />
+    </Draggable>
+  );
+}


### PR DESCRIPTION
I moved the lighting feature from the ConfigurationDialog to the KeymapToolbar.
In addition to that, I made a independent dialog for the lighting settings and show it from the lighting button in the toolbar.

<img width="1277" alt="スクリーンショット 2021-03-04 18 03 56" src="https://user-images.githubusercontent.com/316463/109944575-b472aa00-7d19-11eb-9763-c57cc8b41fca.png">

<img width="1279" alt="スクリーンショット 2021-03-04 18 03 45" src="https://user-images.githubusercontent.com/316463/109944582-b6d50400-7d19-11eb-9c68-569c50a5b520.png">


If there is not lighting settings, the button is disabled.
<img width="90" alt="スクリーンショット 2021-03-04 18 40 16" src="https://user-images.githubusercontent.com/316463/109944696-d3713c00-7d19-11eb-894c-93d878a84b91.png">
