### PR TITLE
overflow scroll if the keyboard is too large

### DIFF
--- a/src/components/configure/Configure.scss
+++ b/src/components/configure/Configure.scss
@@ -1,43 +1,7 @@
 @import '../../_variables.scss';
 
-.header {
-  display: flex;
-  flex-direction: row;
-  margin: 0 $space-m;
-  background: white;
-  height: 42px;
-  align-items: center;
-  .logo {
-    height: 28px;
-  }
-  .kbd-name {
-    display: flex;
-    flex-direction: column;
-    margin-left: $space-m;
-    h2 {
-      margin: 0;
-    }
-    .ids {
-      font-size: $font-xs;
-      color: $color-gray;
-      margin-top: -4px;
-    }
-  }
-  .status {
-    display: flex;
-    .connection {
-      margin-left: $space-m;
-    }
-    .message {
-      font-size: $font-s;
-      color: $warning;
-      margin-left: $space-m;
-    }
-  }
-  .buttons {
-    display: flex;
-    margin-left: auto;
-  }
+.configure-main {
+  overflow-y: hidden;
 }
 
 .message-box-wrapper {

--- a/src/components/configure/Configure.tsx
+++ b/src/components/configure/Configure.tsx
@@ -139,7 +139,7 @@ class Configure extends React.Component<ConfigureProps, OwnState> {
       <React.Fragment>
         <CssBaseline />
         <Header />
-        <main>
+        <main className="configure-main">
           <Content />
         </main>
         <Footer />

--- a/src/components/configure/content/Content.scss
+++ b/src/components/configure/content/Content.scss
@@ -3,8 +3,10 @@
   display: flex;
   position: relative;
   flex-direction: column;
-  min-width: 780px;
-  height: 100vh;
+
+  &.fit-display-height {
+    height: 100vh;
+  }
 
   .phase-processing-wrapper {
     position: relative;

--- a/src/components/configure/content/Content.tsx
+++ b/src/components/configure/content/Content.tsx
@@ -25,7 +25,12 @@ export default class Content extends React.Component<
 
   render() {
     return (
-      <div className="content">
+      <div
+        className={`content ${
+          this.props.setupPhase! != SetupPhase.openedKeyboard &&
+          'fit-display-height'
+        }`}
+      >
         <Contents setupPhase={this.props.setupPhase!} />
       </div>
     );

--- a/src/components/configure/keydiff/Keydiff.tsx
+++ b/src/components/configure/keydiff/Keydiff.tsx
@@ -6,7 +6,6 @@ import { KeydiffActionsType, KeydiffStateType } from './Keydiff.container';
 import { IKeymap } from '../../../services/hid/Hid';
 import KeycodeKey from '../keycodekey/KeycodeKey.container';
 import { genKey, Key } from '../keycodekey/KeyGen';
-import { KEYBOARD_LAYOUT_PADDING } from '../keymap/Keymap';
 
 type KeydiffOwnProps = {};
 
@@ -19,7 +18,7 @@ export default class Keydiff extends React.Component<KeydiffProps, {}> {
     super(props);
   }
   render() {
-    const width = this.props.keyboardWidth! + KEYBOARD_LAYOUT_PADDING * 4;
+    const width = this.props.keyboardWidth!;
     const origin: IKeymap | null = this.props.keydiff!.origin;
     const destination: IKeymap | null = this.props.keydiff!.destination;
     if (!origin || !destination) {

--- a/src/components/configure/keymap/Keymap.scss
+++ b/src/components/configure/keymap/Keymap.scss
@@ -9,11 +9,12 @@
     display: flex;
     justify-content: flex-start;
     align-items: center;
+    padding: $space-l;
   }
 
   .label-lang,
   .balancer {
-    width: 140px;
+    min-width: 80px;
   }
 }
 
@@ -25,8 +26,9 @@
     display: flex;
     flex-direction: column;
     justify-content: center;
-    align-items: center;
-    width: 140px;
+    align-items: flex-start;
+    min-width: 80px;
+    padding-left: $space-l;
     .layers {
       display: flex;
       flex-direction: column;

--- a/src/components/configure/keymap/Keymap.tsx
+++ b/src/components/configure/keymap/Keymap.tsx
@@ -221,7 +221,9 @@ export default class Keymap extends React.Component<
             keymaps={this.props.keymaps!}
             selectedLayer={this.props.selectedLayer!}
             remaps={this.props.remaps!}
-            setKeyboardSize={this.props.setKeyboardSize!}
+            setKeyboardSize={(width, height) => {
+              this.props.setKeyboardSize!(width, height);
+            }}
             onClickKeycap={(pos, key, ref) => {
               this.onClickKeycap(pos, key, ref);
             }}
@@ -360,7 +362,9 @@ export function KeyboardView(props: KeyboardType) {
   );
   const moveLeft = left != 0 ? -left : 0;
 
-  props.setKeyboardSize(width, height);
+  const keyboardWidth = width + (BORDER_WIDTH + KEYBOARD_LAYOUT_PADDING) * 2;
+  const keyboardHeight = height + (BORDER_WIDTH + KEYBOARD_LAYOUT_PADDING) * 2;
+  props.setKeyboardSize(keyboardWidth, keyboardHeight);
 
   // TODO: performance tuning
   const deviceKeymaps = props.keymaps![props.selectedLayer!];
@@ -381,8 +385,8 @@ export function KeyboardView(props: KeyboardType) {
       <div
         className="keyboard-root"
         style={{
-          width: width + (BORDER_WIDTH + KEYBOARD_LAYOUT_PADDING) * 2,
-          height: height + (BORDER_WIDTH + KEYBOARD_LAYOUT_PADDING) * 2,
+          width: keyboardWidth,
+          height: keyboardHeight,
           padding: KEYBOARD_LAYOUT_PADDING,
         }}
       >

--- a/src/components/configure/keymapToolbar/KeymapToolbar.scss
+++ b/src/components/configure/keymapToolbar/KeymapToolbar.scss
@@ -2,7 +2,7 @@
 
 .keymap-menu {
   display: flex;
-  width: 140px;
+  width: 80px;
   flex-direction: column;
   justify-content: center;
   align-items: flex-start;

--- a/src/components/configure/remap/Remap.container.ts
+++ b/src/components/configure/remap/Remap.container.ts
@@ -5,7 +5,6 @@ import { RootState } from '../../../store/state';
 const mapStateToProps = (state: RootState) => {
   return {
     hoverKey: state.configure.keycodeKey.hoverKey,
-    keyboardHeight: state.app.keyboardHeight, // DO NOT REMOVE!! This component should be updated when the keyboardHeight is set
     keyboardWidth: state.app.keyboardWidth, // DO NOT REMOVE!! This component should be updated when the keyboardWidth is set
   };
 };

--- a/src/components/configure/remap/Remap.container.ts
+++ b/src/components/configure/remap/Remap.container.ts
@@ -6,6 +6,7 @@ const mapStateToProps = (state: RootState) => {
   return {
     hoverKey: state.configure.keycodeKey.hoverKey,
     keyboardHeight: state.app.keyboardHeight, // DO NOT REMOVE!! This component should be updated when the keyboardHeight is set
+    keyboardWidth: state.app.keyboardWidth, // DO NOT REMOVE!! This component should be updated when the keyboardWidth is set
   };
 };
 export type RemapStateType = ReturnType<typeof mapStateToProps>;

--- a/src/components/configure/remap/Remap.scss
+++ b/src/components/configure/remap/Remap.scss
@@ -1,7 +1,7 @@
 @import '../../../variables';
 
 .keyboard-wrapper {
-  position: fixed;
+  position: relative;
   width: 100%;
   margin-top: calc(var(--key-height));
   z-index: 1;
@@ -29,7 +29,6 @@
   padding: $space-m $space-m $space-xl $space-m;
   background-color: #f3f3f3;
   flex: 1;
-  overflow-y: scroll;
 
   .disable {
     position: absolute;

--- a/src/components/configure/remap/Remap.tsx
+++ b/src/components/configure/remap/Remap.tsx
@@ -14,7 +14,6 @@ type RemapPropType = OwnProp &
   Partial<RemapActionsType>;
 
 type OwnState = {
-  keycodeY: number;
   minWidth: number;
 };
 
@@ -24,7 +23,6 @@ export default class Remap extends React.Component<RemapPropType, OwnState> {
   constructor(props: RemapPropType | Readonly<RemapPropType>) {
     super(props);
     this.state = {
-      keycodeY: 0,
       minWidth: 0,
     };
   }

--- a/src/components/configure/remap/Remap.tsx
+++ b/src/components/configure/remap/Remap.tsx
@@ -15,38 +15,40 @@ type RemapPropType = OwnProp &
 
 type OwnState = {
   keycodeY: number;
+  minWidth: number;
 };
 
+const MIN_SIDE_MENU_WIDTH = 80;
+
 export default class Remap extends React.Component<RemapPropType, OwnState> {
-  private keyboardWrapperRef: React.RefObject<HTMLDivElement>;
   constructor(props: RemapPropType | Readonly<RemapPropType>) {
     super(props);
     this.state = {
       keycodeY: 0,
+      minWidth: 0,
     };
-    this.keyboardWrapperRef = React.createRef<HTMLDivElement>();
   }
 
-  componentDidMount() {
-    if (!this.keyboardWrapperRef.current) return;
-
-    const headerHeight = 56;
-    const rect = this.keyboardWrapperRef.current.getBoundingClientRect();
-    const keycodeY = headerHeight + rect.height;
-    if (this.state.keycodeY != keycodeY) {
-      this.setState({ keycodeY });
+  componentDidUpdate(prevProps: RemapPropType) {
+    if (this.props.keyboardWidth != prevProps.keyboardWidth) {
+      this.setState({
+        minWidth: this.props.keyboardWidth! + MIN_SIDE_MENU_WIDTH * 2,
+      });
     }
   }
 
   render() {
     return (
       <React.Fragment>
-        <div className="keyboard-wrapper" ref={this.keyboardWrapperRef}>
+        <div
+          className="keyboard-wrapper"
+          style={{ minWidth: this.state.minWidth }}
+        >
           <div className="keymap">
             <Keymap />
           </div>
         </div>
-        <div className="keycode" style={{ marginTop: this.state.keycodeY }}>
+        <div className="keycode" style={{ minWidth: this.state.minWidth }}>
           <Keycodes />
         </div>
         <Desc value={this.props.hoverKey} />


### PR DESCRIPTION
The body content will be scrollable. I removed the fixed layout position in the content.

<img width="1141" alt="スクリーンショット 2021-03-16 10 24 44" src="https://user-images.githubusercontent.com/316463/111242693-0503d480-8643-11eb-94bb-f058d38c906b.png">
<img width="1146" alt="スクリーンショット 2021-03-16 10 24 56" src="https://user-images.githubusercontent.com/316463/111242700-06cd9800-8643-11eb-8e3e-a68032b96cba.png">
