### PR TITLE
Add ci step of caching node_modules.

### DIFF
--- a/.github/workflows/production.yaml
+++ b/.github/workflows/production.yaml
@@ -34,7 +34,7 @@ jobs:
         uses: actions/cache@v2
         with:
           path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
-          key: ${{ runnner.os }}-yarn-${{ hashFiles('**/yarn.lock.json') }}
+          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock.json') }}
           restore-keys: |
             ${{ runner.os }}-yarn-
       - name: Install dependencies

--- a/.github/workflows/production.yaml
+++ b/.github/workflows/production.yaml
@@ -30,8 +30,15 @@ jobs:
         uses: actions/setup-node@v1
         with:
           node-version: ${{ matrix.node-version }}
+      - name: Cache dependencies
+        uses: actions/cache@v2
+        with:
+          path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
+          key: ${{ runnner.os }}-yarn-${{ hashFiles('**/yarn.lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-yarn-
       - name: Install dependencies
-        run: npm install
+        run: yarn install --prefer-offline
       - name: Build and Test
         env:
           REACT_APP_FIREBASE_API_KEY: ${{ secrets.REACT_APP_FIREBASE_API_KEY }}

--- a/.github/workflows/production.yaml
+++ b/.github/workflows/production.yaml
@@ -30,8 +30,12 @@ jobs:
         uses: actions/setup-node@v1
         with:
           node-version: ${{ matrix.node-version }}
+      - name: Get yarn cache directory path
+        id: yarn-cache-dir-path
+        run: echo "::set-output name=dir::$(yarn cache dir)"
       - name: Cache dependencies
         uses: actions/cache@v2
+        id: yarn-cache
         with:
           path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
           key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock.json') }}

--- a/.github/workflows/pullrequest.yaml
+++ b/.github/workflows/pullrequest.yaml
@@ -18,8 +18,15 @@ jobs:
         uses: actions/setup-node@v1
         with:
           node-version: ${{ matrix.node-version }}
+      - name: Cache dependencies
+        uses: actions/cache@v2
+        with:
+          path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
+          key: ${{ runnner.os }}-yarn-${{ hashFiles('**/yarn.lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-yarn-
       - name: Install dependencies
-        run: npm install
+        run: yarn install --prefer-offline
       - name: Build and Test
         env:
           REACT_APP_FIREBASE_API_KEY: ${{ secrets.REACT_APP_FIREBASE_API_KEY }}

--- a/.github/workflows/pullrequest.yaml
+++ b/.github/workflows/pullrequest.yaml
@@ -18,8 +18,12 @@ jobs:
         uses: actions/setup-node@v1
         with:
           node-version: ${{ matrix.node-version }}
+      - name: Get yarn cache directory path
+        id: yarn-cache-dir-path
+        run: echo "::set-output name=dir::$(yarn cache dir)"
       - name: Cache dependencies
         uses: actions/cache@v2
+        id: yarn-cache
         with:
           path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
           key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock.json') }}

--- a/.github/workflows/pullrequest.yaml
+++ b/.github/workflows/pullrequest.yaml
@@ -22,7 +22,7 @@ jobs:
         uses: actions/cache@v2
         with:
           path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
-          key: ${{ runnner.os }}-yarn-${{ hashFiles('**/yarn.lock.json') }}
+          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock.json') }}
           restore-keys: |
             ${{ runner.os }}-yarn-
       - name: Install dependencies


### PR DESCRIPTION
I found ci took a lot of time because node_module does not cached.
I add caching step and change yarn install command.
I refered to https://github.com/actions/cache/blob/main/examples.md#node---yarn

日本語で失礼します。始めてprを出します。誤りや変なところがあったらすいません。
ciの過程でnode_moduleをキャッシュしておらず、2分程度かかっているのを発見したため、より時短できるように設定しました。npmのnuxt projectの場合で恐縮ですが、だいたい10前後で完了するため、より便利になるかなと思います。
ご確認よろしくお願いします。