### PR TITLE
moved the connected device info from ConfigurationDialog to the header

### DIFF
--- a/src/components/configure/configuration/ConfigurationDialog.container.ts
+++ b/src/components/configure/configuration/ConfigurationDialog.container.ts
@@ -8,9 +8,6 @@ import { KeyboardDefinitionSchema } from '../../../gen/types/KeyboardDefinition'
 const mapStateToProps = (state: RootState) => {
   return {
     keyboardLayoutOptions: state.entities.keyboardDefinition?.layouts.labels,
-    keyboard: state.entities.keyboard!,
-    keyboardDefinition: state.entities.keyboardDefinition,
-    keyboardDefinitionDocument: state.entities.keyboardDefinitionDocument,
     selectedKeyboardOptions: state.configure.layoutOptions.selectedOptions,
   };
 };

--- a/src/components/configure/configuration/ConfigurationDialog.stories.tsx
+++ b/src/components/configure/configuration/ConfigurationDialog.stories.tsx
@@ -3,7 +3,6 @@ import CssBaseline from '@material-ui/core/CssBaseline';
 import ConfigurationDialog from './ConfigurationDialog';
 import { KeyboardDefinitionSchema } from '../../../gen/types/KeyboardDefinition';
 import { hexadecimal } from '../../../utils/StringUtils';
-import { mockIKeyboad } from '../../../services/hid/Hid.mock';
 
 export default {
   title: 'ConfigurationDialog',
@@ -76,8 +75,6 @@ export const Default = () => (
     ]}
     selectedKeyboardOptions={[null, 'Option2-2', 'Option3', 'Option4-1']}
     refreshKeyboardDefinition={() => {}}
-    keyboard={mockIKeyboad}
-    keyboardDefinition={keyboardDefinition}
   />
 );
 
@@ -93,8 +90,6 @@ export const NoOptions = () => (
     refreshKeyboardDefinition={(kd: KeyboardDefinitionSchema) => {
       console.log(kd);
     }}
-    keyboard={mockIKeyboad}
-    keyboardDefinition={keyboardDefinition}
   />
 );
 
@@ -126,7 +121,5 @@ export const ValidKeyboardDefinition = () => (
     refreshKeyboardDefinition={(kd: KeyboardDefinitionSchema) => {
       console.log(kd);
     }}
-    keyboard={mockIKeyboad}
-    keyboardDefinition={keyboardDefinition}
   />
 );

--- a/src/components/configure/configuration/ConfigurationDialog.tsx
+++ b/src/components/configure/configuration/ConfigurationDialog.tsx
@@ -23,10 +23,6 @@ import { Alert, AlertTitle } from '@material-ui/lab';
 
 import { KeyboardDefinitionSchema } from '../../../gen/types/KeyboardDefinition';
 import { KeyboardDefinitionFormPart } from '../../common/keyboarddefformpart/KeyboardDefinitionFormPart';
-import { hexadecimal } from '../../../utils/StringUtils';
-
-const GOOGLE_FORM_URL =
-  'https://docs.google.com/forms/d/e/1FAIpQLScZPhiXEG2VETCGZ2dYp4YbzzMlU62Crh1cNxPpFBkN4cCPbA/viewform?usp=pp_url&entry.661359702=${keyboard_name}&entry.135453541=${keyboard_id}';
 
 type OwnProps = {
   open: boolean;
@@ -50,10 +46,6 @@ export default class ConfigurationDialog extends React.Component<
   ConfigurationDialogProps,
   OwnState
 > {
-  private googleFormUrl: string = '';
-  private githubUrl: string = '';
-  private githubDisplayName: string = '';
-
   constructor(
     props: ConfigurationDialogProps | Readonly<ConfigurationDialogProps>
   ) {
@@ -63,18 +55,6 @@ export default class ConfigurationDialog extends React.Component<
       keyboardDefinition: null,
       keyboardDefinitionFile: null,
     };
-  }
-
-  private onEnter() {
-    if (this.props.keyboardDefinitionDocument) {
-      this.googleFormUrl = GOOGLE_FORM_URL.replace(
-        '${keyboard_name}',
-        this.props.keyboardDefinitionDocument.name
-      ).replace('${keyboard_id}', this.props.keyboardDefinitionDocument.id);
-
-      this.githubUrl = this.props.keyboardDefinitionDocument.githubUrl;
-      this.githubDisplayName = this.props.keyboardDefinitionDocument.githubDisplayName;
-    }
   }
 
   private clearKeyboardDefinition() {
@@ -105,17 +85,11 @@ export default class ConfigurationDialog extends React.Component<
     const labels = this.props.keyboardLayoutOptions!;
     const selectedLayoutOptions = this.props.selectedKeyboardOptions!;
 
-    const deviceInfo = this.props.keyboard!.getInformation();
-    const keyboardDef = this.props.keyboardDefinition!;
     let panelIndex = 0;
     return (
       <Dialog
         open={this.props.open}
         maxWidth={'md'}
-        onClose={() => {}}
-        onEnter={() => {
-          this.onEnter();
-        }}
         PaperComponent={PaperComponent}
         className="layout-options-dialog"
       >
@@ -137,7 +111,6 @@ export default class ConfigurationDialog extends React.Component<
           >
             {hasKeyboardOptions && <Tab label="Layout options" />}
             <Tab label="Import" />
-            <Tab label="Info" />
           </Tabs>
           {hasKeyboardOptions && (
             <TabPanel value={this.state.selectedMenuIndex} index={panelIndex++}>
@@ -195,53 +168,6 @@ export default class ConfigurationDialog extends React.Component<
                 </div>
               </Alert>
             )}
-          </TabPanel>
-
-          <TabPanel value={this.state.selectedMenuIndex} index={panelIndex++}>
-            <Grid container spacing={1}>
-              <Grid item xs={12} className="option-info-label">
-                <h4>CONNECTED DEVICE</h4>
-              </Grid>
-              <InfoRow label="Product Name" value={deviceInfo.productName} />
-              <InfoRow
-                label="Vendor ID"
-                value={hexadecimal(deviceInfo.vendorId, 4)}
-              />
-              <InfoRow
-                label="Product ID"
-                value={hexadecimal(deviceInfo.productId, 4)}
-              />
-              <Grid item xs={12} className="option-info-label">
-                <h4>KEYBOARD DEFINITION</h4>
-              </Grid>
-              <InfoRow label="Name" value={keyboardDef.name} />
-              <InfoRow label="Vendor ID" value={keyboardDef.vendorId} />
-              <InfoRow label="Product ID" value={keyboardDef.productId} />
-              <InfoRow
-                label="Col x Row"
-                value={`${keyboardDef.matrix.cols} x ${keyboardDef.matrix.rows}`}
-              />
-              <InfoRow
-                label="Registered by"
-                value={
-                  <a href={this.githubUrl} target="_blank" rel="noreferrer">
-                    {this.githubDisplayName}
-                  </a>
-                }
-              />
-              <Grid item xs={12} className="option-info-label">
-                <div className="option-warning-message">
-                  If you think that the person above does not have any rights
-                  for the keyboard and the keyboard definition (in the case of
-                  the person is not original keyboard designer or etc.), please
-                  report it to the Remap team from{' '}
-                  <a href={this.googleFormUrl} target="_blank" rel="noreferrer">
-                    this form
-                  </a>
-                  .
-                </div>
-              </Grid>
-            </Grid>
           </TabPanel>
         </DialogContent>
       </Dialog>
@@ -317,19 +243,6 @@ function OptionRowComponent(props: OptionRowType) {
             );
           })}
         </Select>
-      </Grid>
-    </React.Fragment>
-  );
-}
-
-function InfoRow(props: { label: string; value: string | React.ReactNode }) {
-  return (
-    <React.Fragment>
-      <Grid item xs={6} className="option-info-label">
-        {props.label}
-      </Grid>
-      <Grid item xs={6} className="option-info-value">
-        {props.value}
       </Grid>
     </React.Fragment>
   );

--- a/src/components/configure/header/Header.container.ts
+++ b/src/components/configure/header/Header.container.ts
@@ -12,7 +12,7 @@ const mapStateToProps = (state: RootState) => {
     draggingKey: state.configure.keycodeKey.draggingKey,
     flashing: state.configure.header.flashing,
     keyboards: state.entities.keyboards,
-    openedKeyboard: state.entities.keyboard,
+    keyboard: state.entities.keyboard,
     productId: info?.productId || NaN,
     productName: info?.productName || '',
     vendorId: info?.vendorId || NaN,

--- a/src/components/configure/header/Header.scss
+++ b/src/components/configure/header/Header.scss
@@ -12,38 +12,41 @@
   background: white;
   border-bottom: 1px solid rgba(0, 0, 0, 0.2);
   z-index: 2;
-
-  .kbd-select {
+  .kbd-device {
     display: flex;
     flex-direction: row;
-    align-items: center;
-    cursor: pointer;
-
-    .kbd-name {
+    .kbd-select {
       display: flex;
-      flex-direction: column;
+      flex-direction: row;
+      align-items: center;
+      cursor: pointer;
 
-      h2 {
-        margin: 0;
-      }
-      .ids {
-        font-size: $font-xs;
-        color: $color-gray;
-        margin-top: -4px;
-      }
-    }
-
-    &:hover {
-      color: $primary;
       .kbd-name {
+        display: flex;
+        flex-direction: column;
+
+        h2 {
+          margin: 0;
+        }
         .ids {
-          color: $primary;
+          font-size: $font-xs;
+          color: $color-gray;
+          margin-top: -4px;
         }
       }
-    }
 
-    .device-list {
-      display: flex;
+      &:hover {
+        color: $primary;
+        .kbd-name {
+          .ids {
+            color: $primary;
+          }
+        }
+      }
+
+      .device-list {
+        display: flex;
+      }
     }
   }
 

--- a/src/components/configure/header/Header.tsx
+++ b/src/components/configure/header/Header.tsx
@@ -44,6 +44,11 @@ export default class Header extends React.Component<HeaderProps, HeaderState> {
     ) {
       this.onClickDevice();
     }
+
+    if (this.props.keyboard && !nextProps.keyboard) {
+      this.setState({ openInfoDialog: false });
+    }
+
     return true;
   }
 
@@ -148,7 +153,7 @@ export default class Header extends React.Component<HeaderProps, HeaderState> {
                 >
                   {this.props.keyboards!.map((kbd, index) => {
                     const info = kbd.getInformation();
-                    const isOpenedKbd = this.props.openedKeyboard == kbd;
+                    const isOpenedKbd = this.props.keyboard == kbd;
                     const linking = isOpenedKbd ? 'link-on' : 'link-off';
                     return (
                       <MenuItem
@@ -212,10 +217,9 @@ export default class Header extends React.Component<HeaderProps, HeaderState> {
           </div>
 
           <div
-            className={[
-              'buttons',
-              this.props.openedKeyboard ? '' : 'hidden',
-            ].join(' ')}
+            className={['buttons', this.props.keyboard ? '' : 'hidden'].join(
+              ' '
+            )}
           >
             <button
               ref={this.flashButtonRef}

--- a/src/components/configure/info/InfoDialog.container.ts
+++ b/src/components/configure/info/InfoDialog.container.ts
@@ -1,0 +1,20 @@
+import { connect } from 'react-redux';
+import InfoDialog from './InfoDialog';
+import { RootState } from '../../../store/state';
+
+const mapStateToProps = (state: RootState) => {
+  return {
+    keyboard: state.entities.keyboard,
+    keyboardDefinition: state.entities.keyboardDefinition,
+    keyboardDefinitionDocument: state.entities.keyboardDefinitionDocument,
+  };
+};
+export type InfoDialogStateType = ReturnType<typeof mapStateToProps>;
+
+// eslint-disable-next-line no-unused-vars
+const mapDispatchToProps = (_dispatch: any) => {
+  return {};
+};
+export type InfoDialogActionsType = ReturnType<typeof mapDispatchToProps>;
+
+export default connect(mapStateToProps, mapDispatchToProps)(InfoDialog);

--- a/src/components/configure/info/InfoDialog.scss
+++ b/src/components/configure/info/InfoDialog.scss
@@ -1,0 +1,14 @@
+@import '../../../variables';
+
+.info-dialog {
+  .close-dialog {
+    position: absolute;
+    top: 20px;
+    right: 20px;
+
+    &:hover {
+      color: $primary-light;
+      cursor: pointer;
+    }
+  }
+}

--- a/src/components/configure/info/InfoDialog.tsx
+++ b/src/components/configure/info/InfoDialog.tsx
@@ -1,0 +1,191 @@
+/* eslint-disable no-undef */
+import React from 'react';
+import './InfoDialog.scss';
+import {
+  Dialog,
+  DialogContent,
+  DialogTitle,
+  Grid,
+  Paper,
+  PaperProps,
+} from '@material-ui/core';
+import CloseIcon from '@material-ui/icons/Close';
+import Draggable from 'react-draggable';
+import {
+  InfoDialogActionsType,
+  InfoDialogStateType,
+} from './InfoDialog.container';
+import { hexadecimal } from '../../../utils/StringUtils';
+
+const GOOGLE_FORM_URL =
+  'https://docs.google.com/forms/d/e/1FAIpQLScZPhiXEG2VETCGZ2dYp4YbzzMlU62Crh1cNxPpFBkN4cCPbA/viewform?usp=pp_url&entry.661359702=${keyboard_name}&entry.135453541=${keyboard_id}';
+
+type OwnState = {
+  deviceInfo: {
+    productName: string;
+    vendorId: number;
+    productId: number;
+  };
+  keyboardDef: {
+    name: string;
+    vendorId: string;
+    productId: string;
+    matrix: {
+      rows: number;
+      cols: number;
+    };
+  };
+};
+
+type OwnProps = {
+  open: boolean;
+  onClose: () => void;
+};
+
+type InfoStateProps = OwnProps &
+  Partial<InfoDialogActionsType> &
+  Partial<InfoDialogStateType>;
+
+export default class InfoDialog extends React.Component<
+  InfoStateProps,
+  OwnState
+> {
+  private googleFormUrl: string = '';
+  private githubUrl: string = '';
+  private githubDisplayName: string = '';
+  constructor(props: InfoStateProps | Readonly<InfoStateProps>) {
+    super(props);
+    this.state = {
+      deviceInfo: {
+        productName: '',
+        vendorId: NaN,
+        productId: NaN,
+      },
+      keyboardDef: {
+        name: '',
+        vendorId: '',
+        productId: '',
+        matrix: {
+          rows: NaN,
+          cols: NaN,
+        },
+      },
+    };
+  }
+
+  private onEnter() {
+    if (this.props.keyboardDefinitionDocument) {
+      this.googleFormUrl = GOOGLE_FORM_URL.replace(
+        '${keyboard_name}',
+        this.props.keyboardDefinitionDocument.name
+      ).replace('${keyboard_id}', this.props.keyboardDefinitionDocument.id);
+
+      this.githubUrl = this.props.keyboardDefinitionDocument.githubUrl;
+      this.githubDisplayName = this.props.keyboardDefinitionDocument.githubDisplayName;
+    }
+
+    const deviceInfo = this.props.keyboard!.getInformation();
+    const keyboardDef = this.props.keyboardDefinition!;
+    this.setState({ deviceInfo, keyboardDef });
+  }
+
+  render() {
+    return (
+      <Dialog
+        open={this.props.open}
+        maxWidth={'sm'}
+        PaperComponent={PaperComponent}
+        className="info-dialog"
+        onEnter={() => {
+          this.onEnter();
+        }}
+      >
+        <DialogTitle id="info-dialog-title" style={{ cursor: 'move' }}>
+          Keyboard Info
+          <div className="close-dialog">
+            <CloseIcon onClick={this.props.onClose} />
+          </div>
+        </DialogTitle>
+        <DialogContent dividers className="info-dialog-content">
+          <Grid container spacing={1}>
+            <Grid item xs={12} className="option-info-label">
+              <h4>CONNECTED DEVICE</h4>
+            </Grid>
+            <InfoRow
+              label="Product Name"
+              value={this.state.deviceInfo.productName}
+            />
+            <InfoRow
+              label="Vendor ID"
+              value={hexadecimal(this.state.deviceInfo.vendorId, 4)}
+            />
+            <InfoRow
+              label="Product ID"
+              value={hexadecimal(this.state.deviceInfo.productId, 4)}
+            />
+            <Grid item xs={12} className="option-info-label">
+              <h4>KEYBOARD DEFINITION</h4>
+            </Grid>
+            <InfoRow label="Name" value={this.state.keyboardDef.name} />
+            <InfoRow
+              label="Vendor ID"
+              value={this.state.keyboardDef.vendorId}
+            />
+            <InfoRow
+              label="Product ID"
+              value={this.state.keyboardDef.productId}
+            />
+            <InfoRow
+              label="Col x Row"
+              value={`${this.state.keyboardDef.matrix.cols} x ${this.state.keyboardDef.matrix.rows}`}
+            />
+            <InfoRow
+              label="Registered by"
+              value={
+                <a href={this.githubUrl} target="_blank" rel="noreferrer">
+                  {this.githubDisplayName}
+                </a>
+              }
+            />
+            <Grid item xs={12} className="option-info-label">
+              <div className="option-warning-message">
+                If you think that the person above does not have any rights for
+                the keyboard and the keyboard definition (in the case of the
+                person is not original keyboard designer or etc.), please report
+                it to the Remap team from{' '}
+                <a href={this.googleFormUrl} target="_blank" rel="noreferrer">
+                  this form
+                </a>
+                .
+              </div>
+            </Grid>
+          </Grid>
+        </DialogContent>
+      </Dialog>
+    );
+  }
+}
+
+function InfoRow(props: { label: string; value: string | React.ReactNode }) {
+  return (
+    <React.Fragment>
+      <Grid item xs={6} className="option-info-label">
+        {props.label}
+      </Grid>
+      <Grid item xs={6} className="option-info-value">
+        {props.value}
+      </Grid>
+    </React.Fragment>
+  );
+}
+
+function PaperComponent(props: PaperProps) {
+  return (
+    <Draggable
+      handle="#info-dialog-title"
+      cancel={'[class*="MuiDialogContent-root"]'}
+    >
+      <Paper {...props} />
+    </Draggable>
+  );
+}


### PR DESCRIPTION
Connected device's info should be nice to be placed on the header instead of ConfigurationDialog, I think.
I moved the info panel from the ConfigurationDialog to the header and create a new dialog for showing the info.
<img width="252" alt="スクリーンショット 2021-03-05 10 55 29" src="https://user-images.githubusercontent.com/316463/110062853-60b1a080-7dad-11eb-8f3e-dc78ba907f51.png">

<img width="1280" alt="スクリーンショット 2021-03-05 10 48 33" src="https://user-images.githubusercontent.com/316463/110062860-6313fa80-7dad-11eb-9ffc-59f9c8a906ee.png">

