### PR TITLE
fixed the broken configure app layout with a low height keyboard

### DIFF
--- a/src/components/configure/remap/Remap.container.ts
+++ b/src/components/configure/remap/Remap.container.ts
@@ -5,9 +5,7 @@ import { RootState } from '../../../store/state';
 const mapStateToProps = (state: RootState) => {
   return {
     hoverKey: state.configure.keycodeKey.hoverKey,
-    keyboard: state.entities.keyboard,
-    keyboardHeight: state.app.keyboardHeight,
-    package: state.app.package,
+    keyboardHeight: state.app.keyboardHeight, // DO NOT REMOVE!! This component should be updated when the keyboardHeight is set
   };
 };
 export type RemapStateType = ReturnType<typeof mapStateToProps>;

--- a/src/components/configure/remap/Remap.tsx
+++ b/src/components/configure/remap/Remap.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable no-undef */
 import React from 'react';
 import './Remap.scss';
 import { hexadecimal } from '../../../utils/StringUtils';
@@ -12,23 +13,43 @@ type RemapPropType = OwnProp &
   Partial<RemapStateType> &
   Partial<RemapActionsType>;
 
-export default class Remap extends React.Component<RemapPropType, {}> {
+type OwnState = {
+  keycodeY: number;
+};
+
+export default class Remap extends React.Component<RemapPropType, OwnState> {
+  private keyboardWrapperRef: React.RefObject<HTMLDivElement>;
   constructor(props: RemapPropType | Readonly<RemapPropType>) {
     super(props);
+    this.state = {
+      keycodeY: 0,
+    };
+    this.keyboardWrapperRef = React.createRef<HTMLDivElement>();
+  }
+
+  // eslint-disable-next-line no-unused-vars
+  shouldComponentUpdate(nextProps: RemapPropType, nextState: OwnState) {
+    if (!this.keyboardWrapperRef.current) return true;
+
+    const headerHeight = 56;
+    const rect = this.keyboardWrapperRef.current.getBoundingClientRect();
+    const keycodeY = headerHeight + rect.height;
+    if (this.state.keycodeY != keycodeY) {
+      this.setState({ keycodeY });
+    }
+
+    return true;
   }
 
   render() {
     return (
       <React.Fragment>
-        <div className="keyboard-wrapper">
+        <div className="keyboard-wrapper" ref={this.keyboardWrapperRef}>
           <div className="keymap">
             <Keymap />
           </div>
         </div>
-        <div
-          className="keycode"
-          style={{ marginTop: 182 + this.props.keyboardHeight! }}
-        >
+        <div className="keycode" style={{ marginTop: this.state.keycodeY }}>
           <Keycodes />
         </div>
         <Desc value={this.props.hoverKey} />


### PR DESCRIPTION
**What's happened?**
The position of keycode area is calculate from the height of the keyboard layout.
If the low keyboard height, the position of keycode is broken.

**How to solve**
Use the actual height of the keyboard area by calculating it when the component is updated.

<img width="642" alt="スクリーンショット 2021-03-06 9 09 43" src="https://user-images.githubusercontent.com/316463/110187860-33bcc680-7e5d-11eb-941e-fe9f63ea781b.png">
