### PR TITLE
added a keycode of EEPROM RESET

### DIFF
--- a/src/services/hid/KeyCategoryList.ts
+++ b/src/services/hid/KeyCategoryList.ts
@@ -411,7 +411,7 @@ export const KEY_SUB_CATEGORY_MOUSE: IKeycodeCategoryInfo = {
 // Reset, Debug
 export const KEY_SUB_CATEGORY_KEYBOARD: IKeycodeCategoryInfo = {
   kinds: ['device', 'keyboard'],
-  codes: [23552, 23553],
+  codes: [23552, 23553, 23774],
 };
 // CL SWAP, CL CTRL, LAG SWP, RAG SWP, GUI OFF, GE SWAP, BS SWAP, NK ON, AG SWAP, CL NORM, CL CAPS, LAG NRM, RAG NRM, GUI ON, GE NORM, BS NORM, NK OFF, AG NORM, NK TOGG, AG TOGG
 export const KEY_SUB_CATEGORY_BOOTMAGIC: IKeycodeCategoryInfo = {

--- a/src/services/hid/KeycodeInfoList.ts
+++ b/src/services/hid/KeycodeInfoList.ts
@@ -4182,6 +4182,18 @@ export const keyInfoList: KeyInfo[] = [
   },
 
   {
+    desc: "Reinitializes the keyboard's EEPROM (persistent memory)",
+    keycodeInfo: {
+      code: 23774,
+      name: {
+        long: 'EEPROM_RESET',
+        short: 'EEP_RST',
+      },
+      label: 'EEPROM RESET',
+    },
+  },
+
+  {
     desc: 'Left Control when held, ( when tapped',
     keycodeInfo: {
       code: 23795,


### PR DESCRIPTION
Added a EEPROM RESET keycode in the device/keyboard category.
<img width="1674" alt="スクリーンショット 2021-03-10 6 15 58" src="https://user-images.githubusercontent.com/316463/110539320-6ff76c00-8168-11eb-8428-75d16af4eb90.png">
