### PR TITLE
User authentication for both /configure and /keyboards

### DIFF
--- a/src/actions/actions.ts
+++ b/src/actions/actions.ts
@@ -252,7 +252,10 @@ export const AppActions = {
   },
 };
 
-type ActionTypes = ReturnType<typeof AppActions[keyof typeof AppActions]>;
+type ActionTypes = ReturnType<
+  | typeof AppActions[keyof typeof AppActions]
+  | typeof NotificationActions[keyof typeof NotificationActions]
+>;
 type ThunkPromiseAction<T> = ThunkAction<
   Promise<T>,
   RootState,
@@ -269,6 +272,54 @@ export const AppActionsThunk = {
     const { auth } = getState();
     await auth.instance!.signOut();
     dispatch(AppActions.updateSignedIn(false));
+  },
+  loginWithGitHubAccount: (): ThunkPromiseAction<void> => async (
+    dispatch: ThunkDispatch<RootState, undefined, ActionTypes>,
+    // eslint-disable-next-line no-unused-vars
+    getState: () => RootState
+  ) => {
+    const { auth } = getState();
+    const result = await auth.instance!.signInWithGitHubWithPopup();
+    if (!result.success) {
+      console.error(result.cause!);
+      dispatch(NotificationActions.addError(result.error!, result.cause));
+    }
+  },
+  loginWithGoogleAccount: (): ThunkPromiseAction<void> => async (
+    dispatch: ThunkDispatch<RootState, undefined, ActionTypes>,
+    // eslint-disable-next-line no-unused-vars
+    getState: () => RootState
+  ) => {
+    const { auth } = getState();
+    const result = await auth.instance!.signInWithGoogleWithPopup();
+    if (!result.success) {
+      console.error(result.cause!);
+      dispatch(NotificationActions.addError(result.error!, result.cause));
+    }
+  },
+  linkToGoogleAccount: (): ThunkPromiseAction<void> => async (
+    dispatch: ThunkDispatch<RootState, undefined, ActionTypes>,
+    // eslint-disable-next-line no-unused-vars
+    getState: () => RootState
+  ) => {
+    const { auth } = getState();
+    const result = await auth.instance!.linkToGoogleWithPopup();
+    if (!result.success) {
+      console.error(result.cause!);
+      dispatch(NotificationActions.addError(result.error!, result.cause));
+    }
+  },
+  linkToGitHubAccount: (): ThunkPromiseAction<void> => async (
+    dispatch: ThunkDispatch<RootState, undefined, ActionTypes>,
+    // eslint-disable-next-line no-unused-vars
+    getState: () => RootState
+  ) => {
+    const { auth } = getState();
+    const result = await auth.instance!.linkToGitHubWithPopup();
+    if (!result.success) {
+      console.error(result.cause!);
+      dispatch(NotificationActions.addError(result.error!, result.cause));
+    }
   },
 };
 

--- a/src/actions/actions.ts
+++ b/src/actions/actions.ts
@@ -3,7 +3,8 @@ import { Key } from '../components/configure/keycodekey/KeyGen';
 import KeyModel from '../models/KeyModel';
 import { IKeymap } from '../services/hid/Hid';
 import { KeyboardLabelLang } from '../services/labellang/KeyLabelLangs';
-import { ISetupPhase } from '../store/state';
+import { ISetupPhase, RootState } from '../store/state';
+import { ThunkAction, ThunkDispatch } from 'redux-thunk';
 
 export const KEYMAP_ACTIONS = '@Keymap';
 export const KEYMAP_CLEAR_SELECTED_POS = `${KEYMAP_ACTIONS}/ClearSelectedLayer`;
@@ -248,6 +249,26 @@ export const AppActions = {
       type: APP_UPDATE_SIGNED_IN,
       value: signedIn,
     };
+  },
+};
+
+type ActionTypes = ReturnType<typeof AppActions[keyof typeof AppActions]>;
+type ThunkPromiseAction<T> = ThunkAction<
+  Promise<T>,
+  RootState,
+  undefined,
+  ActionTypes
+>;
+export const AppActionsThunk = {
+  // eslint-disable-next-line no-undef
+  logout: (): ThunkPromiseAction<void> => async (
+    dispatch: ThunkDispatch<RootState, undefined, ActionTypes>,
+    // eslint-disable-next-line no-unused-vars
+    getState: () => RootState
+  ) => {
+    const { auth } = getState();
+    await auth.instance!.signOut();
+    dispatch(AppActions.updateSignedIn(false));
   },
 };
 

--- a/src/actions/actions.ts
+++ b/src/actions/actions.ts
@@ -181,6 +181,7 @@ export const APP_REMAPS_CLEAR = `${APP_ACTIONS}/Clear`;
 export const APP_PACKAGE_INIT = `${APP_ACTIONS}/PackageInit`;
 export const APP_UPDATE_KEYBOARD_SIZE = `${APP_ACTIONS}/UpdateKeyboardSize`;
 export const APP_UPDATE_LANG_LABEL = `${APP_ACTIONS}/UpdateLangLabel`;
+export const APP_UPDATE_SIGNED_IN = `${APP_ACTIONS}/SignedIn`;
 export const AppActions = {
   updateSetupPhase: (setupPhase: ISetupPhase) => {
     return {
@@ -240,6 +241,12 @@ export const AppActions = {
     return {
       type: APP_UPDATE_LANG_LABEL,
       value: langLabel,
+    };
+  },
+  updateSignedIn: (signedIn: boolean) => {
+    return {
+      type: APP_UPDATE_SIGNED_IN,
+      value: signedIn,
     };
   },
 };

--- a/src/actions/keyboards.actions.ts
+++ b/src/actions/keyboards.actions.ts
@@ -240,6 +240,6 @@ export const keyboardsActionsThunk = {
   ) => {
     const { auth } = getState();
     dispatch(KeyboardsAppActions.updatePhase(KeyboardsPhase.signout));
-    await auth.instance!.signOutFromGitHub();
+    await auth.instance!.signOut();
   },
 };

--- a/src/components/configure/Configure.container.ts
+++ b/src/components/configure/Configure.container.ts
@@ -58,6 +58,10 @@ const mapDispatchToProps = (_dispatch: any) => {
     onCloseKeyboard: (keyboard: IKeyboard) => {
       _dispatch(hidActionsThunk.closeKeyboard(keyboard));
     },
+
+    updateSignedIn: (signedIn: boolean) => {
+      _dispatch(AppActions.updateSignedIn(signedIn));
+    },
   };
 };
 

--- a/src/components/configure/Configure.tsx
+++ b/src/components/configure/Configure.tsx
@@ -108,16 +108,6 @@ class Configure extends React.Component<ConfigureProps, OwnState> {
     this.props.initAppPackage!(name, version);
 
     this.props.auth!.subscribeAuthStatus((user) => {
-      // if (user) {
-      //   user
-      //     .unlink(firebase.auth.GithubAuthProvider.PROVIDER_ID)
-      //     .then(() => {
-      //       console.log('success');
-      //     })
-      //     .catch((err) => {
-      //       console.log(err);
-      //     });
-      // }
       this.props.updateSignedIn!(!!user);
     });
 

--- a/src/components/configure/Configure.tsx
+++ b/src/components/configure/Configure.tsx
@@ -108,6 +108,16 @@ class Configure extends React.Component<ConfigureProps, OwnState> {
     this.props.initAppPackage!(name, version);
 
     this.props.auth!.subscribeAuthStatus((user) => {
+      // if (user) {
+      //   user
+      //     .unlink(firebase.auth.GithubAuthProvider.PROVIDER_ID)
+      //     .then(() => {
+      //       console.log('success');
+      //     })
+      //     .catch((err) => {
+      //       console.log(err);
+      //     });
+      // }
       this.props.updateSignedIn!(!!user);
     });
 

--- a/src/components/configure/Configure.tsx
+++ b/src/components/configure/Configure.tsx
@@ -106,6 +106,11 @@ class Configure extends React.Component<ConfigureProps, OwnState> {
     const version = appPackage.version;
     const name = appPackage.name;
     this.props.initAppPackage!(name, version);
+
+    this.props.auth!.subscribeAuthStatus((user) => {
+      this.props.updateSignedIn!(!!user);
+    });
+
     this.updateTitle();
     this.updateNotifications();
     this.initKeyboardConnectionEventHandler();

--- a/src/components/configure/auth/AuthProviderDialog.container.ts
+++ b/src/components/configure/auth/AuthProviderDialog.container.ts
@@ -1,0 +1,27 @@
+import { connect } from 'react-redux';
+import AuthProviderDialog from './AuthProviderDialog';
+import { RootState } from '../../../store/state';
+import { AppActionsThunk } from '../../../actions/actions';
+
+// eslint-disable-next-line no-unused-vars
+const mapStateToProps = (state: RootState) => {
+  return {};
+};
+export type AuthProviderDialogStateType = ReturnType<typeof mapStateToProps>;
+
+// eslint-disable-next-line no-unused-vars
+const mapDispatchToProps = (_dispatch: any) => {
+  return {
+    loginWithGitHubAccount: () => {
+      _dispatch(AppActionsThunk.loginWithGitHubAccount());
+    },
+    loginWithGoogleAccount: () => {
+      _dispatch(AppActionsThunk.loginWithGoogleAccount());
+    },
+  };
+};
+export type AuthProviderDialogActionsType = ReturnType<
+  typeof mapDispatchToProps
+>;
+
+export default connect(mapStateToProps, mapDispatchToProps)(AuthProviderDialog);

--- a/src/components/configure/auth/AuthProviderDialog.scss
+++ b/src/components/configure/auth/AuthProviderDialog.scss
@@ -1,0 +1,19 @@
+@import '../../../variables';
+
+.auth-provider-dialog {
+  .close-dialog {
+    position: absolute;
+    top: 20px;
+    right: 20px;
+
+    &:hover {
+      color: $primary-light;
+      cursor: pointer;
+    }
+  }
+
+  &-content {
+    display: flex;
+    flex-direction: column;
+  }
+}

--- a/src/components/configure/auth/AuthProviderDialog.scss
+++ b/src/components/configure/auth/AuthProviderDialog.scss
@@ -15,5 +15,10 @@
   &-content {
     display: flex;
     flex-direction: column;
+
+    &-provider {
+      display: inline-block;
+      margin-left: $space-m;
+    }
   }
 }

--- a/src/components/configure/auth/AuthProviderDialog.tsx
+++ b/src/components/configure/auth/AuthProviderDialog.tsx
@@ -12,6 +12,7 @@ import {
 import CloseIcon from '@material-ui/icons/Close';
 import React from 'react';
 import './AuthProviderDialog.scss';
+import { GitHub, Person } from '@material-ui/icons';
 
 type OwnState = {};
 
@@ -62,10 +63,16 @@ export default class AuthProviderDialog extends React.Component<
             Which do you want to login with?
           </Typography>
           <Button onClick={this.onGoogleLoginButtonClick}>
-            Google Account
+            <Person />
+            <span className="auth-provider-dialog-content-provider">
+              Google Account
+            </span>
           </Button>
           <Button onClick={this.onGitHubLoginButtonClick}>
-            GitHub Account
+            <GitHub />
+            <span className="auth-provider-dialog-content-provider">
+              GitHub Account
+            </span>
           </Button>
         </DialogContent>
       </Dialog>

--- a/src/components/configure/auth/AuthProviderDialog.tsx
+++ b/src/components/configure/auth/AuthProviderDialog.tsx
@@ -1,0 +1,74 @@
+import {
+  AuthProviderDialogActionsType,
+  AuthProviderDialogStateType,
+} from './AuthProviderDialog.container';
+import {
+  Button,
+  Dialog,
+  DialogContent,
+  DialogTitle,
+  Typography,
+} from '@material-ui/core';
+import CloseIcon from '@material-ui/icons/Close';
+import React from 'react';
+import './AuthProviderDialog.scss';
+
+type OwnState = {};
+
+type OwnProps = {
+  open: boolean;
+  onClose: () => void;
+};
+
+type AuthProviderDialogProps = OwnProps &
+  Partial<AuthProviderDialogActionsType> &
+  Partial<AuthProviderDialogStateType>;
+
+export default class AuthProviderDialog extends React.Component<
+  AuthProviderDialogProps,
+  OwnState
+> {
+  constructor(
+    props: AuthProviderDialogProps | Readonly<AuthProviderDialogProps>
+  ) {
+    super(props);
+  }
+
+  onGitHubLoginButtonClick = () => {
+    this.props.onClose();
+    this.props.loginWithGitHubAccount!();
+  };
+
+  onGoogleLoginButtonClick = () => {
+    this.props.onClose();
+    this.props.loginWithGoogleAccount!();
+  };
+
+  render() {
+    return (
+      <Dialog
+        open={this.props.open}
+        maxWidth="sm"
+        className="auth-provider-dialog"
+      >
+        <DialogTitle id="auth-provider-dialog-title">
+          Login
+          <div className="close-dialog">
+            <CloseIcon onClick={this.props.onClose} />
+          </div>
+        </DialogTitle>
+        <DialogContent dividers className="auth-provider-dialog-content">
+          <Typography variant="subtitle1">
+            Which do you want to login with?
+          </Typography>
+          <Button onClick={this.onGoogleLoginButtonClick}>
+            Google Account
+          </Button>
+          <Button onClick={this.onGitHubLoginButtonClick}>
+            GitHub Account
+          </Button>
+        </DialogContent>
+      </Dialog>
+    );
+  }
+}

--- a/src/components/configure/header/Header.container.ts
+++ b/src/components/configure/header/Header.container.ts
@@ -18,6 +18,7 @@ const mapStateToProps = (state: RootState) => {
     vendorId: info?.vendorId || NaN,
     showKeyboardList: !!kbd,
     remaps: state.app.remaps,
+    auth: state.auth.instance,
   };
 };
 export type HeaderStateType = ReturnType<typeof mapStateToProps>;

--- a/src/components/configure/header/Header.container.ts
+++ b/src/components/configure/header/Header.container.ts
@@ -3,7 +3,7 @@ import Header from './Header';
 import { RootState } from '../../../store/state';
 import { hidActionsThunk } from '../../../actions/hid.action';
 import { IKeyboard } from '../../../services/hid/Hid';
-import { HeaderActions } from '../../../actions/actions';
+import { AppActionsThunk, HeaderActions } from '../../../actions/actions';
 
 const mapStateToProps = (state: RootState) => {
   const kbd = state.entities.keyboard;
@@ -19,6 +19,7 @@ const mapStateToProps = (state: RootState) => {
     showKeyboardList: !!kbd,
     remaps: state.app.remaps,
     auth: state.auth.instance,
+    signedIn: state.app.signedIn,
   };
 };
 export type HeaderStateType = ReturnType<typeof mapStateToProps>;
@@ -34,6 +35,9 @@ const mapDispatchToProps = (_dispatch: any) => {
     onClickFlashButton: () => {
       _dispatch(HeaderActions.updateFlashing(true));
       _dispatch(hidActionsThunk.flash());
+    },
+    logout: () => {
+      _dispatch(AppActionsThunk.logout());
     },
   };
 };

--- a/src/components/configure/header/Header.container.ts
+++ b/src/components/configure/header/Header.container.ts
@@ -39,6 +39,12 @@ const mapDispatchToProps = (_dispatch: any) => {
     logout: () => {
       _dispatch(AppActionsThunk.logout());
     },
+    linkToGoogleAccount: () => {
+      _dispatch(AppActionsThunk.linkToGoogleAccount());
+    },
+    linkToGitHubAccount: () => {
+      _dispatch(AppActionsThunk.linkToGitHubAccount());
+    },
   };
 };
 export type HeaderActionsType = ReturnType<typeof mapDispatchToProps>;

--- a/src/components/configure/header/Header.scss
+++ b/src/components/configure/header/Header.scss
@@ -61,6 +61,7 @@
     margin-left: auto;
     width: 120px;
     justify-content: center;
+    height: 40px;
     .flash-btn {
       min-width: 80px !important;
     }
@@ -75,6 +76,17 @@
 
   .hidden {
     visibility: hidden;
+  }
+
+  &-right {
+    display: flex;
+    flex-direction: row;
+    align-items: center;
+  }
+
+  .header-avatar {
+    width: 31px !important;
+    height: 31px !important;
   }
 }
 

--- a/src/components/configure/header/Header.tsx
+++ b/src/components/configure/header/Header.tsx
@@ -113,7 +113,10 @@ export default class Header extends React.Component<HeaderProps, HeaderState> {
   };
 
   async handleLogoutMenuClick() {
-    console.log('logout');
+    this.props.logout!();
+    this.setState({
+      authMenuAnchorEl: null,
+    });
   }
 
   async handleLoginMenuClick() {
@@ -122,9 +125,8 @@ export default class Header extends React.Component<HeaderProps, HeaderState> {
 
   renderAvatarIcon() {
     const { authMenuAnchorEl } = this.state;
-
-    const user = this.props.auth!.getCurrentAuthenticatedUser();
-    if (user) {
+    if (this.props.signedIn) {
+      const user = this.props.auth!.getCurrentAuthenticatedUser();
       const githubProviderDataResult = getGitHubProviderData(user);
       if (!githubProviderDataResult.exists) {
         throw new Error('The user does not have a GitHub Provider data.');

--- a/src/components/configure/header/Header.tsx
+++ b/src/components/configure/header/Header.tsx
@@ -148,7 +148,7 @@ export default class Header extends React.Component<HeaderProps, HeaderState> {
     if (user && !getGoogleProviderData(user).exists) {
       return (
         <MenuItem
-          key="1"
+          key="auth-menu-link-google-account"
           button={true}
           onClick={() => this.handleLinkGoogleAccountMenuClick()}
         >
@@ -165,7 +165,7 @@ export default class Header extends React.Component<HeaderProps, HeaderState> {
     if (user && !getGitHubProviderData(user).exists) {
       return (
         <MenuItem
-          key="2"
+          key="auth-menu-link-github-account"
           button={true}
           onClick={() => this.handleLinkGitHubAccountMenuClick()}
         >
@@ -218,7 +218,7 @@ export default class Header extends React.Component<HeaderProps, HeaderState> {
             {this.renderLinkGoogleAccountMenu()}
             {this.renderLinkGitHubAccountMenu()}
             <MenuItem
-              key="3"
+              key="auth-menu-logout"
               button={true}
               onClick={() => this.handleLogoutMenuClick()}
             >
@@ -247,7 +247,7 @@ export default class Header extends React.Component<HeaderProps, HeaderState> {
             onClose={this.handleAuthMenuClose}
           >
             <MenuItem
-              key="1"
+              key="auth-menu-login"
               button={true}
               onClick={() => this.handleLoginMenuClick()}
             >

--- a/src/components/configure/header/Header.tsx
+++ b/src/components/configure/header/Header.tsx
@@ -17,7 +17,6 @@ type HeaderState = {
   logoAnimation: boolean;
   openInfoDialog: boolean;
   authMenuAnchorEl: any;
-  authenticated: boolean;
 };
 
 type OwnProps = {};
@@ -37,7 +36,6 @@ export default class Header extends React.Component<HeaderProps, HeaderState> {
       logoAnimation: false,
       openInfoDialog: false,
       authMenuAnchorEl: null,
-      authenticated: false,
     };
     this.flashButtonRef = React.createRef<HTMLButtonElement>();
     this.deviceMenuRef = React.createRef<HTMLDivElement>();
@@ -56,14 +54,6 @@ export default class Header extends React.Component<HeaderProps, HeaderState> {
     }
 
     return true;
-  }
-
-  componentDidMount() {
-    this.props.auth!.subscribeAuthStatus((user) => {
-      this.setState({
-        authenticated: !!user,
-      });
-    });
   }
 
   get openConnectionStateMenu() {

--- a/src/components/keyboards/KeyboardDefinitionManagement.tsx
+++ b/src/components/keyboards/KeyboardDefinitionManagement.tsx
@@ -77,25 +77,15 @@ class KeyboardDefinitionManagement extends React.Component<
             this.props.updateKeyboard!(definitionId);
           }
         } else {
-          this.props
-            .auth!.linkToGitHub()
-            .then(() => {
-              // N/A
-            })
-            .catch((err) => {
-              console.error(err);
-            });
+          this.props.auth!.linkToGitHub().then(() => {
+            // N/A
+          });
         }
       } else {
         if (this.props.phase !== 'signout') {
-          this.props
-            .auth!.signInWithGitHub()
-            .then(() => {
-              // N/A
-            })
-            .catch((err) => {
-              console.error(err);
-            });
+          this.props.auth!.signInWithGitHub().then(() => {
+            // N/A
+          });
         }
       }
     });

--- a/src/components/keyboards/KeyboardDefinitionManagement.tsx
+++ b/src/components/keyboards/KeyboardDefinitionManagement.tsx
@@ -10,6 +10,7 @@ import CloseIcon from '@material-ui/icons/Close';
 import Header from './header/Header.container';
 import Content from './content/Content.container';
 import { RouteComponentProps, withRouter } from 'react-router-dom';
+import { getGitHubProviderData } from '../../services/auth/Auth';
 
 type ParamsType = {
   definitionId: string;
@@ -66,20 +67,35 @@ class KeyboardDefinitionManagement extends React.Component<
 
   componentDidMount() {
     this.props.auth!.subscribeAuthStatus((user) => {
-      // TODO Check whether GitHub account authentication has aleady been done.
       if (user) {
-        this.props.startInitializing!();
-        this.updateNotifications();
-        this.props.updateKeyboards!();
-        const definitionId = this.props.match.params.definitionId;
-        if (definitionId) {
-          this.props.updateKeyboard!(definitionId);
+        if (getGitHubProviderData(user).exists) {
+          this.props.startInitializing!();
+          this.updateNotifications();
+          this.props.updateKeyboards!();
+          const definitionId = this.props.match.params.definitionId;
+          if (definitionId) {
+            this.props.updateKeyboard!(definitionId);
+          }
+        } else {
+          this.props
+            .auth!.linkToGitHub()
+            .then(() => {
+              // N/A
+            })
+            .catch((err) => {
+              console.error(err);
+            });
         }
       } else {
         if (this.props.phase !== 'signout') {
-          this.props.auth!.signInWithGitHub().then(() => {
-            // N/A
-          });
+          this.props
+            .auth!.signInWithGitHub()
+            .then(() => {
+              // N/A
+            })
+            .catch((err) => {
+              console.error(err);
+            });
         }
       }
     });

--- a/src/components/keyboards/KeyboardDefinitionManagement.tsx
+++ b/src/components/keyboards/KeyboardDefinitionManagement.tsx
@@ -66,6 +66,7 @@ class KeyboardDefinitionManagement extends React.Component<
 
   componentDidMount() {
     this.props.auth!.subscribeAuthStatus((user) => {
+      // TODO Check whether GitHub account authentication has aleady been done.
       if (user) {
         this.props.startInitializing!();
         this.updateNotifications();

--- a/src/components/keyboards/KeyboardDefinitionManagement.tsx
+++ b/src/components/keyboards/KeyboardDefinitionManagement.tsx
@@ -67,7 +67,6 @@ class KeyboardDefinitionManagement extends React.Component<
   componentDidMount() {
     this.props.auth!.subscribeAuthStatus((user) => {
       if (user) {
-        console.log(user.providerData);
         this.props.startInitializing!();
         this.updateNotifications();
         this.props.updateKeyboards!();

--- a/src/components/keyboards/header/Header.scss
+++ b/src/components/keyboards/header/Header.scss
@@ -19,4 +19,9 @@
     right: 16px;
     cursor: pointer;
   }
+
+  &-avatar {
+    width: 31px !important;
+    height: 31px !important;
+  }
 }

--- a/src/components/keyboards/header/Header.tsx
+++ b/src/components/keyboards/header/Header.tsx
@@ -52,38 +52,46 @@ class Header extends React.Component<HeaderProps, HeaderState> {
 
       const profileImageUrl = githubProviderData.photoURL || '';
       const profileDisplayName = githubProviderData.displayName || '';
+      let avatar: React.ReactNode;
       if (profileImageUrl) {
-        return (
-          <React.Fragment>
-            <IconButton
-              aria-owns={menuAnchorEl ? 'keyboards-header-menu' : undefined}
-              onClick={this.handleMenuIconClick}
-            >
-              <Avatar alt={profileDisplayName} src={profileImageUrl} />
-            </IconButton>
-            <Menu
-              id="keyboards-header-menu"
-              anchorEl={menuAnchorEl}
-              open={Boolean(menuAnchorEl)}
-              onClose={this.handleMenuClose}
-            >
-              <MenuItem
-                key="1"
-                button={true}
-                onClick={() => this.handleLogoutMenuClick()}
-              >
-                Logout
-              </MenuItem>
-            </Menu>
-          </React.Fragment>
+        avatar = (
+          <Avatar
+            alt={profileDisplayName}
+            src={profileImageUrl}
+            className="keyboards-header-avatar"
+          />
         );
       } else {
-        return (
-          <Avatar>
+        avatar = (
+          <Avatar className="keyboards-header-avatar">
             <Person />
           </Avatar>
         );
       }
+      return (
+        <React.Fragment>
+          <IconButton
+            aria-owns={menuAnchorEl ? 'keyboards-header-menu' : undefined}
+            onClick={this.handleMenuIconClick}
+          >
+            {avatar}
+          </IconButton>
+          <Menu
+            id="keyboards-header-menu"
+            anchorEl={menuAnchorEl}
+            open={Boolean(menuAnchorEl)}
+            onClose={this.handleMenuClose}
+          >
+            <MenuItem
+              key="1"
+              button={true}
+              onClick={() => this.handleLogoutMenuClick()}
+            >
+              Logout
+            </MenuItem>
+          </Menu>
+        </React.Fragment>
+      );
     } else {
       return null;
     }

--- a/src/components/keyboards/header/Header.tsx
+++ b/src/components/keyboards/header/Header.tsx
@@ -44,11 +44,11 @@ class Header extends React.Component<HeaderProps, HeaderState> {
     if (user) {
       const { menuAnchorEl } = this.state;
 
-      const githubProviderDataResutl = getGitHubProviderData(user);
-      if (!githubProviderDataResutl.exists) {
+      const githubProviderDataResult = getGitHubProviderData(user);
+      if (!githubProviderDataResult.exists) {
         throw new Error('The user does not have a GitHub Provider data.');
       }
-      const githubProviderData = githubProviderDataResutl.userInfo!;
+      const githubProviderData = githubProviderDataResult.userInfo!;
 
       const profileImageUrl = githubProviderData.photoURL || '';
       const profileDisplayName = githubProviderData.displayName || '';

--- a/src/services/auth/Auth.ts
+++ b/src/services/auth/Auth.ts
@@ -5,7 +5,7 @@ export interface IAuth {
   // eslint-disable-next-line no-unused-vars
   subscribeAuthStatus(callback: (user: firebase.User | null) => void): void;
   getCurrentAuthenticatedUser(): firebase.User;
-  signOutFromGitHub(): Promise<void>;
+  signOut(): Promise<void>;
 }
 
 export type IGetProviderDataResult = {

--- a/src/services/auth/Auth.ts
+++ b/src/services/auth/Auth.ts
@@ -1,7 +1,17 @@
 import firebase from 'firebase';
 
+export type IAuthenticationResult = {
+  success: boolean;
+  error?: string;
+  cause?: any;
+};
+
 export interface IAuth {
   signInWithGitHub(): Promise<void>;
+  signInWithGitHubWithPopup(): Promise<IAuthenticationResult>;
+  signInWithGoogleWithPopup(): Promise<IAuthenticationResult>;
+  linkToGoogleWithPopup(): Promise<IAuthenticationResult>;
+  linkToGitHubWithPopup(): Promise<IAuthenticationResult>;
   // eslint-disable-next-line no-unused-vars
   subscribeAuthStatus(callback: (user: firebase.User | null) => void): void;
   getCurrentAuthenticatedUser(): firebase.User;
@@ -16,14 +26,33 @@ export type IGetProviderDataResult = {
 export const getGitHubProviderData = (
   user: firebase.User
 ): IGetProviderDataResult => {
-  const providerData = user.providerData;
-  const githubProviderData = providerData.find(
-    (data) => data?.providerId === 'github.com'
+  return getConcreteProviderData(
+    user,
+    firebase.auth.GithubAuthProvider.PROVIDER_ID
   );
-  if (githubProviderData) {
+};
+
+export const getGoogleProviderData = (
+  user: firebase.User
+): IGetProviderDataResult => {
+  return getConcreteProviderData(
+    user,
+    firebase.auth.GoogleAuthProvider.PROVIDER_ID
+  );
+};
+
+const getConcreteProviderData = (
+  user: firebase.User,
+  providerId: string
+): IGetProviderDataResult => {
+  const providerDataList = user.providerData;
+  const providerData = providerDataList.find(
+    (data) => data?.providerId === providerId
+  );
+  if (providerData) {
     return {
       exists: true,
-      userInfo: githubProviderData,
+      userInfo: providerData,
     };
   } else {
     return {

--- a/src/services/auth/Auth.ts
+++ b/src/services/auth/Auth.ts
@@ -12,6 +12,7 @@ export interface IAuth {
   signInWithGoogleWithPopup(): Promise<IAuthenticationResult>;
   linkToGoogleWithPopup(): Promise<IAuthenticationResult>;
   linkToGitHubWithPopup(): Promise<IAuthenticationResult>;
+  linkToGitHub(): Promise<void>;
   // eslint-disable-next-line no-unused-vars
   subscribeAuthStatus(callback: (user: firebase.User | null) => void): void;
   getCurrentAuthenticatedUser(): firebase.User;

--- a/src/services/provider/Firebase.ts
+++ b/src/services/provider/Firebase.ts
@@ -376,7 +376,7 @@ export class FirebaseProvider implements IStorage, IAuth {
     return this.auth.currentUser!;
   }
 
-  async signOutFromGitHub(): Promise<void> {
+  async signOut(): Promise<void> {
     await this.auth.signOut();
   }
 }

--- a/src/services/provider/Firebase.ts
+++ b/src/services/provider/Firebase.ts
@@ -10,7 +10,7 @@ import {
   IResult,
   IStorage,
 } from '../storage/Storage';
-import { IAuth } from '../auth/Auth';
+import { IAuth, IAuthenticationResult } from '../auth/Auth';
 import { IFirmwareCodePlace } from '../../store/state';
 
 const config = {
@@ -360,6 +360,114 @@ export class FirebaseProvider implements IStorage, IAuth {
   signInWithGitHub(): Promise<void> {
     const provider = new firebase.auth.GithubAuthProvider();
     return this.auth.signInWithRedirect(provider);
+  }
+
+  async signInWithGitHubWithPopup(): Promise<IAuthenticationResult> {
+    try {
+      const provider = new firebase.auth.GithubAuthProvider();
+      const userCredential = await this.auth.signInWithPopup(provider);
+      if (userCredential) {
+        return {
+          success: true,
+        };
+      } else {
+        return {
+          success: false,
+          error: 'Authenticating with GitHub Account failed.',
+        };
+      }
+    } catch (err) {
+      return {
+        success: false,
+        error: err.message,
+        cause: err,
+      };
+    }
+  }
+
+  async signInWithGoogleWithPopup(): Promise<IAuthenticationResult> {
+    try {
+      const provider = new firebase.auth.GoogleAuthProvider();
+      const userCredential = await this.auth.signInWithPopup(provider);
+      if (userCredential) {
+        return {
+          success: true,
+        };
+      } else {
+        return {
+          success: false,
+          error: 'Authenticating with Google Account failed.',
+        };
+      }
+    } catch (err) {
+      return {
+        success: false,
+        error: err.message,
+        cause: err,
+      };
+    }
+  }
+
+  async linkToGoogleWithPopup(): Promise<IAuthenticationResult> {
+    const currentUser = this.auth.currentUser;
+    if (currentUser) {
+      try {
+        const provider = new firebase.auth.GoogleAuthProvider();
+        const userCredential = await currentUser.linkWithPopup(provider);
+        if (userCredential) {
+          return {
+            success: true,
+          };
+        } else {
+          return {
+            success: false,
+            error: 'Linking to Google Account failed.',
+          };
+        }
+      } catch (err) {
+        return {
+          success: false,
+          error: err.message,
+          cause: err,
+        };
+      }
+    } else {
+      return {
+        success: false,
+        error: 'Not authenticated yet.',
+      };
+    }
+  }
+
+  async linkToGitHubWithPopup(): Promise<IAuthenticationResult> {
+    const currentUser = this.auth.currentUser;
+    if (currentUser) {
+      try {
+        const provider = new firebase.auth.GithubAuthProvider();
+        const userCredential = await currentUser.linkWithPopup(provider);
+        if (userCredential) {
+          return {
+            success: true,
+          };
+        } else {
+          return {
+            success: false,
+            error: 'Linking to GitHub Account failed.',
+          };
+        }
+      } catch (err) {
+        return {
+          success: false,
+          error: err.message,
+          cause: err,
+        };
+      }
+    } else {
+      return {
+        success: false,
+        error: 'Not authenticated yet.',
+      };
+    }
   }
 
   // eslint-disable-next-line no-unused-vars

--- a/src/services/provider/Firebase.ts
+++ b/src/services/provider/Firebase.ts
@@ -362,6 +362,16 @@ export class FirebaseProvider implements IStorage, IAuth {
     return this.auth.signInWithRedirect(provider);
   }
 
+  linkToGitHub(): Promise<void> {
+    const currentUser = this.auth.currentUser;
+    if (currentUser) {
+      const provider = new firebase.auth.GithubAuthProvider();
+      return currentUser.linkWithRedirect(provider);
+    } else {
+      throw new Error('Invalid situation. Not signed in.');
+    }
+  }
+
   async signInWithGitHubWithPopup(): Promise<IAuthenticationResult> {
     try {
       const provider = new firebase.auth.GithubAuthProvider();

--- a/src/store/reducers.ts
+++ b/src/store/reducers.ts
@@ -38,6 +38,7 @@ import {
   LAYOUT_OPTIONS_INIT_SELECTED_OPTION,
   APP_UPDATE_KEYBOARD_SIZE,
   APP_UPDATE_LANG_LABEL,
+  APP_UPDATE_SIGNED_IN,
 } from '../actions/actions';
 import {
   HID_ACTIONS,
@@ -337,6 +338,10 @@ const appReducer = (action: Action, draft: WritableDraft<RootState>) => {
     }
     case APP_UPDATE_LANG_LABEL: {
       draft.app.labelLang = action.value;
+      break;
+    }
+    case APP_UPDATE_SIGNED_IN: {
+      draft.app.signedIn = action.value;
       break;
     }
   }

--- a/src/store/state.ts
+++ b/src/store/state.ts
@@ -93,6 +93,7 @@ export type RootState = {
     keyboardHeight: number;
     keyboardWidth: number;
     labelLang: KeyboardLabelLang;
+    signedIn: boolean;
   };
   configure: {
     header: {
@@ -211,6 +212,7 @@ export const INIT_STATE: RootState = {
     keyboardHeight: 0,
     keyboardWidth: 0,
     labelLang: 'en-us',
+    signedIn: false,
   },
   configure: {
     header: {


### PR DESCRIPTION
Fix #388 

右上のアイコンをクリックした後に出てくるメニューで「Login」を選択した後

<img width="1674" alt="スクリーンショット 2021-03-12 6 28 11" src="https://user-images.githubusercontent.com/261787/110857554-58e98300-82fc-11eb-986f-ea708b1ccbed.png">

１枚めのダイアログのGoogle Accountをクリックした後

<img width="1673" alt="スクリーンショット 2021-03-12 6 29 09" src="https://user-images.githubusercontent.com/261787/110857578-5d15a080-82fc-11eb-9d37-4825e951f422.png">

認証後の画面

<img width="1676" alt="スクリーンショット 2021-03-12 6 29 27" src="https://user-images.githubusercontent.com/261787/110857586-60109100-82fc-11eb-8e94-cc6f0be64b8b.png">

If a user who has already been signed in with Google account accesses to `/keyboards`, Remap asks an authentication to  link a GitHub account to the Google account.