### PR TITLE
replaced the info icon to the original rounded icon

### DIFF
--- a/src/components/common/icons/InfoIcon.tsx
+++ b/src/components/common/icons/InfoIcon.tsx
@@ -1,0 +1,10 @@
+import React from 'react';
+import { SvgIcon } from '@material-ui/core';
+
+export function InfoIcon(props: any) {
+  return (
+    <SvgIcon {...props}>
+      <path d="M 11 7 h 2 v 2 h -2 z m 0 5 C 11 11 12 11 12 11 c 0 0 1 0 1 1 v 4 C 13 17 12 17 12 17 c 0 0 -1 0 -1 -1 z m 1 -10 C 6.48 2 2 6.48 2 12 s 4.48 10 10 10 s 10 -4.48 10 -10 S 17.52 2 12 2 z m 0 18 c -4.41 0 -8 -3.59 -8 -8 s 3.59 -8 8 -8 s 8 3.59 8 8 s -3.59 8 -8 8 z" />
+    </SvgIcon>
+  );
+}

--- a/src/components/configure/header/Header.tsx
+++ b/src/components/configure/header/Header.tsx
@@ -3,12 +3,13 @@ import React from 'react';
 import './Header.scss';
 import { hexadecimal } from '../../../utils/StringUtils';
 import { Button, IconButton, Menu, MenuItem } from '@material-ui/core';
-import { ArrowDropDown, Link, InfoOutlined } from '@material-ui/icons';
+import { ArrowDropDown, Link } from '@material-ui/icons';
 import ConnectionModal from '../modals/connection/ConnectionModal';
 import { HeaderActionsType, HeaderStateType } from './Header.container';
 import { IKeyboard, IKeymap } from '../../../services/hid/Hid';
 import { Logo } from '../../common/logo/Logo';
 import InfoDialog from '../info/InfoDialog.container';
+import { InfoIcon } from '../../common/icons/InfoIcon';
 
 type HeaderState = {
   connectionStateEl: any;
@@ -202,7 +203,7 @@ export default class Header extends React.Component<HeaderProps, HeaderState> {
               </div>
             </div>
             <IconButton onClick={this.onClickShowInfoDialog.bind(this)}>
-              <InfoOutlined />
+              <InfoIcon />
             </IconButton>
           </div>
 


### PR DESCRIPTION
Current info icon is not rounded in spite of the other icons are rounded.
<img width="246" alt="スクリーンショット 2021-03-06 10 12 32" src="https://user-images.githubusercontent.com/316463/110190257-c06b8280-7e65-11eb-9fbb-dfeed1b41f75.png">

I designed an outlined rounded info icon because there is no one in the material icons.
<img width="215" alt="スクリーンショット 2021-03-06 10 19 43" src="https://user-images.githubusercontent.com/316463/110190296-f01a8a80-7e65-11eb-9d04-022d8a775987.png">
