### PR TITLE
Refactor the logic to get a GitHub provider data.

### DIFF
--- a/src/actions/storage.action.ts
+++ b/src/actions/storage.action.ts
@@ -19,6 +19,7 @@ import {
   KeyboardsAppActions,
   KeyboardsEditDefinitionActions,
 } from './keyboards.actions';
+import { getGitHubProviderData } from '../services/auth/Auth';
 
 export const STORAGE_ACTIONS = '@Storage';
 export const STORAGE_UPDATE_KEYBOARD_DEFINITION = `${STORAGE_ACTIONS}/UpdateKeyboardDefinition`;
@@ -259,7 +260,17 @@ export const storageActionsThunk = {
     const { storage, auth, keyboards, github } = getState();
     const keyboardDefinition = keyboards.createdefinition.keyboardDefinition!;
     const user = auth.instance!.getCurrentAuthenticatedUser();
-    const githubProviderData = user.providerData[0]!;
+    const githubProviderDataResutl = getGitHubProviderData(user);
+    if (!githubProviderDataResutl.exists) {
+      console.error('The user does not have a GitHub Provider data.');
+      dispatch(
+        NotificationActions.addError(
+          'The user does not have a GitHub Provider data.'
+        )
+      );
+      return;
+    }
+    const githubProviderData = githubProviderDataResutl.userInfo!;
 
     const fetchAccountInfoResult = await github.instance.fetchAccountInfo(
       githubProviderData.uid
@@ -313,7 +324,17 @@ export const storageActionsThunk = {
     const keyboardDefinition = keyboards.createdefinition.keyboardDefinition!;
 
     const user = auth.instance!.getCurrentAuthenticatedUser();
-    const githubProviderData = user.providerData[0]!;
+    const githubProviderDataResutl = getGitHubProviderData(user);
+    if (!githubProviderDataResutl.exists) {
+      console.error('The user does not have a GitHub Provider data.');
+      dispatch(
+        NotificationActions.addError(
+          'The user does not have a GitHub Provider data.'
+        )
+      );
+      return;
+    }
+    const githubProviderData = githubProviderDataResutl.userInfo!;
 
     const fetchAccountInfoResult = await github.instance.fetchAccountInfo(
       githubProviderData.uid

--- a/src/components/keyboards/KeyboardDefinitionManagement.tsx
+++ b/src/components/keyboards/KeyboardDefinitionManagement.tsx
@@ -67,6 +67,7 @@ class KeyboardDefinitionManagement extends React.Component<
   componentDidMount() {
     this.props.auth!.subscribeAuthStatus((user) => {
       if (user) {
+        console.log(user.providerData);
         this.props.startInitializing!();
         this.updateNotifications();
         this.props.updateKeyboards!();

--- a/src/components/keyboards/header/Header.tsx
+++ b/src/components/keyboards/header/Header.tsx
@@ -4,6 +4,7 @@ import { HeaderActionsType, HeaderStateType } from './Header.container';
 import { Logo } from '../../common/logo/Logo';
 import { Avatar, IconButton, Menu, MenuItem } from '@material-ui/core';
 import { Person } from '@material-ui/icons';
+import { getGitHubProviderData } from '../../../services/auth/Auth';
 
 type HeaderState = {
   menuAnchorEl: any;
@@ -42,8 +43,15 @@ class Header extends React.Component<HeaderProps, HeaderState> {
     const user = this.props.auth!.getCurrentAuthenticatedUser();
     if (user) {
       const { menuAnchorEl } = this.state;
-      const profileImageUrl = user.providerData[0]?.photoURL || '';
-      const profileDisplayName = user.providerData[0]?.displayName || '';
+
+      const githubProviderDataResutl = getGitHubProviderData(user);
+      if (!githubProviderDataResutl.exists) {
+        throw new Error('The user does not have a GitHub Provider data.');
+      }
+      const githubProviderData = githubProviderDataResutl.userInfo!;
+
+      const profileImageUrl = githubProviderData.photoURL || '';
+      const profileDisplayName = githubProviderData.displayName || '';
       if (profileImageUrl) {
         return (
           <React.Fragment>

--- a/src/services/auth/Auth.ts
+++ b/src/services/auth/Auth.ts
@@ -2,7 +2,32 @@ import firebase from 'firebase';
 
 export interface IAuth {
   signInWithGitHub(): Promise<void>;
+  // eslint-disable-next-line no-unused-vars
   subscribeAuthStatus(callback: (user: firebase.User | null) => void): void;
   getCurrentAuthenticatedUser(): firebase.User;
   signOutFromGitHub(): Promise<void>;
 }
+
+export type IGetProviderDataResult = {
+  exists: boolean;
+  userInfo?: firebase.UserInfo;
+};
+
+export const getGitHubProviderData = (
+  user: firebase.User
+): IGetProviderDataResult => {
+  const providerData = user.providerData;
+  const githubProviderData = providerData.find(
+    (data) => data?.providerId === 'github.com'
+  );
+  if (githubProviderData) {
+    return {
+      exists: true,
+      userInfo: githubProviderData,
+    };
+  } else {
+    return {
+      exists: false,
+    };
+  }
+};


### PR DESCRIPTION
We intend to introduce an authentication feature for users on the `/configure`. Currently, Remap uses a GitHub authentication provider only, therefore, the array size of the `providerData` array is 1. However, the length of the `providerData` array will be 2 or more after introducing other authentication providers.