### PR TITLE
Feat 218 save and restore keymap

### DIFF
--- a/src/actions/actions.ts
+++ b/src/actions/actions.ts
@@ -177,6 +177,7 @@ export const APP_ACTIONS = '@App';
 export const APP_UPDATE_SETUP_PHASE = `${APP_ACTIONS}/UpdateSetupPhase`;
 export const APP_REMAPS_INIT = `${APP_ACTIONS}/RemapsInit`;
 export const APP_REMAPS_SET_KEY = `${APP_ACTIONS}/RemapsSetKey`;
+export const APP_REMAPS_SET_KEYS = `${APP_ACTIONS}/RemapsSetKeys`;
 export const APP_REMAPS_REMOVE_KEY = `${APP_ACTIONS}/RemapsRemoveKey`;
 export const APP_REMAPS_CLEAR = `${APP_ACTIONS}/Clear`;
 export const APP_PACKAGE_INIT = `${APP_ACTIONS}/PackageInit`;
@@ -207,6 +208,12 @@ export const AppActions = {
         pos: pos,
         keymap,
       },
+    };
+  },
+  remapsSetKeys: (keymaps: { [pos: string]: IKeymap }[]) => {
+    return {
+      type: APP_REMAPS_SET_KEYS,
+      value: keymaps,
     };
   },
   remapsRemoveKey: (layer: number, pos: string) => {

--- a/src/actions/actions.ts
+++ b/src/actions/actions.ts
@@ -5,6 +5,7 @@ import { IKeymap } from '../services/hid/Hid';
 import { KeyboardLabelLang } from '../services/labellang/KeyLabelLangs';
 import { ISetupPhase, RootState } from '../store/state';
 import { ThunkAction, ThunkDispatch } from 'redux-thunk';
+import { LayoutOption } from '../components/configure/keymap/Keymap';
 
 export const KEYMAP_ACTIONS = '@Keymap';
 export const KEYMAP_CLEAR_SELECTED_POS = `${KEYMAP_ACTIONS}/ClearSelectedLayer`;
@@ -333,20 +334,30 @@ export const AppActionsThunk = {
 export const LAYOUT_OPTIONS_ACTIONS = '@LayoutOptions';
 export const LAYOUT_OPTIONS_INIT_SELECTED_OPTION = `${LAYOUT_OPTIONS_ACTIONS}/InitSelectedOption`;
 export const LAYOUT_OPTIONS_UPDATE_SELECTED_OPTION = `${LAYOUT_OPTIONS_ACTIONS}/UpdateSelectedOption`;
+export const LAYOUT_OPTIONS_RESTORE_SELECTED_OPTIONS = `${LAYOUT_OPTIONS_ACTIONS}/RestoreSelectedOptions`;
 export const LayoutOptionsActions = {
-  updateSelectedOption: (optionIndex: number, option: string | null) => {
+  restoreLayoutOptions: (layoutOptions: LayoutOption[]) => {
+    return {
+      type: LAYOUT_OPTIONS_RESTORE_SELECTED_OPTIONS,
+      value: layoutOptions,
+    };
+  },
+  updateSelectedOption: (option: number, optionChoice: number) => {
     return {
       type: LAYOUT_OPTIONS_UPDATE_SELECTED_OPTION,
       value: {
-        optionIndex,
         option,
+        optionChoice,
       },
     };
   },
+
   initSelectedOptions: (options: (string | string[])[]) => {
-    const list: (null | string)[] = options.map((item) => {
-      return typeof item == 'string' ? null : item[1]; // the default value should be off or 1st value
-    });
+    const list: LayoutOption[] = [];
+    for (let i = 0; i < options.length; i++) {
+      list.push({ option: i, optionChoice: 0 });
+    }
+
     return {
       type: LAYOUT_OPTIONS_INIT_SELECTED_OPTION,
       value: list,

--- a/src/actions/hid.action.ts
+++ b/src/actions/hid.action.ts
@@ -278,6 +278,9 @@ export const hidActionsThunk = {
       dispatch(KeycodeKeyActions.clear());
       dispatch(KeymapActions.clearSelectedPos());
       dispatch(StorageActions.updateKeyboardDefinition(null));
+      dispatch(StorageActions.clearKeyboardDefinitionDocument());
+      dispatch(StorageActions.updateSavedRegisteredKeymapList([]));
+      dispatch(StorageActions.updateSavedUnregisteredKeymapDataList([]));
       dispatch(HidActions.updateKeyboard(null));
     }
   },
@@ -355,6 +358,7 @@ const initOpenedKeyboard = async (
     columnCount,
     labelLang
   );
+
   dispatch(HidActions.updateKeymaps(keymaps));
   dispatch(AppActions.remapsInit(layerCount));
   dispatch(KeymapActions.updateSelectedLayer(0)); // initial selected layer

--- a/src/actions/hid.action.ts
+++ b/src/actions/hid.action.ts
@@ -279,8 +279,7 @@ export const hidActionsThunk = {
       dispatch(KeymapActions.clearSelectedPos());
       dispatch(StorageActions.updateKeyboardDefinition(null));
       dispatch(StorageActions.clearKeyboardDefinitionDocument());
-      dispatch(StorageActions.updateSavedRegisteredKeymapList([]));
-      dispatch(StorageActions.updateSavedUnregisteredKeymapDataList([]));
+      dispatch(StorageActions.updateSavedKeymaps([]));
       dispatch(HidActions.updateKeyboard(null));
     }
   },

--- a/src/actions/storage.action.ts
+++ b/src/actions/storage.action.ts
@@ -546,7 +546,10 @@ export const storageActionsThunk = {
     if (resultList.success) {
       dispatch(StorageActions.updateSavedKeymaps(resultList.savedKeymaps));
     } else {
-      console.log(resultList.cause);
+      console.error(resultList.cause!);
+      dispatch(
+        NotificationActions.addError(resultList.error!, resultList.cause)
+      );
     }
   },
 
@@ -560,7 +563,13 @@ export const storageActionsThunk = {
 
     const result = await storage.instance!.createSavedKeymap(keymapData);
     if (!result.success) {
-      dispatch(NotificationActions.addWarn("Couldn't save the keymap."));
+      console.error(result.cause!);
+      dispatch(
+        NotificationActions.addError(
+          `Couldn't save the keymap: ${result.error!}`,
+          result.cause
+        )
+      );
       return;
     }
     const info: IDeviceInformation = {
@@ -580,7 +589,13 @@ export const storageActionsThunk = {
     const { storage } = getState();
     const result = await storage.instance!.updateSavedKeymap(keymapData);
     if (!result.success) {
-      dispatch(NotificationActions.addWarn("Couldn't update the keymap."));
+      console.error(result.cause!);
+      dispatch(
+        NotificationActions.addError(
+          `Couldn't update the keymap: ${result.error!}`,
+          result.cause
+        )
+      );
       return;
     }
 
@@ -601,7 +616,13 @@ export const storageActionsThunk = {
     const { storage } = getState();
     const result = await storage.instance!.deleteSavedKeymap(keymapData.id!);
     if (!result.success) {
-      dispatch(NotificationActions.addWarn("Couldn't delete the keymap."));
+      console.error(result.cause!);
+      dispatch(
+        NotificationActions.addError(
+          `Couldn't delete the keymap: ${result.error!}`,
+          result.cause
+        )
+      );
       return;
     }
 

--- a/src/actions/storage.action.ts
+++ b/src/actions/storage.action.ts
@@ -27,8 +27,7 @@ export const STORAGE_ACTIONS = '@Storage';
 export const STORAGE_UPDATE_KEYBOARD_DEFINITION = `${STORAGE_ACTIONS}/UpdateKeyboardDefinition`;
 export const STORAGE_UPDATE_KEYBOARD_DEFINITION_DOCUMENTS = `${STORAGE_ACTIONS}/UpdateKeyboardDefinitionDocuments`;
 export const STORAGE_UPDATE_KEYBOARD_DEFINITION_DOCUMENT = `${STORAGE_ACTIONS}/UpdateKeyboardDefinitionDocument`;
-export const STORAGE_UPDATE_SAVED_REGISTERED_KEYMAPS = `${STORAGE_ACTIONS}/UpdateSavedRegisteredKeymaps`;
-export const STORAGE_UPDATE_SAVED_UNREGISTERED_KEYMAPS = `${STORAGE_ACTIONS}/UpdateSavedUnregisteredKeymaps`;
+export const STORAGE_UPDATE_SAVED_KEYMAPS = `${STORAGE_ACTIONS}/UpdateSavedKeymaps`;
 export const StorageActions = {
   updateKeyboardDefinition: (keyboardDefinition: any) => {
     return {
@@ -58,15 +57,9 @@ export const StorageActions = {
       value: null,
     };
   },
-  updateSavedRegisteredKeymapList: (keymaps: SavedKeymapData[]) => {
+  updateSavedKeymaps: (keymaps: SavedKeymapData[]) => {
     return {
-      type: STORAGE_UPDATE_SAVED_REGISTERED_KEYMAPS,
-      value: keymaps,
-    };
-  },
-  updateSavedUnregisteredKeymapDataList: (keymaps: SavedKeymapData[]) => {
-    return {
-      type: STORAGE_UPDATE_SAVED_UNREGISTERED_KEYMAPS,
+      type: STORAGE_UPDATE_SAVED_KEYMAPS,
       value: keymaps,
     };
   },
@@ -513,7 +506,7 @@ export const storageActionsThunk = {
     }
   },
 
-  fetchSavedRegisteredKeymaps: (
+  fetchMySavedKeymaps: (
     info: IDeviceInformation
   ): ThunkPromiseAction<void> => async (
     // eslint-disable-next-line no-unused-vars
@@ -522,21 +515,16 @@ export const storageActionsThunk = {
     getState: () => RootState
   ) => {
     const { storage } = getState();
-    const resultList = await storage.instance!.fetchSavedKeymaps(
-      info,
-      'registereds'
-    );
+    const resultList = await storage.instance!.fetchMySavedKeymaps(info);
 
     if (resultList.success) {
-      dispatch(
-        StorageActions.updateSavedRegisteredKeymapList(resultList.savedKeymaps)
-      );
+      dispatch(StorageActions.updateSavedKeymaps(resultList.savedKeymaps));
     } else {
       console.log(resultList.cause);
     }
   },
 
-  createRegisteredKeymapData: (
+  createSavedKeymap: (
     keymapData: SavedKeymapData
   ): ThunkPromiseAction<void> => async (
     dispatch: ThunkDispatch<RootState, undefined, ActionTypes>,
@@ -544,10 +532,7 @@ export const storageActionsThunk = {
   ) => {
     const { storage } = getState();
 
-    const result = await storage.instance!.createSavedKeymap(
-      keymapData,
-      'registereds'
-    );
+    const result = await storage.instance!.createSavedKeymap(keymapData);
     if (!result.success) {
       dispatch(NotificationActions.addWarn("Couldn't save the keymap."));
       return;
@@ -557,20 +542,17 @@ export const storageActionsThunk = {
       productId: keymapData.product_id,
       productName: keymapData.product_name,
     };
-    dispatch(storageActionsThunk.fetchSavedRegisteredKeymaps(info));
+    dispatch(storageActionsThunk.fetchMySavedKeymaps(info));
   },
 
-  updateRegisteredKeymapData: (
+  updateSavedKeymap: (
     keymapData: SavedKeymapData
   ): ThunkPromiseAction<void> => async (
     dispatch: ThunkDispatch<RootState, undefined, ActionTypes>,
     getState: () => RootState
   ) => {
     const { storage } = getState();
-    const result = await storage.instance!.updateSavedKeymap(
-      keymapData,
-      'registereds'
-    );
+    const result = await storage.instance!.updateSavedKeymap(keymapData);
     if (!result.success) {
       dispatch(NotificationActions.addWarn("Couldn't update the keymap."));
       return;
@@ -581,20 +563,17 @@ export const storageActionsThunk = {
       productId: keymapData.product_id,
       productName: keymapData.product_name,
     };
-    dispatch(storageActionsThunk.fetchSavedRegisteredKeymaps(info));
+    dispatch(storageActionsThunk.fetchMySavedKeymaps(info));
   },
 
-  deleteRegisteredKeymapData: (
+  deleteSavedKeymap: (
     keymapData: SavedKeymapData
   ): ThunkPromiseAction<void> => async (
     dispatch: ThunkDispatch<RootState, undefined, ActionTypes>,
     getState: () => RootState
   ) => {
     const { storage } = getState();
-    const result = await storage.instance!.deleteSavedKeymap(
-      keymapData.id!,
-      'registereds'
-    );
+    const result = await storage.instance!.deleteSavedKeymap(keymapData.id!);
     if (!result.success) {
       dispatch(NotificationActions.addWarn("Couldn't delete the keymap."));
       return;
@@ -605,102 +584,6 @@ export const storageActionsThunk = {
       productId: keymapData.product_id,
       productName: keymapData.product_name,
     };
-    dispatch(storageActionsThunk.fetchSavedRegisteredKeymaps(info));
-  },
-
-  fetchSavedUnregisteredKeymaps: (
-    info: IDeviceInformation
-  ): ThunkPromiseAction<void> => async (
-    // eslint-disable-next-line no-unused-vars
-    dispatch: ThunkDispatch<RootState, undefined, ActionTypes>,
-    // eslint-disable-next-line no-unused-vars
-    getState: () => RootState
-  ) => {
-    const { storage } = getState();
-    const resultList = await storage.instance!.fetchSavedKeymaps(
-      info,
-      'unregistereds'
-    );
-
-    if (resultList.success) {
-      dispatch(
-        StorageActions.updateSavedUnregisteredKeymapDataList(
-          resultList.savedKeymaps
-        )
-      );
-    } else {
-      console.log(resultList.cause);
-    }
-  },
-
-  createUnregisteredKeymapData: (
-    keymapData: SavedKeymapData
-  ): ThunkPromiseAction<void> => async (
-    dispatch: ThunkDispatch<RootState, undefined, ActionTypes>,
-    getState: () => RootState
-  ) => {
-    const { storage } = getState();
-
-    const result = await storage.instance!.createSavedKeymap(
-      keymapData,
-      'unregistereds'
-    );
-    if (!result.success) {
-      dispatch(NotificationActions.addWarn("Couldn't save the keymap."));
-      return;
-    }
-    const info: IDeviceInformation = {
-      vendorId: keymapData.vendor_id,
-      productId: keymapData.product_id,
-      productName: keymapData.product_name,
-    };
-    dispatch(storageActionsThunk.fetchSavedUnregisteredKeymaps(info));
-  },
-
-  updateUnregisteredKeymapData: (
-    keymapData: SavedKeymapData
-  ): ThunkPromiseAction<void> => async (
-    dispatch: ThunkDispatch<RootState, undefined, ActionTypes>,
-    getState: () => RootState
-  ) => {
-    const { storage } = getState();
-    const result = await storage.instance!.updateSavedKeymap(
-      keymapData,
-      'unregistereds'
-    );
-    if (!result.success) {
-      dispatch(NotificationActions.addWarn("Couldn't update the keymap."));
-      return;
-    }
-
-    const info: IDeviceInformation = {
-      vendorId: keymapData.vendor_id,
-      productId: keymapData.product_id,
-      productName: keymapData.product_name,
-    };
-    dispatch(storageActionsThunk.fetchSavedUnregisteredKeymaps(info));
-  },
-
-  deleteUnregisteredKeymapData: (
-    keymapData: SavedKeymapData
-  ): ThunkPromiseAction<void> => async (
-    dispatch: ThunkDispatch<RootState, undefined, ActionTypes>,
-    getState: () => RootState
-  ) => {
-    const { storage } = getState();
-    const result = await storage.instance!.deleteSavedKeymap(
-      keymapData.id!,
-      'unregistereds'
-    );
-    if (!result.success) {
-      dispatch(NotificationActions.addWarn("Couldn't delete the keymap."));
-      return;
-    }
-    const info: IDeviceInformation = {
-      vendorId: keymapData.vendor_id,
-      productId: keymapData.product_id,
-      productName: keymapData.product_name,
-    };
-    dispatch(storageActionsThunk.fetchSavedUnregisteredKeymaps(info));
+    dispatch(storageActionsThunk.fetchMySavedKeymaps(info));
   },
 };

--- a/src/actions/storage.action.ts
+++ b/src/actions/storage.action.ts
@@ -573,9 +573,9 @@ export const storageActionsThunk = {
       return;
     }
     const info: IDeviceInformation = {
-      vendorId: keymapData.vendorId,
-      productId: keymapData.productId,
-      productName: keymapData.productName,
+      vendorId: keymapData.vendor_id,
+      productId: keymapData.product_id,
+      productName: keymapData.product_name,
     };
     dispatch(storageActionsThunk.fetchMySavedKeymaps(info));
   },
@@ -600,9 +600,9 @@ export const storageActionsThunk = {
     }
 
     const info: IDeviceInformation = {
-      vendorId: keymapData.vendorId,
-      productId: keymapData.productId,
-      productName: keymapData.productName,
+      vendorId: keymapData.vendor_id,
+      productId: keymapData.product_id,
+      productName: keymapData.product_name,
     };
     dispatch(storageActionsThunk.fetchMySavedKeymaps(info));
   },
@@ -627,9 +627,9 @@ export const storageActionsThunk = {
     }
 
     const info: IDeviceInformation = {
-      vendorId: keymapData.vendorId,
-      productId: keymapData.productId,
-      productName: keymapData.productName,
+      vendorId: keymapData.vendor_id,
+      productId: keymapData.product_id,
+      productName: keymapData.product_name,
     };
     dispatch(storageActionsThunk.fetchMySavedKeymaps(info));
   },

--- a/src/actions/storage.action.ts
+++ b/src/actions/storage.action.ts
@@ -13,9 +13,8 @@ import { validateKeyboardDefinitionSchema } from '../services/storage/Validator'
 import { KeyboardDefinitionSchema } from '../gen/types/KeyboardDefinition';
 import {
   IKeyboardDefinitionDocument,
-  SavedRegisteredKeymapData,
-  SavedUnregisteredKeymapData,
   KeyboardDefinitionStatus,
+  SavedKeymapData,
 } from '../services/storage/Storage';
 import {
   KeyboardsAppActions,
@@ -59,15 +58,13 @@ export const StorageActions = {
       value: null,
     };
   },
-  updateSavedRegisteredKeymapList: (keymaps: SavedRegisteredKeymapData[]) => {
+  updateSavedRegisteredKeymapList: (keymaps: SavedKeymapData[]) => {
     return {
       type: STORAGE_UPDATE_SAVED_REGISTERED_KEYMAPS,
       value: keymaps,
     };
   },
-  updateSavedUnregisteredKeymapDataList: (
-    keymaps: SavedUnregisteredKeymapData[]
-  ) => {
+  updateSavedUnregisteredKeymapDataList: (keymaps: SavedKeymapData[]) => {
     return {
       type: STORAGE_UPDATE_SAVED_UNREGISTERED_KEYMAPS,
       value: keymaps,
@@ -517,7 +514,7 @@ export const storageActionsThunk = {
   },
 
   fetchSavedRegisteredKeymaps: (
-    definitionId: string
+    info: IDeviceInformation
   ): ThunkPromiseAction<void> => async (
     // eslint-disable-next-line no-unused-vars
     dispatch: ThunkDispatch<RootState, undefined, ActionTypes>,
@@ -525,23 +522,22 @@ export const storageActionsThunk = {
     getState: () => RootState
   ) => {
     const { storage } = getState();
-    const resultList = await storage.instance!.fetchSavedRegisteredKeymaps(
-      definitionId
+    const resultList = await storage.instance!.fetchSavedKeymaps(
+      info,
+      'registereds'
     );
 
     if (resultList.success) {
       dispatch(
-        StorageActions.updateSavedRegisteredKeymapList(
-          resultList.savedKeymaps as SavedRegisteredKeymapData[]
-        )
+        StorageActions.updateSavedRegisteredKeymapList(resultList.savedKeymaps)
       );
     } else {
-      console.error(resultList.cause);
+      console.log(resultList.cause);
     }
   },
 
   createRegisteredKeymapData: (
-    keymapData: SavedRegisteredKeymapData
+    keymapData: SavedKeymapData
   ): ThunkPromiseAction<void> => async (
     dispatch: ThunkDispatch<RootState, undefined, ActionTypes>,
     getState: () => RootState
@@ -556,13 +552,16 @@ export const storageActionsThunk = {
       dispatch(NotificationActions.addWarn("Couldn't save the keymap."));
       return;
     }
-    dispatch(
-      storageActionsThunk.fetchSavedRegisteredKeymaps(keymapData.definition_id!)
-    );
+    const info: IDeviceInformation = {
+      vendorId: keymapData.vendor_id,
+      productId: keymapData.product_id,
+      productName: keymapData.product_name,
+    };
+    dispatch(storageActionsThunk.fetchSavedRegisteredKeymaps(info));
   },
 
   updateRegisteredKeymapData: (
-    keymapData: SavedRegisteredKeymapData
+    keymapData: SavedKeymapData
   ): ThunkPromiseAction<void> => async (
     dispatch: ThunkDispatch<RootState, undefined, ActionTypes>,
     getState: () => RootState
@@ -577,13 +576,16 @@ export const storageActionsThunk = {
       return;
     }
 
-    dispatch(
-      storageActionsThunk.fetchSavedRegisteredKeymaps(keymapData.definition_id!)
-    );
+    const info: IDeviceInformation = {
+      vendorId: keymapData.vendor_id,
+      productId: keymapData.product_id,
+      productName: keymapData.product_name,
+    };
+    dispatch(storageActionsThunk.fetchSavedRegisteredKeymaps(info));
   },
 
   deleteRegisteredKeymapData: (
-    keymapData: SavedRegisteredKeymapData
+    keymapData: SavedKeymapData
   ): ThunkPromiseAction<void> => async (
     dispatch: ThunkDispatch<RootState, undefined, ActionTypes>,
     getState: () => RootState
@@ -597,9 +599,13 @@ export const storageActionsThunk = {
       dispatch(NotificationActions.addWarn("Couldn't delete the keymap."));
       return;
     }
-    dispatch(
-      storageActionsThunk.fetchSavedRegisteredKeymaps(keymapData.definition_id!)
-    );
+
+    const info: IDeviceInformation = {
+      vendorId: keymapData.vendor_id,
+      productId: keymapData.product_id,
+      productName: keymapData.product_name,
+    };
+    dispatch(storageActionsThunk.fetchSavedRegisteredKeymaps(info));
   },
 
   fetchSavedUnregisteredKeymaps: (
@@ -611,21 +617,24 @@ export const storageActionsThunk = {
     getState: () => RootState
   ) => {
     const { storage } = getState();
-    const resultList = await storage.instance!.fetchUnregisteredKeymaps(info);
+    const resultList = await storage.instance!.fetchSavedKeymaps(
+      info,
+      'unregistereds'
+    );
 
     if (resultList.success) {
       dispatch(
         StorageActions.updateSavedUnregisteredKeymapDataList(
-          resultList.savedKeymaps as SavedUnregisteredKeymapData[]
+          resultList.savedKeymaps
         )
       );
     } else {
-      console.error(resultList.cause);
+      console.log(resultList.cause);
     }
   },
 
   createUnregisteredKeymapData: (
-    keymapData: SavedUnregisteredKeymapData
+    keymapData: SavedKeymapData
   ): ThunkPromiseAction<void> => async (
     dispatch: ThunkDispatch<RootState, undefined, ActionTypes>,
     getState: () => RootState
@@ -649,7 +658,7 @@ export const storageActionsThunk = {
   },
 
   updateUnregisteredKeymapData: (
-    keymapData: SavedUnregisteredKeymapData
+    keymapData: SavedKeymapData
   ): ThunkPromiseAction<void> => async (
     dispatch: ThunkDispatch<RootState, undefined, ActionTypes>,
     getState: () => RootState
@@ -673,7 +682,7 @@ export const storageActionsThunk = {
   },
 
   deleteUnregisteredKeymapData: (
-    keymapData: SavedUnregisteredKeymapData
+    keymapData: SavedKeymapData
   ): ThunkPromiseAction<void> => async (
     dispatch: ThunkDispatch<RootState, undefined, ActionTypes>,
     getState: () => RootState

--- a/src/actions/storage.action.ts
+++ b/src/actions/storage.action.ts
@@ -13,6 +13,7 @@ import { validateKeyboardDefinitionSchema } from '../services/storage/Validator'
 import { KeyboardDefinitionSchema } from '../gen/types/KeyboardDefinition';
 import {
   IKeyboardDefinitionDocument,
+  ISavedKeymapData,
   KeyboardDefinitionStatus,
 } from '../services/storage/Storage';
 import {
@@ -25,6 +26,7 @@ export const STORAGE_ACTIONS = '@Storage';
 export const STORAGE_UPDATE_KEYBOARD_DEFINITION = `${STORAGE_ACTIONS}/UpdateKeyboardDefinition`;
 export const STORAGE_UPDATE_KEYBOARD_DEFINITION_DOCUMENTS = `${STORAGE_ACTIONS}/UpdateKeyboardDefinitionDocuments`;
 export const STORAGE_UPDATE_KEYBOARD_DEFINITION_DOCUMENT = `${STORAGE_ACTIONS}/UpdateKeyboardDefinitionDocument`;
+export const STORAGE_UPDATE_MY_SAVED_KEYMAPDATA_LIST = `${STORAGE_ACTIONS}/UpdateMySavedKeymapDataList`;
 export const StorageActions = {
   updateKeyboardDefinition: (keyboardDefinition: any) => {
     return {
@@ -46,6 +48,12 @@ export const StorageActions = {
     return {
       type: STORAGE_UPDATE_KEYBOARD_DEFINITION_DOCUMENT,
       value: keyboardDefinitionDocument,
+    };
+  },
+  updateMySavedKeymapDataList: (keymaps: ISavedKeymapData[]) => {
+    return {
+      type: STORAGE_UPDATE_MY_SAVED_KEYMAPDATA_LIST,
+      value: keymaps,
     };
   },
 };
@@ -489,5 +497,55 @@ export const storageActionsThunk = {
       console.error(result.cause!);
       dispatch(NotificationActions.addError(result.error!, result.cause));
     }
+  },
+
+  fetchMySavedKeymapDataList: (): ThunkPromiseAction<void> => async (
+    // eslint-disable-next-line no-unused-vars
+    dispatch: ThunkDispatch<RootState, undefined, ActionTypes>,
+    // eslint-disable-next-line no-unused-vars
+    getState: () => RootState
+  ) => {
+    // TODO
+  },
+
+  createMySavedKeymapData: (
+    keymapData: ISavedKeymapData
+  ): ThunkPromiseAction<void> => async (
+    dispatch: ThunkDispatch<RootState, undefined, ActionTypes>,
+    getState: () => RootState
+  ) => {
+    const { entities } = getState();
+    // TODO: save the keymap data to the Firestore
+    keymapData.id = '' + Date.now();
+    const dataList = [...entities.savedKeymaps, keymapData];
+
+    // TODO:fetch the saved list from the Firestore
+    dispatch(StorageActions.updateMySavedKeymapDataList(dataList));
+  },
+
+  updateMySavedKeymapData: (
+    keymapData: ISavedKeymapData
+  ): ThunkPromiseAction<void> => async (
+    dispatch: ThunkDispatch<RootState, undefined, ActionTypes>,
+    getState: () => RootState
+  ) => {
+    const { entities } = getState();
+    // TODO: save the keymap data to the Firestore
+    const dataList = entities.savedKeymaps.map((data) => {
+      return data.id === keymapData.id ? keymapData : data;
+    });
+
+    dispatch(StorageActions.updateMySavedKeymapDataList(dataList));
+  },
+
+  deleteMySavedKeymapData: (id: string): ThunkPromiseAction<void> => async (
+    dispatch: ThunkDispatch<RootState, undefined, ActionTypes>,
+    getState: () => RootState
+  ) => {
+    const { entities } = getState();
+    // TODO: delete the keymap data in the Firestore
+    const dataList = entities.savedKeymaps.filter((data) => data.id != id);
+    console.log(dataList);
+    dispatch(StorageActions.updateMySavedKeymapDataList(dataList));
   },
 };

--- a/src/actions/storage.action.ts
+++ b/src/actions/storage.action.ts
@@ -573,9 +573,9 @@ export const storageActionsThunk = {
       return;
     }
     const info: IDeviceInformation = {
-      vendorId: keymapData.vendor_id,
-      productId: keymapData.product_id,
-      productName: keymapData.product_name,
+      vendorId: keymapData.vendorId,
+      productId: keymapData.productId,
+      productName: keymapData.productName,
     };
     dispatch(storageActionsThunk.fetchMySavedKeymaps(info));
   },
@@ -600,9 +600,9 @@ export const storageActionsThunk = {
     }
 
     const info: IDeviceInformation = {
-      vendorId: keymapData.vendor_id,
-      productId: keymapData.product_id,
-      productName: keymapData.product_name,
+      vendorId: keymapData.vendorId,
+      productId: keymapData.productId,
+      productName: keymapData.productName,
     };
     dispatch(storageActionsThunk.fetchMySavedKeymaps(info));
   },
@@ -627,9 +627,9 @@ export const storageActionsThunk = {
     }
 
     const info: IDeviceInformation = {
-      vendorId: keymapData.vendor_id,
-      productId: keymapData.product_id,
-      productName: keymapData.product_name,
+      vendorId: keymapData.vendorId,
+      productId: keymapData.productId,
+      productName: keymapData.productName,
     };
     dispatch(storageActionsThunk.fetchMySavedKeymaps(info));
   },

--- a/src/components/configure/content/Content.container.ts
+++ b/src/components/configure/content/Content.container.ts
@@ -1,15 +1,23 @@
 import { connect } from 'react-redux';
 import Content from './Content';
 import { RootState } from '../../../store/state';
+import { storageActionsThunk } from '../../../actions/storage.action';
 
 const mapStateToProps = (state: RootState) => {
   return {
     setupPhase: state.app.setupPhase,
+    keyboardDefDocument: state.entities.keyboardDefinitionDocument,
   };
 };
 export type ContentStateType = ReturnType<typeof mapStateToProps>;
 
-const mapDispatchToProps = {};
-export type ContentActionsType = typeof mapDispatchToProps;
+const mapDispatchToProps = (_dispatch: any) => {
+  return {
+    fetchSavedKeymaps: (definitionId: string) => {
+      _dispatch(storageActionsThunk.fetchSavedKeymapDataList(definitionId));
+    },
+  };
+};
+export type ContentActionsType = ReturnType<typeof mapDispatchToProps>;
 
 export default connect(mapStateToProps, mapDispatchToProps)(Content);

--- a/src/components/configure/content/Content.container.ts
+++ b/src/components/configure/content/Content.container.ts
@@ -2,19 +2,24 @@ import { connect } from 'react-redux';
 import Content from './Content';
 import { RootState } from '../../../store/state';
 import { storageActionsThunk } from '../../../actions/storage.action';
+import { IDeviceInformation } from '../../../services/hid/Hid';
 
 const mapStateToProps = (state: RootState) => {
   return {
     setupPhase: state.app.setupPhase,
     keyboardDefDocument: state.entities.keyboardDefinitionDocument,
+    keyboard: state.entities.keyboard,
   };
 };
 export type ContentStateType = ReturnType<typeof mapStateToProps>;
 
 const mapDispatchToProps = (_dispatch: any) => {
   return {
-    fetchSavedKeymaps: (definitionId: string) => {
-      _dispatch(storageActionsThunk.fetchSavedKeymapDataList(definitionId));
+    fetchSavedRegisteredKeymaps: (definitionId: string) => {
+      _dispatch(storageActionsThunk.fetchSavedRegisteredKeymaps(definitionId));
+    },
+    fetchSavedUnregisteredKeymaps: (info: IDeviceInformation) => {
+      _dispatch(storageActionsThunk.fetchSavedUnregisteredKeymaps(info));
     },
   };
 };

--- a/src/components/configure/content/Content.container.ts
+++ b/src/components/configure/content/Content.container.ts
@@ -6,6 +6,7 @@ import { IDeviceInformation } from '../../../services/hid/Hid';
 
 const mapStateToProps = (state: RootState) => {
   return {
+    signedIn: state.app.signedIn,
     setupPhase: state.app.setupPhase,
     keyboardDefDocument: state.entities.keyboardDefinitionDocument,
     keyboard: state.entities.keyboard,
@@ -15,11 +16,8 @@ export type ContentStateType = ReturnType<typeof mapStateToProps>;
 
 const mapDispatchToProps = (_dispatch: any) => {
   return {
-    fetchSavedRegisteredKeymaps: (info: IDeviceInformation) => {
-      _dispatch(storageActionsThunk.fetchSavedRegisteredKeymaps(info));
-    },
-    fetchSavedUnregisteredKeymaps: (info: IDeviceInformation) => {
-      _dispatch(storageActionsThunk.fetchSavedUnregisteredKeymaps(info));
+    fetchSavedKeymaps: (info: IDeviceInformation) => {
+      _dispatch(storageActionsThunk.fetchMySavedKeymaps(info));
     },
   };
 };

--- a/src/components/configure/content/Content.container.ts
+++ b/src/components/configure/content/Content.container.ts
@@ -15,8 +15,8 @@ export type ContentStateType = ReturnType<typeof mapStateToProps>;
 
 const mapDispatchToProps = (_dispatch: any) => {
   return {
-    fetchSavedRegisteredKeymaps: (definitionId: string) => {
-      _dispatch(storageActionsThunk.fetchSavedRegisteredKeymaps(definitionId));
+    fetchSavedRegisteredKeymaps: (info: IDeviceInformation) => {
+      _dispatch(storageActionsThunk.fetchSavedRegisteredKeymaps(info));
     },
     fetchSavedUnregisteredKeymaps: (info: IDeviceInformation) => {
       _dispatch(storageActionsThunk.fetchSavedUnregisteredKeymaps(info));

--- a/src/components/configure/content/Content.tsx
+++ b/src/components/configure/content/Content.tsx
@@ -26,10 +26,14 @@ export default class Content extends React.Component<
 
   componentDidUpdate() {
     if (this.props.setupPhase === 'openedKeyboard') {
-      // The KeyboardDefinitionDocument MUST be set when the SetupPhase is "openKeyboard".
       if (this.props.keyboardDefDocument) {
-        const definitionId = this.props.keyboardDefDocument.id;
-        this.props.fetchSavedRegisteredKeymaps!(definitionId);
+        const doc = this.props.keyboardDefDocument;
+        const info: IDeviceInformation = {
+          vendorId: doc.vendorId,
+          productId: doc.productId,
+          productName: doc.productName,
+        };
+        this.props.fetchSavedRegisteredKeymaps!(info);
       }
       const info: IDeviceInformation = this.props.keyboard!.getInformation();
       this.props.fetchSavedUnregisteredKeymaps!(info);

--- a/src/components/configure/content/Content.tsx
+++ b/src/components/configure/content/Content.tsx
@@ -6,6 +6,7 @@ import { ISetupPhase, SetupPhase } from '../../../store/state';
 import KeyboardDefinitionForm from '../keyboarddefform/KeyboardDefinitionForm.container';
 import Remap from '../remap/Remap.container';
 import { CircularProgress } from '@material-ui/core';
+import { isApprovedKeyboard } from '../../../services/storage/Storage';
 
 type ContentState = {};
 
@@ -26,8 +27,8 @@ export default class Content extends React.Component<
   componentDidUpdate() {
     if (this.props.signedIn && this.props.setupPhase === 'openedKeyboard') {
       let info: { vendorId: number; productId: number; productName: string };
-      if (this.props.keyboardDefDocument) {
-        info = this.props.keyboardDefDocument;
+      if (isApprovedKeyboard(this.props.keyboardDefDocument)) {
+        info = this.props.keyboardDefDocument!;
       } else {
         info = this.props.keyboard!.getInformation();
       }

--- a/src/components/configure/content/Content.tsx
+++ b/src/components/configure/content/Content.tsx
@@ -6,7 +6,6 @@ import { ISetupPhase, SetupPhase } from '../../../store/state';
 import KeyboardDefinitionForm from '../keyboarddefform/KeyboardDefinitionForm.container';
 import Remap from '../remap/Remap.container';
 import { CircularProgress } from '@material-ui/core';
-import { IDeviceInformation } from '../../../services/hid/Hid';
 
 type ContentState = {};
 
@@ -25,18 +24,14 @@ export default class Content extends React.Component<
   }
 
   componentDidUpdate() {
-    if (this.props.setupPhase === 'openedKeyboard') {
+    if (this.props.signedIn && this.props.setupPhase === 'openedKeyboard') {
+      let info: { vendorId: number; productId: number; productName: string };
       if (this.props.keyboardDefDocument) {
-        const doc = this.props.keyboardDefDocument;
-        const info: IDeviceInformation = {
-          vendorId: doc.vendorId,
-          productId: doc.productId,
-          productName: doc.productName,
-        };
-        this.props.fetchSavedRegisteredKeymaps!(info);
+        info = this.props.keyboardDefDocument;
+      } else {
+        info = this.props.keyboard!.getInformation();
       }
-      const info: IDeviceInformation = this.props.keyboard!.getInformation();
-      this.props.fetchSavedUnregisteredKeymaps!(info);
+      this.props.fetchSavedKeymaps!(info);
     }
   }
 

--- a/src/components/configure/content/Content.tsx
+++ b/src/components/configure/content/Content.tsx
@@ -23,6 +23,14 @@ export default class Content extends React.Component<
     super(props);
   }
 
+  componentDidUpdate() {
+    if (this.props.setupPhase === 'openedKeyboard') {
+      // The KeyboardDefinitionDocument MUST be set when the SetupPhase is "openKeyboard".
+      const definitionId = this.props.keyboardDefDocument!.id;
+      this.props.fetchSavedKeymaps!(definitionId);
+    }
+  }
+
   render() {
     return (
       <div

--- a/src/components/configure/content/Content.tsx
+++ b/src/components/configure/content/Content.tsx
@@ -6,6 +6,7 @@ import { ISetupPhase, SetupPhase } from '../../../store/state';
 import KeyboardDefinitionForm from '../keyboarddefform/KeyboardDefinitionForm.container';
 import Remap from '../remap/Remap.container';
 import { CircularProgress } from '@material-ui/core';
+import { IDeviceInformation } from '../../../services/hid/Hid';
 
 type ContentState = {};
 
@@ -26,8 +27,12 @@ export default class Content extends React.Component<
   componentDidUpdate() {
     if (this.props.setupPhase === 'openedKeyboard') {
       // The KeyboardDefinitionDocument MUST be set when the SetupPhase is "openKeyboard".
-      const definitionId = this.props.keyboardDefDocument!.id;
-      this.props.fetchSavedKeymaps!(definitionId);
+      if (this.props.keyboardDefDocument) {
+        const definitionId = this.props.keyboardDefDocument.id;
+        this.props.fetchSavedRegisteredKeymaps!(definitionId);
+      }
+      const info: IDeviceInformation = this.props.keyboard!.getInformation();
+      this.props.fetchSavedUnregisteredKeymaps!(info);
     }
   }
 

--- a/src/components/configure/keymap/Keymap.stories.tsx
+++ b/src/components/configure/keymap/Keymap.stories.tsx
@@ -23,6 +23,7 @@ import { HotdoxKeymap } from '../../../assets/keymaps/HotdoxKeymap';
 import { BigAssEnterKeymap } from '../../../assets/keymaps/BigAssEnterKeymap';
 import { VerticalSplitKeymap } from '../../../assets/keymaps/VerticalSplit';
 import { KeyopsSuccessionKeymap } from '../../../assets/keymaps/KeyopsSuccession';
+import { LayoutOption } from './Keymap';
 
 export default {
   title: 'Keyboards',
@@ -33,11 +34,11 @@ type KeycapData = {
   remap: IKeymap | null;
 };
 type KeymapType = ((string | KeyOp)[] | { name: string })[];
-type OptionsType = { option: string; optionChoice: string }[];
+
 const genKeyboardView = (
   name: string,
   km: KeymapType,
-  options?: OptionsType
+  options?: LayoutOption[]
 ) => {
   const kbd = new KeyboardModel(km);
   const { keymaps, width, height, left } = kbd.getKeymap(options);
@@ -138,121 +139,121 @@ export const Cornelius = () => genKeyboardView('Cornelius', CorneliusKeymap);
 export const Aleth42 = () => genKeyboardView('Aleth42', Aleth42Keymap);
 export const Hotdox = () => genKeyboardView('Hotdox', HotdoxKeymap);
 export const Zinc = () =>
-  genKeyboardView('Zinc0', ZincKeymap, [{ option: '0', optionChoice: '0' }]);
+  genKeyboardView('Zinc0', ZincKeymap, [{ option: 0, optionChoice: 0 }]);
 export const ZincSymmetrical = () =>
-  genKeyboardView('Zinc1', ZincKeymap, [{ option: '0', optionChoice: '1' }]);
+  genKeyboardView('Zinc1', ZincKeymap, [{ option: 0, optionChoice: 1 }]);
 export const OptionChoice0 = () =>
   genKeyboardView('OptionChoice0', OptionChoiceKeymap, [
-    { option: '0', optionChoice: '0' },
-    { option: '1', optionChoice: '0' },
-    { option: '2', optionChoice: '0' },
-    { option: '3', optionChoice: '0' },
-    { option: '4', optionChoice: '0' },
+    { option: 0, optionChoice: 0 },
+    { option: 1, optionChoice: 0 },
+    { option: 2, optionChoice: 0 },
+    { option: 3, optionChoice: 0 },
+    { option: 4, optionChoice: 0 },
   ]);
 export const OptionChoice1 = () =>
   genKeyboardView('OptionChoice1', OptionChoiceKeymap, [
-    { option: '0', optionChoice: '1' },
-    { option: '1', optionChoice: '1' },
-    { option: '2', optionChoice: '1' },
-    { option: '3', optionChoice: '1' },
-    { option: '4', optionChoice: '1' },
+    { option: 0, optionChoice: 1 },
+    { option: 1, optionChoice: 1 },
+    { option: 2, optionChoice: 1 },
+    { option: 3, optionChoice: 1 },
+    { option: 4, optionChoice: 1 },
   ]);
 export const OptionChoice2 = () =>
   genKeyboardView('OptionChoice2', OptionChoiceKeymap, [
-    { option: '0', optionChoice: '1' },
-    { option: '1', optionChoice: '1' },
-    { option: '2', optionChoice: '1' },
-    { option: '3', optionChoice: '1' },
-    { option: '4', optionChoice: '2' },
+    { option: 0, optionChoice: 1 },
+    { option: 1, optionChoice: 1 },
+    { option: 2, optionChoice: 1 },
+    { option: 3, optionChoice: 1 },
+    { option: 4, optionChoice: 2 },
   ]);
 export const OptionChoice3 = () =>
   genKeyboardView('OptionChoice3', OptionChoiceKeymap, [
-    { option: '0', optionChoice: '1' },
-    { option: '1', optionChoice: '1' },
-    { option: '2', optionChoice: '1' },
-    { option: '3', optionChoice: '1' },
-    { option: '4', optionChoice: '3' },
+    { option: 0, optionChoice: 1 },
+    { option: 1, optionChoice: 1 },
+    { option: 2, optionChoice: 1 },
+    { option: 3, optionChoice: 1 },
+    { option: 4, optionChoice: 3 },
   ]);
 export const OptionChoice200000 = () =>
   genKeyboardView('OptionChoice200000', OptionChoice2Keymap, [
-    { option: '0', optionChoice: '0' },
-    { option: '1', optionChoice: '0' },
-    { option: '2', optionChoice: '0' },
-    { option: '3', optionChoice: '0' },
-    { option: '4', optionChoice: '0' },
+    { option: 0, optionChoice: 0 },
+    { option: 1, optionChoice: 0 },
+    { option: 2, optionChoice: 0 },
+    { option: 3, optionChoice: 0 },
+    { option: 4, optionChoice: 0 },
   ]);
 export const OptionChoice200001 = () =>
   genKeyboardView('OptionChoice200001', OptionChoice2Keymap, [
-    { option: '0', optionChoice: '1' },
-    { option: '1', optionChoice: '0' },
-    { option: '2', optionChoice: '0' },
-    { option: '3', optionChoice: '0' },
-    { option: '4', optionChoice: '0' },
+    { option: 0, optionChoice: 1 },
+    { option: 1, optionChoice: 0 },
+    { option: 2, optionChoice: 0 },
+    { option: 3, optionChoice: 0 },
+    { option: 4, optionChoice: 0 },
   ]);
 export const OptionChoice200002 = () =>
   genKeyboardView('OptionChoice200002', OptionChoice2Keymap, [
-    { option: '0', optionChoice: '2' },
-    { option: '1', optionChoice: '0' },
-    { option: '2', optionChoice: '0' },
-    { option: '3', optionChoice: '0' },
-    { option: '4', optionChoice: '0' },
+    { option: 0, optionChoice: 2 },
+    { option: 1, optionChoice: 0 },
+    { option: 2, optionChoice: 0 },
+    { option: 3, optionChoice: 0 },
+    { option: 4, optionChoice: 0 },
   ]);
 
 export const OptionChoice200010 = () =>
   genKeyboardView('OptionChoice200010', OptionChoice2Keymap, [
-    { option: '0', optionChoice: '0' },
-    { option: '1', optionChoice: '1' },
-    { option: '2', optionChoice: '0' },
-    { option: '3', optionChoice: '0' },
-    { option: '4', optionChoice: '0' },
+    { option: 0, optionChoice: 0 },
+    { option: 1, optionChoice: 1 },
+    { option: 2, optionChoice: 0 },
+    { option: 3, optionChoice: 0 },
+    { option: 4, optionChoice: 0 },
   ]);
 export const OptionChoice200020 = () =>
   genKeyboardView('OptionChoice200020', OptionChoice2Keymap, [
-    { option: '0', optionChoice: '0' },
-    { option: '1', optionChoice: '2' },
-    { option: '2', optionChoice: '0' },
-    { option: '3', optionChoice: '0' },
-    { option: '4', optionChoice: '0' },
+    { option: 0, optionChoice: 0 },
+    { option: 1, optionChoice: 2 },
+    { option: 2, optionChoice: 0 },
+    { option: 3, optionChoice: 0 },
+    { option: 4, optionChoice: 0 },
   ]);
 export const OptionChoice200100 = () =>
   genKeyboardView('OptionChoice200100', OptionChoice2Keymap, [
-    { option: '0', optionChoice: '0' },
-    { option: '1', optionChoice: '0' },
-    { option: '2', optionChoice: '1' },
-    { option: '3', optionChoice: '0' },
-    { option: '4', optionChoice: '0' },
+    { option: 0, optionChoice: 0 },
+    { option: 1, optionChoice: 0 },
+    { option: 2, optionChoice: 1 },
+    { option: 3, optionChoice: 0 },
+    { option: 4, optionChoice: 0 },
   ]);
 export const OptionChoice201000 = () =>
   genKeyboardView('OptionChoice201000', OptionChoice2Keymap, [
-    { option: '0', optionChoice: '0' },
-    { option: '1', optionChoice: '0' },
-    { option: '2', optionChoice: '0' },
-    { option: '3', optionChoice: '1' },
-    { option: '4', optionChoice: '0' },
+    { option: 0, optionChoice: 0 },
+    { option: 1, optionChoice: 0 },
+    { option: 2, optionChoice: 0 },
+    { option: 3, optionChoice: 1 },
+    { option: 4, optionChoice: 0 },
   ]);
 export const OptionChoice202000 = () =>
   genKeyboardView('OptionChoice201000', OptionChoice2Keymap, [
-    { option: '0', optionChoice: '0' },
-    { option: '1', optionChoice: '0' },
-    { option: '2', optionChoice: '0' },
-    { option: '3', optionChoice: '2' },
-    { option: '4', optionChoice: '0' },
+    { option: 0, optionChoice: 0 },
+    { option: 1, optionChoice: 0 },
+    { option: 2, optionChoice: 0 },
+    { option: 3, optionChoice: 2 },
+    { option: 4, optionChoice: 0 },
   ]);
 export const OptionChoice210000 = () =>
   genKeyboardView('OptionChoice210000', OptionChoice2Keymap, [
-    { option: '0', optionChoice: '0' },
-    { option: '1', optionChoice: '0' },
-    { option: '2', optionChoice: '0' },
-    { option: '3', optionChoice: '0' },
-    { option: '4', optionChoice: '1' },
+    { option: 0, optionChoice: 0 },
+    { option: 1, optionChoice: 0 },
+    { option: 2, optionChoice: 0 },
+    { option: 3, optionChoice: 0 },
+    { option: 4, optionChoice: 1 },
   ]);
 export const OptionChoice202102 = () =>
   genKeyboardView('OptionChoice202102', OptionChoice2Keymap, [
-    { option: '0', optionChoice: '2' },
-    { option: '1', optionChoice: '0' },
-    { option: '2', optionChoice: '1' },
-    { option: '3', optionChoice: '2' },
-    { option: '4', optionChoice: '0' },
+    { option: 0, optionChoice: 2 },
+    { option: 1, optionChoice: 0 },
+    { option: 2, optionChoice: 1 },
+    { option: 3, optionChoice: 2 },
+    { option: 4, optionChoice: 0 },
   ]);
 export const Iso105 = () => genKeyboardView('Iso105', Iso105Keymap);
 export const ErgoDox = () => genKeyboardView('ErgoDox', ErgoDoxKeymap);
@@ -260,45 +261,45 @@ export const BigAssEnter = () =>
   genKeyboardView('BigAssEnter', BigAssEnterKeymap);
 export const VerticalSplitNormal = () =>
   genKeyboardView('VerticalSplitNormal', VerticalSplitKeymap, [
-    { option: '0', optionChoice: '0' },
-    { option: '1', optionChoice: '0' },
-    { option: '2', optionChoice: '0' },
-    { option: '3', optionChoice: '0' },
+    { option: 0, optionChoice: 0 },
+    { option: 1, optionChoice: 0 },
+    { option: 2, optionChoice: 0 },
+    { option: 3, optionChoice: 0 },
   ]);
 export const VerticalSplit2U = () =>
   genKeyboardView('VerticalSplit2U', VerticalSplitKeymap, [
-    { option: '0', optionChoice: '0' },
-    { option: '1', optionChoice: '0' },
-    { option: '2', optionChoice: '1' },
-    { option: '3', optionChoice: '0' },
+    { option: 0, optionChoice: 0 },
+    { option: 1, optionChoice: 0 },
+    { option: 2, optionChoice: 1 },
+    { option: 3, optionChoice: 0 },
   ]);
 export const VerticalSplit2Uinner = () =>
   genKeyboardView('VerticalSplit2Uinner', VerticalSplitKeymap, [
-    { option: '0', optionChoice: '0' },
-    { option: '1', optionChoice: '0' },
-    { option: '2', optionChoice: '0' },
-    { option: '3', optionChoice: '1' },
+    { option: 0, optionChoice: 0 },
+    { option: 1, optionChoice: 0 },
+    { option: 2, optionChoice: 0 },
+    { option: 3, optionChoice: 1 },
   ]);
 export const VerticalSplit3U = () =>
   genKeyboardView('VerticalSplit0', VerticalSplitKeymap, [
-    { option: '0', optionChoice: '0' },
-    { option: '1', optionChoice: '1' },
-    { option: '2', optionChoice: '0' },
-    { option: '3', optionChoice: '0' },
+    { option: 0, optionChoice: 0 },
+    { option: 1, optionChoice: 1 },
+    { option: 2, optionChoice: 0 },
+    { option: 3, optionChoice: 0 },
   ]);
 export const VerticalSplit4U = () =>
   genKeyboardView('VerticalSplit0', VerticalSplitKeymap, [
-    { option: '0', optionChoice: '1' },
-    { option: '1', optionChoice: '0' },
-    { option: '2', optionChoice: '0' },
-    { option: '3', optionChoice: '0' },
+    { option: 0, optionChoice: 1 },
+    { option: 1, optionChoice: 0 },
+    { option: 2, optionChoice: 0 },
+    { option: 3, optionChoice: 0 },
   ]);
 export const VerticalSplitAll = () =>
   genKeyboardView('VerticalSplit0', VerticalSplitKeymap, [
-    { option: '0', optionChoice: '1' },
-    { option: '1', optionChoice: '1' },
-    { option: '2', optionChoice: '1' },
-    { option: '3', optionChoice: '1' },
+    { option: 0, optionChoice: 1 },
+    { option: 1, optionChoice: 1 },
+    { option: 2, optionChoice: 1 },
+    { option: 3, optionChoice: 1 },
   ]);
 export const KeyopsSuccession = () =>
   genKeyboardView('KeyopsSuccession', KeyopsSuccessionKeymap);

--- a/src/components/configure/keymap/Keymap.tsx
+++ b/src/components/configure/keymap/Keymap.tsx
@@ -22,6 +22,11 @@ import {
 } from '../../../services/labellang/KeyLabelLangs';
 import KeymapToolbar from '../keymapToolbar/KeymapToolbar.container';
 
+export type LayoutOption = {
+  option: number;
+  optionChoice: number;
+};
+
 type OwnProp = {};
 
 type KeymapPropsType = OwnProp &
@@ -47,31 +52,6 @@ export default class Keymap extends React.Component<
       selectedKey: null,
       customKeyPopoverPosition: { left: 0, top: 0, side: 'above' },
     };
-  }
-
-  public static buildLayerOptions(
-    selectedKeyboardOptions: (string | null)[],
-    keyboardLabels: (string | string[])[]
-  ): { option: string; optionChoice: string }[] | undefined {
-    let layoutOptions: { option: string; optionChoice: string }[] | undefined;
-    const hasKeyboardOptions = 0 < selectedKeyboardOptions.length;
-    if (hasKeyboardOptions) {
-      layoutOptions = keyboardLabels.map(
-        (choices: string | string[], index) => {
-          if (typeof choices == 'string') {
-            const selected: string | null = selectedKeyboardOptions[index];
-            return selected
-              ? { option: '' + index, optionChoice: '1' }
-              : { option: '' + index, optionChoice: '0' };
-          } else {
-            const choice: string = selectedKeyboardOptions[index] as string;
-            const choiceIndex = choices.indexOf(choice) - 1; // first item of choices is for choice's label
-            return { option: '' + index, optionChoice: '' + choiceIndex };
-          }
-        }
-      );
-    }
-    return layoutOptions;
   }
 
   // eslint-disable-next-line no-unused-vars
@@ -177,11 +157,6 @@ export default class Keymap extends React.Component<
   }
 
   render() {
-    const layoutOptions = Keymap.buildLayerOptions(
-      this.props.selectedKeyboardOptions!,
-      this.props.keyboardLabels!
-    );
-
     return (
       <React.Fragment>
         {this.props.draggingKey && <div className="dragMask"></div>}
@@ -217,7 +192,7 @@ export default class Keymap extends React.Component<
 
           <KeyboardView
             keyboardModel={this.state.keyboardModel}
-            layoutOptions={layoutOptions}
+            layoutOptions={this.props.selectedKeyboardOptions!}
             keymaps={this.props.keymaps!}
             selectedLayer={this.props.selectedLayer!}
             remaps={this.props.remaps!}
@@ -337,7 +312,7 @@ type KeycapData = {
 
 type KeyboardType = {
   keyboardModel: KeyboardModel;
-  layoutOptions?: { option: string; optionChoice: string }[];
+  layoutOptions?: LayoutOption[];
   keymaps: { [pos: string]: IKeymap }[];
   selectedLayer: number;
   remaps: { [pos: string]: IKeymap }[];

--- a/src/components/configure/keymapToolbar/KeymapToolbar.tsx
+++ b/src/components/configure/keymapToolbar/KeymapToolbar.tsx
@@ -19,6 +19,8 @@ import LightingDialog from '../lighting/LightingDialog';
 import LayoutOptionPopover from '../layoutoption/LayoutOptionPopover.container';
 import { ImportFileIcon } from '../../common/icons/ImportFileIcon';
 import ImportDefDialog from '../importDef/ImportDefDialog.container';
+import SwapHorizRoundedIcon from '@material-ui/icons/SwapHorizRounded';
+import KeymapListPopover from '../keymaplist/KeymapListPopover.container';
 
 type OwnProp = {};
 
@@ -29,6 +31,7 @@ type KeymapMenuPropsType = OwnProp &
 type OwnKeymapMenuStateType = {
   openLightingDialog: boolean;
   layoutOptionPopoverPosition: { left: number; top: number } | null;
+  keymapListPopoverPosition: { left: number; top: number } | null;
   openImportDefDialog: boolean;
 };
 
@@ -41,6 +44,7 @@ export default class KeymapMenu extends React.Component<
     this.state = {
       openLightingDialog: false,
       layoutOptionPopoverPosition: null,
+      keymapListPopoverPosition: null,
       openImportDefDialog: false,
     };
   }
@@ -112,6 +116,22 @@ export default class KeymapMenu extends React.Component<
     pdf.genPdf(productName, layoutOptions);
   }
 
+  private onClickOpenKeymapListPopover(
+    event: React.MouseEvent<HTMLButtonElement, MouseEvent>
+  ) {
+    const { left, top } = event.currentTarget.getBoundingClientRect();
+    this.setState({
+      keymapListPopoverPosition: {
+        left,
+        top,
+      },
+    });
+  }
+
+  private onCloseKeymapListPopover() {
+    this.setState({ keymapListPopoverPosition: null });
+  }
+
   render() {
     const isLightingAvailable = LightingDialog.isLightingAvailable(
       this.props.keyboardDefinition!.lighting
@@ -177,6 +197,30 @@ export default class KeymapMenu extends React.Component<
               />
             </div>
           )}
+
+          <div className="keymap-menu-item">
+            <Tooltip
+              arrow={true}
+              placement="top"
+              title="Save/Import another keymap"
+            >
+              <IconButton
+                size="small"
+                onClick={(event) => {
+                  this.onClickOpenKeymapListPopover(event);
+                }}
+              >
+                <SwapHorizRoundedIcon />
+              </IconButton>
+            </Tooltip>
+            <KeymapListPopover
+              open={Boolean(this.state.keymapListPopoverPosition)}
+              onClose={() => {
+                this.onCloseKeymapListPopover();
+              }}
+              position={this.state.keymapListPopoverPosition}
+            />
+          </div>
 
           <div className="keymap-menu-item">
             <Tooltip

--- a/src/components/configure/keymapToolbar/KeymapToolbar.tsx
+++ b/src/components/configure/keymapToolbar/KeymapToolbar.tsx
@@ -14,7 +14,6 @@ import {
 import { IKeymap } from '../../../services/hid/Hid';
 import { genKey, Key } from '../keycodekey/KeyGen';
 import { KeymapPdfGenerator } from '../../../services/pdf/KeymapPdfGenerator';
-import Keymap from '../keymap/Keymap';
 import LightingDialog from '../lighting/LightingDialog';
 import LayoutOptionPopover from '../layoutoption/LayoutOptionPopover.container';
 import { ImportFileIcon } from '../../common/icons/ImportFileIcon';
@@ -101,10 +100,7 @@ export default class KeymapMenu extends React.Component<
       });
       keys.push(keyMap);
     }
-    const layoutOptions = Keymap.buildLayerOptions(
-      this.props.selectedKeyboardOptions!,
-      this.props.keyboardDefinition!.layouts.labels!
-    );
+
     const { productName } = this.props.keyboard!.getInformation();
     const pdf = new KeymapPdfGenerator(
       this.props.keyboardDefinition!.layouts.keymap,
@@ -113,7 +109,7 @@ export default class KeymapMenu extends React.Component<
       this.props.labelLang!
     );
 
-    pdf.genPdf(productName, layoutOptions);
+    pdf.genPdf(productName, this.props.selectedKeyboardOptions!);
   }
 
   private onClickOpenKeymapListPopover(

--- a/src/components/configure/keymapToolbar/KeymapToolbar.tsx
+++ b/src/components/configure/keymapToolbar/KeymapToolbar.tsx
@@ -199,11 +199,7 @@ export default class KeymapMenu extends React.Component<
           )}
 
           <div className="keymap-menu-item">
-            <Tooltip
-              arrow={true}
-              placement="top"
-              title="Save/Import another keymap"
-            >
+            <Tooltip arrow={true} placement="top" title="Save/Restore a keymap">
               <IconButton
                 size="small"
                 onClick={(event) => {

--- a/src/components/configure/keymaplist/KeymapListPopover.container.ts
+++ b/src/components/configure/keymaplist/KeymapListPopover.container.ts
@@ -1,0 +1,20 @@
+import { connect } from 'react-redux';
+import KeymapListPopover from './KeymapListPopover';
+import { RootState } from '../../../store/state';
+
+// eslint-disable-next-line no-unused-vars
+const mapStateToProps = (state: RootState) => {
+  return {};
+};
+export type KeymapListPopoverStateType = ReturnType<typeof mapStateToProps>;
+
+// eslint-disable-next-line no-unused-vars
+const mapDispatchToProps = (_dispatch: any) => {
+  return {};
+};
+
+export type KeymapListPopoverActionsType = ReturnType<
+  typeof mapDispatchToProps
+>;
+
+export default connect(mapStateToProps, mapDispatchToProps)(KeymapListPopover);

--- a/src/components/configure/keymaplist/KeymapListPopover.container.ts
+++ b/src/components/configure/keymaplist/KeymapListPopover.container.ts
@@ -1,16 +1,36 @@
 import { connect } from 'react-redux';
 import KeymapListPopover from './KeymapListPopover';
 import { RootState } from '../../../store/state';
+import { ISavedKeymapData } from '../../../services/storage/Storage';
+import { storageActionsThunk } from '../../../actions/storage.action';
+import { AppActions, KeydiffActions } from '../../../actions/actions';
+import { KeyboardLabelLang } from '../../../services/labellang/KeyLabelLangs';
+import { IKeymap } from '../../../services/hid/Hid';
 
 // eslint-disable-next-line no-unused-vars
 const mapStateToProps = (state: RootState) => {
-  return {};
+  return {
+    savedKeymaps: state.entities.savedKeymaps,
+    keymaps: state.entities.device.keymaps,
+  };
 };
 export type KeymapListPopoverStateType = ReturnType<typeof mapStateToProps>;
 
 // eslint-disable-next-line no-unused-vars
 const mapDispatchToProps = (_dispatch: any) => {
-  return {};
+  return {
+    createSavedKeymapData: (keymapData: ISavedKeymapData) => {
+      _dispatch(storageActionsThunk.createMySavedKeymapData(keymapData));
+    },
+    applySavedKeymapData: (
+      keymaps: { [pos: string]: IKeymap }[],
+      labelLang: KeyboardLabelLang
+    ) => {
+      _dispatch(AppActions.updateLangLabel(labelLang));
+      _dispatch(KeydiffActions.clearKeydiff());
+      _dispatch(AppActions.remapsSetKeys(keymaps));
+    },
+  };
 };
 
 export type KeymapListPopoverActionsType = ReturnType<

--- a/src/components/configure/keymaplist/KeymapListPopover.container.ts
+++ b/src/components/configure/keymaplist/KeymapListPopover.container.ts
@@ -1,16 +1,20 @@
 import { connect } from 'react-redux';
 import KeymapListPopover from './KeymapListPopover';
 import { RootState } from '../../../store/state';
-import { ISavedKeymapData } from '../../../services/storage/Storage';
-import { storageActionsThunk } from '../../../actions/storage.action';
-import { AppActions, KeydiffActions } from '../../../actions/actions';
+import {
+  AppActions,
+  KeydiffActions,
+  LayoutOptionsActions,
+} from '../../../actions/actions';
 import { KeyboardLabelLang } from '../../../services/labellang/KeyLabelLangs';
 import { IKeymap } from '../../../services/hid/Hid';
+import { LayoutOption } from '../keymap/Keymap';
 
 // eslint-disable-next-line no-unused-vars
 const mapStateToProps = (state: RootState) => {
   return {
-    savedKeymaps: state.entities.savedKeymaps,
+    savedRegisteredKeymaps: state.entities.savedRegisteredKeymaps,
+    savedUnregisteredKeymaps: state.entities.savedUnregisteredKeymaps,
     keymaps: state.entities.device.keymaps,
     auth: state.auth.instance,
     signedIn: state.app.signedIn,
@@ -21,16 +25,15 @@ export type KeymapListPopoverStateType = ReturnType<typeof mapStateToProps>;
 // eslint-disable-next-line no-unused-vars
 const mapDispatchToProps = (_dispatch: any) => {
   return {
-    createSavedKeymapData: (keymapData: ISavedKeymapData) => {
-      _dispatch(storageActionsThunk.createSavedKeymapData(keymapData));
-    },
     applySavedKeymapData: (
       keymaps: { [pos: string]: IKeymap }[],
+      layoutOptions: LayoutOption[],
       labelLang: KeyboardLabelLang
     ) => {
       _dispatch(AppActions.updateLangLabel(labelLang));
       _dispatch(KeydiffActions.clearKeydiff());
       _dispatch(AppActions.remapsSetKeys(keymaps));
+      _dispatch(LayoutOptionsActions.restoreLayoutOptions(layoutOptions));
     },
   };
 };

--- a/src/components/configure/keymaplist/KeymapListPopover.container.ts
+++ b/src/components/configure/keymaplist/KeymapListPopover.container.ts
@@ -12,6 +12,8 @@ const mapStateToProps = (state: RootState) => {
   return {
     savedKeymaps: state.entities.savedKeymaps,
     keymaps: state.entities.device.keymaps,
+    auth: state.auth.instance,
+    signedIn: state.app.signedIn,
   };
 };
 export type KeymapListPopoverStateType = ReturnType<typeof mapStateToProps>;
@@ -20,7 +22,7 @@ export type KeymapListPopoverStateType = ReturnType<typeof mapStateToProps>;
 const mapDispatchToProps = (_dispatch: any) => {
   return {
     createSavedKeymapData: (keymapData: ISavedKeymapData) => {
-      _dispatch(storageActionsThunk.createMySavedKeymapData(keymapData));
+      _dispatch(storageActionsThunk.createSavedKeymapData(keymapData));
     },
     applySavedKeymapData: (
       keymaps: { [pos: string]: IKeymap }[],

--- a/src/components/configure/keymaplist/KeymapListPopover.container.ts
+++ b/src/components/configure/keymaplist/KeymapListPopover.container.ts
@@ -13,8 +13,7 @@ import { LayoutOption } from '../keymap/Keymap';
 // eslint-disable-next-line no-unused-vars
 const mapStateToProps = (state: RootState) => {
   return {
-    savedRegisteredKeymaps: state.entities.savedRegisteredKeymaps,
-    savedUnregisteredKeymaps: state.entities.savedUnregisteredKeymaps,
+    savedKeymaps: state.entities.savedKeymaps,
     keymaps: state.entities.device.keymaps,
     auth: state.auth.instance,
     signedIn: state.app.signedIn,

--- a/src/components/configure/keymaplist/KeymapListPopover.scss
+++ b/src/components/configure/keymaplist/KeymapListPopover.scss
@@ -1,0 +1,26 @@
+@import '../../../variables';
+
+.keymaplist-root {
+  .keymaplist {
+    padding: 0 $space-l;
+  }
+  .keymaplist-popover {
+    width: 360px;
+    max-height: 400px;
+    display: flex;
+    flex-direction: column;
+    .keymaplist-header {
+      display: flex;
+      flex-direction: row;
+      align-items: center;
+      border-bottom: 1px solid rgba(0, 0, 0, 0.2);
+      .keymaplist-header-buttons {
+        margin-left: auto;
+      }
+    }
+    .keymaplist-content {
+      display: flex;
+      flex-direction: column;
+    }
+  }
+}

--- a/src/components/configure/keymaplist/KeymapListPopover.scss
+++ b/src/components/configure/keymaplist/KeymapListPopover.scss
@@ -21,6 +21,13 @@
     .keymaplist-content {
       display: flex;
       flex-direction: column;
+      overflow-y: scroll;
+      .no-saved-keymap {
+        padding-bottom: $space-l;
+        .keymaplist-warning {
+          color: $warning;
+        }
+      }
     }
   }
 }

--- a/src/components/configure/keymaplist/KeymapListPopover.scss
+++ b/src/components/configure/keymaplist/KeymapListPopover.scss
@@ -22,11 +22,17 @@
       display: flex;
       flex-direction: column;
       overflow-y: scroll;
+      overflow-x: hidden;
       .no-saved-keymap {
         padding-bottom: $space-l;
         .keymaplist-warning {
           color: $warning;
         }
+      }
+      .MuiListItemText-secondary {
+        overflow-wrap: anywhere;
+        overflow-y: scroll;
+        max-height: 40px;
       }
     }
 

--- a/src/components/configure/keymaplist/KeymapListPopover.scss
+++ b/src/components/configure/keymaplist/KeymapListPopover.scss
@@ -5,7 +5,7 @@
     padding: 0 $space-l;
   }
   .keymaplist-popover {
-    width: 360px;
+    width: 330px;
     max-height: 400px;
     display: flex;
     flex-direction: column;
@@ -23,6 +23,12 @@
       flex-direction: column;
       overflow-y: scroll;
       overflow-x: hidden;
+      -ms-overflow-style: none; /* IE, Edge */
+      scrollbar-width: none; /* Firefox */
+      &::-webkit-scrollbar {
+        /* Chrome, Safari  */
+        display: none;
+      }
       .no-saved-keymap {
         padding-bottom: $space-l;
         .keymaplist-warning {
@@ -31,11 +37,24 @@
       }
       .MuiListItemText-primary {
         overflow-x: scroll;
+        white-space: nowrap;
+        -ms-overflow-style: none; /* IE, Edge */
+        scrollbar-width: none; /* Firefox */
+        &::-webkit-scrollbar {
+          /* Chrome, Safari  */
+          display: none;
+        }
       }
       .MuiListItemText-secondary {
         overflow-wrap: anywhere;
         overflow-y: scroll;
         max-height: 40px;
+        -ms-overflow-style: none; /* IE, Edge */
+        scrollbar-width: none; /* Firefox */
+        &::-webkit-scrollbar {
+          /* Chrome, Safari  */
+          display: none;
+        }
       }
     }
 

--- a/src/components/configure/keymaplist/KeymapListPopover.scss
+++ b/src/components/configure/keymaplist/KeymapListPopover.scss
@@ -29,6 +29,9 @@
           color: $warning;
         }
       }
+      .MuiListItemText-primary {
+        overflow-x: scroll;
+      }
       .MuiListItemText-secondary {
         overflow-wrap: anywhere;
         overflow-y: scroll;

--- a/src/components/configure/keymaplist/KeymapListPopover.scss
+++ b/src/components/configure/keymaplist/KeymapListPopover.scss
@@ -29,5 +29,20 @@
         }
       }
     }
+
+    .request-signin {
+      padding: $space-l;
+      display: flex;
+      flex-direction: column;
+
+      .request-signin-message {
+        color: $warning;
+      }
+      .request-signin-actions {
+        display: flex;
+        justify-content: center;
+        padding-top: $space-l;
+      }
+    }
   }
 }

--- a/src/components/configure/keymaplist/KeymapListPopover.tsx
+++ b/src/components/configure/keymaplist/KeymapListPopover.tsx
@@ -1,0 +1,199 @@
+/* eslint-disable no-undef */
+import React from 'react';
+import './KeymapListPopover.scss';
+import {
+  KeymapListPopoverActionsType,
+  KeymapListPopoverStateType,
+} from './KeymapListPopover.container';
+import {
+  Button,
+  IconButton,
+  List,
+  ListItem,
+  ListItemSecondaryAction,
+  ListItemText,
+  Popover,
+} from '@material-ui/core';
+import EditRoundedIcon from '@material-ui/icons/EditRounded';
+import KeymapSaveDialog from './KeymapSaveDialog.container';
+
+type PopoverPosition = {
+  left: number;
+  top: number;
+};
+
+type OwnProps = {
+  open: boolean;
+  position: PopoverPosition | null;
+  onClose: () => void;
+};
+
+type KeymapListPopoverProps = OwnProps &
+  Partial<KeymapListPopoverActionsType> &
+  Partial<KeymapListPopoverStateType>;
+
+type OwnState = {
+  keymapSaveDialog: {
+    edit: boolean;
+    id?: string;
+    title?: string;
+    desc?: string;
+  } | null;
+};
+
+export default class KeymapListPopover extends React.Component<
+  KeymapListPopoverProps,
+  OwnState
+> {
+  private popoverRef: React.RefObject<HTMLDivElement>;
+  constructor(props: OwnProps | Readonly<OwnProps>) {
+    super(props);
+    this.state = {
+      keymapSaveDialog: null,
+    };
+    this.popoverRef = React.createRef<HTMLDivElement>();
+  }
+
+  get position(): { left: number; top: number } {
+    if (!this.props.position) {
+      return {
+        left: 0,
+        top: 0,
+      };
+    }
+    const { left, top } = this.props.position;
+    const width = 360;
+    const height = 400;
+
+    const iconSize = 30;
+
+    if (window.innerWidth < left + width + iconSize + 10) {
+      const x = Math.min(left, left - (width - (window.innerWidth - left)));
+      const y = top + iconSize + 10; // 10=margin
+      return { left: x, top: y };
+    } else {
+      const x = left + iconSize + 10; // 10=margin
+      const y = top - height / 2 + iconSize / 2;
+      return { left: x, top: y };
+    }
+  }
+
+  private onEnter() {}
+
+  private onClickOpenKeymapSaveDialog(keymapSaveDialog: {
+    edit: boolean;
+    title?: string;
+    desc?: string;
+  }) {
+    this.setState({ keymapSaveDialog });
+  }
+
+  private onCloseKeymapSaveDialog() {
+    this.setState({ keymapSaveDialog: null });
+  }
+
+  render() {
+    if (!this.props.position) {
+      return <></>;
+    }
+
+    return (
+      <Popover
+        open={this.props.open}
+        anchorReference="anchorPosition"
+        anchorPosition={this.position}
+        onEnter={this.onEnter.bind(this)}
+        onClose={() => {
+          this.props.onClose();
+        }}
+        transformOrigin={{
+          vertical: 'top',
+          horizontal: 'left',
+        }}
+        className="keymaplist-root"
+      >
+        <div className="keymaplist-popover" ref={this.popoverRef}>
+          <div className="keymaplist keymaplist-header">
+            <div>
+              <h2>Keymaps</h2>
+            </div>
+            <div className="keymaplist-header-buttons">
+              <Button
+                color="primary"
+                onClick={() => {
+                  this.onClickOpenKeymapSaveDialog({ edit: false });
+                }}
+              >
+                SAVE CURRENT KEYMAP
+              </Button>
+            </div>
+          </div>
+          <div className="keymaplist keymaplist-content">
+            <List dense={true}>
+              {keymaps.map((item, index) => {
+                return (
+                  <ListItem key={`keymaplist-keymap${index}`} button>
+                    <ListItemText primary={item.title} secondary={item.desc} />
+                    <ListItemSecondaryAction>
+                      <IconButton
+                        edge="end"
+                        aria-label="edit"
+                        onClick={() => {
+                          this.onClickOpenKeymapSaveDialog({
+                            ...item,
+                            edit: true,
+                          });
+                        }}
+                      >
+                        <EditRoundedIcon />
+                      </IconButton>
+                    </ListItemSecondaryAction>
+                  </ListItem>
+                );
+              })}
+            </List>
+          </div>
+        </div>
+        <KeymapSaveDialog
+          open={Boolean(this.state.keymapSaveDialog)}
+          edit={this.state.keymapSaveDialog?.edit || false}
+          id={this.state.keymapSaveDialog?.id}
+          title={this.state.keymapSaveDialog?.title}
+          desc={this.state.keymapSaveDialog?.desc}
+          onClose={() => {
+            this.onCloseKeymapSaveDialog();
+          }}
+          onSave={(store) => {
+            console.log(store);
+          }}
+          onDelete={(id) => {
+            console.log(id);
+          }}
+        />
+      </Popover>
+    );
+  }
+}
+
+const keymaps: { id: string; title: string; desc: string }[] = [
+  {
+    id: '1',
+    title: 'title1',
+    desc: 'desc1',
+  },
+  {
+    id: '2',
+    title: 'title2',
+    desc: 'desc2',
+  },
+  {
+    id: '3',
+    title: 'title3',
+    desc: 'desc3',
+  },
+  {
+    id: '4',
+    title: 'title4',
+    desc: 'desc4',
+  },
+];

--- a/src/components/configure/keymaplist/KeymapListPopover.tsx
+++ b/src/components/configure/keymaplist/KeymapListPopover.tsx
@@ -83,8 +83,8 @@ export default class KeymapListPopover extends React.Component<
   }
 
   private onClickApplySavedKeymapData(savedKeymapData: SavedKeymapData) {
-    const labelLang = savedKeymapData.labelLang;
-    const layoutOptions = savedKeymapData.layoutOptions;
+    const labelLang = savedKeymapData.label_lang;
+    const layoutOptions = savedKeymapData.layout_options;
     let keycodes: { [pos: string]: IKeymap }[] = [];
     const savedKeycodes: { [pos: string]: number }[] = savedKeymapData.keycodes;
     const keymaps: { [pos: string]: IKeymap }[] = this.props.keymaps!;

--- a/src/components/configure/keymaplist/KeymapListPopover.tsx
+++ b/src/components/configure/keymaplist/KeymapListPopover.tsx
@@ -124,10 +124,6 @@ export default class KeymapListPopover extends React.Component<
       return <></>;
     }
 
-    const savedKeymaps = [
-      ...this.props.savedRegisteredKeymaps!,
-      ...this.props.savedUnregisteredKeymaps!,
-    ];
     return (
       <Popover
         open={this.props.open}
@@ -147,7 +143,7 @@ export default class KeymapListPopover extends React.Component<
           {this.props.signedIn ? (
             <>
               <KeymapList
-                savedKeymaps={savedKeymaps}
+                savedKeymaps={this.props.savedKeymaps!}
                 onClickOpenKeymapSaveDialog={this.onClickOpenKeymapSaveDialog.bind(
                   this
                 )}

--- a/src/components/configure/keymaplist/KeymapListPopover.tsx
+++ b/src/components/configure/keymaplist/KeymapListPopover.tsx
@@ -16,7 +16,7 @@ import {
 } from '@material-ui/core';
 import EditRoundedIcon from '@material-ui/icons/EditRounded';
 import KeymapSaveDialog from './KeymapSaveDialog.container';
-import { ISavedKeymapData } from '../../../services/storage/Storage';
+import { SavedKeymapData } from '../../../services/storage/Storage';
 import { IKeymap } from '../../../services/hid/Hid';
 import { KeycodeList } from '../../../services/hid/KeycodeList';
 import AuthProviderDialog from '../auth/AuthProviderDialog.container';
@@ -38,7 +38,7 @@ type KeymapListPopoverProps = OwnProps &
 
 type OwnState = {
   openKeymapSaveDialog: boolean;
-  savedKeymapData: ISavedKeymapData | null;
+  savedKeymapData: SavedKeymapData | null;
   openAuthProviderDialog: boolean;
   popoverPosition: PopoverPosition;
 };
@@ -82,8 +82,9 @@ export default class KeymapListPopover extends React.Component<
     }
   }
 
-  private onClickApplySavedKeymapData(savedKeymapData: ISavedKeymapData) {
+  private onClickApplySavedKeymapData(savedKeymapData: SavedKeymapData) {
     const labelLang = savedKeymapData.label_lang;
+    const layoutOptions = savedKeymapData.layout_options;
     let keycodes: { [pos: string]: IKeymap }[] = [];
     const savedKeycodes: { [pos: string]: number }[] = savedKeymapData.keycodes;
     const keymaps: { [pos: string]: IKeymap }[] = this.props.keymaps!;
@@ -99,12 +100,10 @@ export default class KeymapListPopover extends React.Component<
       keycodes.push(changes);
     }
 
-    this.props.applySavedKeymapData!(keycodes, labelLang);
+    this.props.applySavedKeymapData!(keycodes, layoutOptions, labelLang);
   }
 
-  private onClickOpenKeymapSaveDialog(
-    savedKeymapData: ISavedKeymapData | null
-  ) {
+  private onClickOpenKeymapSaveDialog(savedKeymapData: SavedKeymapData | null) {
     this.setState({ openKeymapSaveDialog: true, savedKeymapData });
   }
 
@@ -125,6 +124,10 @@ export default class KeymapListPopover extends React.Component<
       return <></>;
     }
 
+    const savedKeymaps = [
+      ...this.props.savedRegisteredKeymaps!,
+      ...this.props.savedUnregisteredKeymaps!,
+    ];
     return (
       <Popover
         open={this.props.open}
@@ -144,7 +147,7 @@ export default class KeymapListPopover extends React.Component<
           {this.props.signedIn ? (
             <>
               <KeymapList
-                savedKeymaps={this.props.savedKeymaps!}
+                savedKeymaps={savedKeymaps}
                 onClickOpenKeymapSaveDialog={this.onClickOpenKeymapSaveDialog.bind(
                   this
                 )}
@@ -176,13 +179,13 @@ export default class KeymapListPopover extends React.Component<
 }
 
 type KeymapListProps = {
-  savedKeymaps: ISavedKeymapData[];
+  savedKeymaps: SavedKeymapData[];
   onClickOpenKeymapSaveDialog: (
     // eslint-disable-next-line no-unused-vars
-    savedKeymapData: ISavedKeymapData | null
+    savedKeymapData: SavedKeymapData | null
   ) => void;
   // eslint-disable-next-line no-unused-vars
-  onClickApplySavedKeymapData: (savedKeymapData: ISavedKeymapData) => void;
+  onClickApplySavedKeymapData: (savedKeymapData: SavedKeymapData) => void;
 };
 
 function KeymapList(props: KeymapListProps) {

--- a/src/components/configure/keymaplist/KeymapListPopover.tsx
+++ b/src/components/configure/keymaplist/KeymapListPopover.tsx
@@ -19,6 +19,7 @@ import KeymapSaveDialog from './KeymapSaveDialog.container';
 import { ISavedKeymapData } from '../../../services/storage/Storage';
 import { IKeymap } from '../../../services/hid/Hid';
 import { KeycodeList } from '../../../services/hid/KeycodeList';
+import AuthProviderDialog from '../auth/AuthProviderDialog.container';
 
 type PopoverPosition = {
   left: number;
@@ -38,6 +39,8 @@ type KeymapListPopoverProps = OwnProps &
 type OwnState = {
   openKeymapSaveDialog: boolean;
   savedKeymapData: ISavedKeymapData | null;
+  openAuthProviderDialog: boolean;
+  popoverPosition: PopoverPosition;
 };
 
 export default class KeymapListPopover extends React.Component<
@@ -50,41 +53,39 @@ export default class KeymapListPopover extends React.Component<
     this.state = {
       openKeymapSaveDialog: false,
       savedKeymapData: null,
+      openAuthProviderDialog: false,
+      popoverPosition: { top: 0, left: 0 },
     };
     this.popoverRef = React.createRef<HTMLDivElement>();
   }
 
-  get position(): { left: number; top: number } {
-    if (!this.props.position) {
-      return {
-        left: 0,
-        top: 0,
-      };
-    }
-    const { left, top } = this.props.position;
-    const width = 360;
-    const height = 400;
-    const iconSize = 30;
-    const margin = 10;
+  private onEnter() {
+    if (this.popoverRef.current && this.props.position) {
+      // Adjust the Popover position regarding to its size.
+      const { left, top } = this.props.position;
+      const { width, height } = this.popoverRef.current.getBoundingClientRect();
+      const iconSize = 30;
+      const margin = 10;
 
-    if (window.innerWidth < left + width + iconSize + margin) {
-      const x = Math.min(left, left - (width - (window.innerWidth - left)));
-      const y = top + iconSize + margin; // 10=margin
-      return { left: x, top: y };
-    } else {
-      const x = left + iconSize + margin; // 10=margin
-      const y = top - height / 2 + iconSize / 2;
-      return { left: x, top: y };
+      let x = 0;
+      let y = 0;
+      if (window.innerWidth < left + width + iconSize + margin) {
+        // show the dialog below the icon
+        x = Math.min(left, left - (width - (window.innerWidth - left)));
+        y = top + iconSize + margin; // 10=margin
+      } else {
+        // show the dialog right side of the icon
+        x = left + iconSize + margin; // 10=margin
+        y = top - height / 2 + iconSize / 2;
+      }
+      this.setState({ popoverPosition: { left: x, top: y } });
     }
   }
 
-  private onEnter() {}
-
   private onClickApplySavedKeymapData(savedKeymapData: ISavedKeymapData) {
-    const labelLang = savedKeymapData.data.labelLang;
+    const labelLang = savedKeymapData.label_lang;
     let keycodes: { [pos: string]: IKeymap }[] = [];
-    const savedKeycodes: { [pos: string]: number }[] =
-      savedKeymapData.data.keycodes;
+    const savedKeycodes: { [pos: string]: number }[] = savedKeymapData.keycodes;
     const keymaps: { [pos: string]: IKeymap }[] = this.props.keymaps!;
     for (let i = 0; i < keymaps.length; i++) {
       const keymap = keymaps[i];
@@ -111,6 +112,14 @@ export default class KeymapListPopover extends React.Component<
     this.setState({ openKeymapSaveDialog: false, savedKeymapData: null });
   }
 
+  private onClickSignIn() {
+    this.setState({ openAuthProviderDialog: true });
+  }
+
+  private onCloseAuthProviderDialog() {
+    this.setState({ openAuthProviderDialog: false });
+  }
+
   render() {
     if (!this.props.position) {
       return <></>;
@@ -120,7 +129,7 @@ export default class KeymapListPopover extends React.Component<
       <Popover
         open={this.props.open}
         anchorReference="anchorPosition"
-        anchorPosition={this.position}
+        anchorPosition={this.state.popoverPosition}
         onEnter={this.onEnter.bind(this)}
         onClose={() => {
           this.props.onClose();
@@ -132,69 +141,134 @@ export default class KeymapListPopover extends React.Component<
         className="keymaplist-root"
       >
         <div className="keymaplist-popover" ref={this.popoverRef}>
-          <div className="keymaplist keymaplist-header">
-            <div>
-              <h2>Keymaps</h2>
-            </div>
-            <div className="keymaplist-header-buttons">
-              <Button
-                color="primary"
-                onClick={() => {
-                  this.onClickOpenKeymapSaveDialog(null);
+          {this.props.signedIn ? (
+            <>
+              <KeymapList
+                savedKeymaps={this.props.savedKeymaps!}
+                onClickOpenKeymapSaveDialog={this.onClickOpenKeymapSaveDialog.bind(
+                  this
+                )}
+                onClickApplySavedKeymapData={this.onClickApplySavedKeymapData.bind(
+                  this
+                )}
+              />
+              <KeymapSaveDialog
+                open={this.state.openKeymapSaveDialog}
+                savedKeymapData={this.state.savedKeymapData}
+                authorUid={this.props.auth!.getCurrentAuthenticatedUser().uid}
+                onClose={() => {
+                  this.onCloseKeymapSaveDialog();
                 }}
-              >
-                SAVE CURRENT KEYMAP
-              </Button>
-            </div>
-          </div>
-          <div className="keymaplist keymaplist-content">
-            <List dense={true}>
-              {this.props.savedKeymaps!.map((item, index) => {
-                return (
-                  <ListItem
-                    key={`keymaplist-keymap${index}`}
-                    button
-                    onClick={() => {
-                      this.onClickApplySavedKeymapData(item);
-                    }}
-                  >
-                    <ListItemText primary={item.title} secondary={item.desc} />
-                    <ListItemSecondaryAction>
-                      <IconButton
-                        edge="end"
-                        aria-label="edit"
-                        onClick={() => {
-                          console.log(item);
-                          this.onClickOpenKeymapSaveDialog(item);
-                        }}
-                      >
-                        <EditRoundedIcon />
-                      </IconButton>
-                    </ListItemSecondaryAction>
-                  </ListItem>
-                );
-              })}
-            </List>
-            {this.props.savedKeymaps!.length === 0 && (
-              <div className="no-saved-keymap">
-                You can save the current keymap by clicking the top-right
-                button. You can restore your saved keymap everytime.
-                <div className="keymaplist-warning">
-                  * Please note that the change candidates will discard when you
-                  save/restore the kemyap.
-                </div>
-              </div>
-            )}
-          </div>
+              />
+            </>
+          ) : (
+            <RequestSignIn onClickSignIn={this.onClickSignIn.bind(this)} />
+          )}
         </div>
-        <KeymapSaveDialog
-          open={this.state.openKeymapSaveDialog}
-          savedKeymapData={this.state.savedKeymapData}
-          onClose={() => {
-            this.onCloseKeymapSaveDialog();
-          }}
+
+        <AuthProviderDialog
+          open={this.state.openAuthProviderDialog}
+          onClose={this.onCloseAuthProviderDialog.bind(this)}
         />
       </Popover>
     );
   }
+}
+
+type KeymapListProps = {
+  savedKeymaps: ISavedKeymapData[];
+  onClickOpenKeymapSaveDialog: (
+    // eslint-disable-next-line no-unused-vars
+    savedKeymapData: ISavedKeymapData | null
+  ) => void;
+  // eslint-disable-next-line no-unused-vars
+  onClickApplySavedKeymapData: (savedKeymapData: ISavedKeymapData) => void;
+};
+
+function KeymapList(props: KeymapListProps) {
+  return (
+    <>
+      <div className="keymaplist keymaplist-header">
+        <div>
+          <h2>Keymaps</h2>
+        </div>
+        <div className="keymaplist-header-buttons">
+          <Button
+            color="primary"
+            onClick={() => {
+              props.onClickOpenKeymapSaveDialog(null);
+            }}
+          >
+            SAVE CURRENT KEYMAP
+          </Button>
+        </div>
+      </div>
+      <div className="keymaplist keymaplist-content">
+        <List dense={true}>
+          {props.savedKeymaps.map((item, index) => {
+            return (
+              <ListItem
+                key={`keymaplist-keymap${index}`}
+                button
+                onClick={() => {
+                  props.onClickApplySavedKeymapData(item);
+                }}
+              >
+                <ListItemText primary={item.title} secondary={item.desc} />
+                <ListItemSecondaryAction>
+                  <IconButton
+                    edge="end"
+                    aria-label="edit"
+                    onClick={() => {
+                      props.onClickOpenKeymapSaveDialog(item);
+                    }}
+                  >
+                    <EditRoundedIcon />
+                  </IconButton>
+                </ListItemSecondaryAction>
+              </ListItem>
+            );
+          })}
+        </List>
+        {props.savedKeymaps!.length === 0 && (
+          <div className="no-saved-keymap">
+            You can save the current keymap by clicking the top-right button.
+            You can restore your saved keymap every time.
+            <div className="keymaplist-warning">
+              * Please note that the change candidates will discard when you
+              save/restore the keymap.
+            </div>
+          </div>
+        )}
+      </div>
+    </>
+  );
+}
+
+type RequestSignInType = {
+  onClickSignIn: () => void;
+};
+function RequestSignIn(props: RequestSignInType) {
+  return (
+    <div className="request-signin">
+      <div>
+        You can save/restore the current keymap. Using this feature, you can
+        manage many kinds of keymaps.
+      </div>
+      <div className="request-signin-message">
+        *You need to sign in to use this feature.
+      </div>
+      <div className="request-signin-actions">
+        <Button
+          variant="contained"
+          color="primary"
+          onClick={() => {
+            props.onClickSignIn();
+          }}
+        >
+          SignIn
+        </Button>
+      </div>
+    </div>
+  );
 }

--- a/src/components/configure/keymaplist/KeymapListPopover.tsx
+++ b/src/components/configure/keymaplist/KeymapListPopover.tsx
@@ -83,8 +83,8 @@ export default class KeymapListPopover extends React.Component<
   }
 
   private onClickApplySavedKeymapData(savedKeymapData: SavedKeymapData) {
-    const labelLang = savedKeymapData.label_lang;
-    const layoutOptions = savedKeymapData.layout_options;
+    const labelLang = savedKeymapData.labelLang;
+    const layoutOptions = savedKeymapData.layoutOptions;
     let keycodes: { [pos: string]: IKeymap }[] = [];
     const savedKeycodes: { [pos: string]: number }[] = savedKeymapData.keycodes;
     const keymaps: { [pos: string]: IKeymap }[] = this.props.keymaps!;

--- a/src/components/configure/keymaplist/KeymapSaveDialog.container.ts
+++ b/src/components/configure/keymaplist/KeymapSaveDialog.container.ts
@@ -1,0 +1,28 @@
+import { connect } from 'react-redux';
+import KeymapSaveDialog from './KeymapSaveDialog';
+import { RootState } from '../../../store/state';
+import { LayoutOptionsActions } from '../../../actions/actions';
+
+const mapStateToProps = (state: RootState) => {
+  return {
+    keyboard: state.entities.keyboard,
+    keymaps: state.entities.device.keymaps,
+    labelLang: state.app.labelLang,
+    layerCount: state.entities.device.layerCount,
+    layoutLabels: state.entities.keyboardDefinition?.layouts.labels,
+    selectedLayoutOptions: state.configure.layoutOptions.selectedOptions,
+  };
+};
+export type KeymapSaveDialogStateType = ReturnType<typeof mapStateToProps>;
+
+const mapDispatchToProps = (_dispatch: any) => {
+  return {
+    setLayoutOption: (optionIndex: number, option: string | null) => {
+      _dispatch(LayoutOptionsActions.updateSelectedOption(optionIndex, option));
+    },
+  };
+};
+
+export type KeymapSaveDialogActionsType = ReturnType<typeof mapDispatchToProps>;
+
+export default connect(mapStateToProps, mapDispatchToProps)(KeymapSaveDialog);

--- a/src/components/configure/keymaplist/KeymapSaveDialog.container.ts
+++ b/src/components/configure/keymaplist/KeymapSaveDialog.container.ts
@@ -1,7 +1,8 @@
 import { connect } from 'react-redux';
 import KeymapSaveDialog from './KeymapSaveDialog';
 import { RootState } from '../../../store/state';
-import { LayoutOptionsActions } from '../../../actions/actions';
+import { storageActionsThunk } from '../../../actions/storage.action';
+import { ISavedKeymapData } from '../../../services/storage/Storage';
 
 const mapStateToProps = (state: RootState) => {
   return {
@@ -17,8 +18,14 @@ export type KeymapSaveDialogStateType = ReturnType<typeof mapStateToProps>;
 
 const mapDispatchToProps = (_dispatch: any) => {
   return {
-    setLayoutOption: (optionIndex: number, option: string | null) => {
-      _dispatch(LayoutOptionsActions.updateSelectedOption(optionIndex, option));
+    createSavedKeymapData: (keymapData: ISavedKeymapData) => {
+      _dispatch(storageActionsThunk.createMySavedKeymapData(keymapData));
+    },
+    updateSavedKeymapData: (keymapData: ISavedKeymapData) => {
+      _dispatch(storageActionsThunk.updateMySavedKeymapData(keymapData));
+    },
+    deleteSavedKeymapData: (id: string) => {
+      _dispatch(storageActionsThunk.deleteMySavedKeymapData(id));
     },
   };
 };

--- a/src/components/configure/keymaplist/KeymapSaveDialog.container.ts
+++ b/src/components/configure/keymaplist/KeymapSaveDialog.container.ts
@@ -12,6 +12,7 @@ const mapStateToProps = (state: RootState) => {
     layerCount: state.entities.device.layerCount,
     layoutLabels: state.entities.keyboardDefinition?.layouts.labels,
     selectedLayoutOptions: state.configure.layoutOptions.selectedOptions,
+    keyboardDefinitionDocument: state.entities.keyboardDefinitionDocument,
   };
 };
 export type KeymapSaveDialogStateType = ReturnType<typeof mapStateToProps>;
@@ -19,13 +20,13 @@ export type KeymapSaveDialogStateType = ReturnType<typeof mapStateToProps>;
 const mapDispatchToProps = (_dispatch: any) => {
   return {
     createSavedKeymapData: (keymapData: ISavedKeymapData) => {
-      _dispatch(storageActionsThunk.createMySavedKeymapData(keymapData));
+      _dispatch(storageActionsThunk.createSavedKeymapData(keymapData));
     },
     updateSavedKeymapData: (keymapData: ISavedKeymapData) => {
-      _dispatch(storageActionsThunk.updateMySavedKeymapData(keymapData));
+      _dispatch(storageActionsThunk.updateSavedKeymapData(keymapData));
     },
-    deleteSavedKeymapData: (id: string) => {
-      _dispatch(storageActionsThunk.deleteMySavedKeymapData(id));
+    deleteSavedKeymapData: (keymapData: ISavedKeymapData) => {
+      _dispatch(storageActionsThunk.deleteSavedKeymapData(keymapData));
     },
   };
 };

--- a/src/components/configure/keymaplist/KeymapSaveDialog.container.ts
+++ b/src/components/configure/keymaplist/KeymapSaveDialog.container.ts
@@ -19,23 +19,14 @@ export type KeymapSaveDialogStateType = ReturnType<typeof mapStateToProps>;
 
 const mapDispatchToProps = (_dispatch: any) => {
   return {
-    createSavedRegisteredKeymap: (keymapData: SavedKeymapData) => {
-      _dispatch(storageActionsThunk.createRegisteredKeymapData(keymapData));
+    createSavedKeymap: (keymapData: SavedKeymapData) => {
+      _dispatch(storageActionsThunk.createSavedKeymap(keymapData));
     },
-    updateSavedRegisteredKeymap: (keymapData: SavedKeymapData) => {
-      _dispatch(storageActionsThunk.updateRegisteredKeymapData(keymapData));
+    updateSavedKeymap: (keymapData: SavedKeymapData) => {
+      _dispatch(storageActionsThunk.updateSavedKeymap(keymapData));
     },
-    deleteSavedRegisteredKeymap: (keymapData: SavedKeymapData) => {
-      _dispatch(storageActionsThunk.deleteRegisteredKeymapData(keymapData));
-    },
-    createSavedUnregisteredKeymap: (keymapData: SavedKeymapData) => {
-      _dispatch(storageActionsThunk.createUnregisteredKeymapData(keymapData));
-    },
-    updateSavedUnregisteredKeymap: (keymapData: SavedKeymapData) => {
-      _dispatch(storageActionsThunk.updateUnregisteredKeymapData(keymapData));
-    },
-    deleteSavedUnregisteredKeymap: (keymapData: SavedKeymapData) => {
-      _dispatch(storageActionsThunk.deleteUnregisteredKeymapData(keymapData));
+    deleteSavedKeymap: (keymapData: SavedKeymapData) => {
+      _dispatch(storageActionsThunk.deleteSavedKeymap(keymapData));
     },
   };
 };

--- a/src/components/configure/keymaplist/KeymapSaveDialog.container.ts
+++ b/src/components/configure/keymaplist/KeymapSaveDialog.container.ts
@@ -2,7 +2,10 @@ import { connect } from 'react-redux';
 import KeymapSaveDialog from './KeymapSaveDialog';
 import { RootState } from '../../../store/state';
 import { storageActionsThunk } from '../../../actions/storage.action';
-import { ISavedKeymapData } from '../../../services/storage/Storage';
+import {
+  SavedRegisteredKeymapData,
+  SavedUnregisteredKeymapData,
+} from '../../../services/storage/Storage';
 
 const mapStateToProps = (state: RootState) => {
   return {
@@ -19,14 +22,29 @@ export type KeymapSaveDialogStateType = ReturnType<typeof mapStateToProps>;
 
 const mapDispatchToProps = (_dispatch: any) => {
   return {
-    createSavedKeymapData: (keymapData: ISavedKeymapData) => {
-      _dispatch(storageActionsThunk.createSavedKeymapData(keymapData));
+    createSavedRegisteredKeymap: (keymapData: SavedRegisteredKeymapData) => {
+      _dispatch(storageActionsThunk.createRegisteredKeymapData(keymapData));
     },
-    updateSavedKeymapData: (keymapData: ISavedKeymapData) => {
-      _dispatch(storageActionsThunk.updateSavedKeymapData(keymapData));
+    updateSavedRegisteredKeymap: (keymapData: SavedRegisteredKeymapData) => {
+      _dispatch(storageActionsThunk.updateRegisteredKeymapData(keymapData));
     },
-    deleteSavedKeymapData: (keymapData: ISavedKeymapData) => {
-      _dispatch(storageActionsThunk.deleteSavedKeymapData(keymapData));
+    deleteSavedRegisteredKeymap: (keymapData: SavedRegisteredKeymapData) => {
+      _dispatch(storageActionsThunk.deleteRegisteredKeymapData(keymapData));
+    },
+    createSavedUnregisteredKeymap: (
+      keymapData: SavedUnregisteredKeymapData
+    ) => {
+      _dispatch(storageActionsThunk.createUnregisteredKeymapData(keymapData));
+    },
+    updateSavedUnregisteredKeymap: (
+      keymapData: SavedUnregisteredKeymapData
+    ) => {
+      _dispatch(storageActionsThunk.updateUnregisteredKeymapData(keymapData));
+    },
+    deleteSavedUnregisteredKeymap: (
+      keymapData: SavedUnregisteredKeymapData
+    ) => {
+      _dispatch(storageActionsThunk.deleteUnregisteredKeymapData(keymapData));
     },
   };
 };

--- a/src/components/configure/keymaplist/KeymapSaveDialog.container.ts
+++ b/src/components/configure/keymaplist/KeymapSaveDialog.container.ts
@@ -2,10 +2,7 @@ import { connect } from 'react-redux';
 import KeymapSaveDialog from './KeymapSaveDialog';
 import { RootState } from '../../../store/state';
 import { storageActionsThunk } from '../../../actions/storage.action';
-import {
-  SavedRegisteredKeymapData,
-  SavedUnregisteredKeymapData,
-} from '../../../services/storage/Storage';
+import { SavedKeymapData } from '../../../services/storage/Storage';
 
 const mapStateToProps = (state: RootState) => {
   return {
@@ -22,28 +19,22 @@ export type KeymapSaveDialogStateType = ReturnType<typeof mapStateToProps>;
 
 const mapDispatchToProps = (_dispatch: any) => {
   return {
-    createSavedRegisteredKeymap: (keymapData: SavedRegisteredKeymapData) => {
+    createSavedRegisteredKeymap: (keymapData: SavedKeymapData) => {
       _dispatch(storageActionsThunk.createRegisteredKeymapData(keymapData));
     },
-    updateSavedRegisteredKeymap: (keymapData: SavedRegisteredKeymapData) => {
+    updateSavedRegisteredKeymap: (keymapData: SavedKeymapData) => {
       _dispatch(storageActionsThunk.updateRegisteredKeymapData(keymapData));
     },
-    deleteSavedRegisteredKeymap: (keymapData: SavedRegisteredKeymapData) => {
+    deleteSavedRegisteredKeymap: (keymapData: SavedKeymapData) => {
       _dispatch(storageActionsThunk.deleteRegisteredKeymapData(keymapData));
     },
-    createSavedUnregisteredKeymap: (
-      keymapData: SavedUnregisteredKeymapData
-    ) => {
+    createSavedUnregisteredKeymap: (keymapData: SavedKeymapData) => {
       _dispatch(storageActionsThunk.createUnregisteredKeymapData(keymapData));
     },
-    updateSavedUnregisteredKeymap: (
-      keymapData: SavedUnregisteredKeymapData
-    ) => {
+    updateSavedUnregisteredKeymap: (keymapData: SavedKeymapData) => {
       _dispatch(storageActionsThunk.updateUnregisteredKeymapData(keymapData));
     },
-    deleteSavedUnregisteredKeymap: (
-      keymapData: SavedUnregisteredKeymapData
-    ) => {
+    deleteSavedUnregisteredKeymap: (keymapData: SavedKeymapData) => {
       _dispatch(storageActionsThunk.deleteUnregisteredKeymapData(keymapData));
     },
   };

--- a/src/components/configure/keymaplist/KeymapSaveDialog.scss
+++ b/src/components/configure/keymaplist/KeymapSaveDialog.scss
@@ -1,0 +1,30 @@
+@import '../../../variables';
+
+.keymap-save-dialog {
+  .close-dialog {
+    position: absolute;
+    top: 20px;
+    right: 20px;
+
+    &:hover {
+      color: $primary-light;
+      cursor: pointer;
+    }
+  }
+
+  .keymap-save-content {
+    width: 540px;
+    display: flex;
+    flex-direction: column;
+    .keymap-save-textfield {
+      margin-bottom: $space-l;
+    }
+  }
+  .keymap-save-footer {
+    display: flex;
+    flex-direction: row;
+    .keymap-save-savebtn {
+      margin-left: auto;
+    }
+  }
+}

--- a/src/components/configure/keymaplist/KeymapSaveDialog.scss
+++ b/src/components/configure/keymaplist/KeymapSaveDialog.scss
@@ -17,7 +17,14 @@
     display: flex;
     flex-direction: column;
     .keymap-save-textfield {
-      margin-bottom: $space-l;
+    }
+    .keymap-save-text-counter {
+      text-align: right;
+      color: $color-gray-600;
+      margin-right: 8px;
+      margin-bottom: $space-m;
+      top: -20px;
+      position: relative;
     }
   }
   .keymap-save-footer {

--- a/src/components/configure/keymaplist/KeymapSaveDialog.tsx
+++ b/src/components/configure/keymaplist/KeymapSaveDialog.tsx
@@ -1,0 +1,197 @@
+/* eslint-disable no-undef */
+import React from 'react';
+import './KeymapSaveDialog.scss';
+import {
+  Button,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogTitle,
+  Paper,
+  PaperProps,
+  TextField,
+} from '@material-ui/core';
+
+import Draggable from 'react-draggable';
+import CloseIcon from '@material-ui/icons/Close';
+import {
+  KeymapSaveDialogActionsType,
+  KeymapSaveDialogStateType,
+} from './KeymapSaveDialog.container';
+import { IKeymap } from '../../../services/hid/Hid';
+import Keymap from '../keymap/Keymap';
+import { KeyboardLabelLang } from '../../../services/labellang/KeyLabelLangs';
+
+type StoreKeymapData = {
+  labelLang: KeyboardLabelLang;
+  layoutOptions: { option: string; optionChoice: string }[] | undefined;
+  keycodes: { [pos: string]: number }[];
+};
+
+type StoreKeymap = {
+  id?: string;
+  title: string;
+  desc: string;
+  data: StoreKeymapData;
+};
+
+type OwnProps = {
+  open: boolean;
+  edit: boolean;
+  id?: string;
+  title?: string;
+  desc?: string;
+  onClose: () => void;
+  // eslint-disable-next-line no-unused-vars
+  onSave: (store: StoreKeymap) => void;
+  // eslint-disable-next-line no-unused-vars
+  onDelete: (id: string) => void;
+};
+
+type KeymapSaveDialogProps = OwnProps &
+  Partial<KeymapSaveDialogActionsType> &
+  Partial<KeymapSaveDialogStateType>;
+
+type OwnState = {
+  title: string;
+  desc: string;
+};
+export default class LayoutOptionPopover extends React.Component<
+  KeymapSaveDialogProps,
+  OwnState
+> {
+  constructor(props: OwnProps | Readonly<OwnProps>) {
+    super(props);
+    this.state = {
+      title: this.props.title || '',
+      desc: this.props.desc || '',
+    };
+  }
+
+  private onEnter() {
+    this.setState({
+      title: this.props.title || '',
+      desc: this.props.desc || '',
+    });
+  }
+
+  private buildCurrentKeymapData(): StoreKeymapData {
+    const keymaps: { [pos: string]: IKeymap }[] = this.props.keymaps!;
+    const keycodes: { [pos: string]: number }[] = [];
+    for (let i = 0; i < this.props.layerCount!; i++) {
+      const keyMap: { [pos: string]: number } = {};
+      const km = keymaps[i];
+      Object.keys(km).forEach((pos) => {
+        keyMap[pos] = km[pos].code;
+      });
+      keycodes.push(keyMap);
+    }
+    const { productName } = this.props.keyboard!.getInformation();
+    // eslint-disable-next-line no-unused-vars
+    const name = productName.trim().replace(/\s/g, '_').toLocaleLowerCase();
+    const labelLang: KeyboardLabelLang = this.props.labelLang!;
+    const layoutOptions = Keymap.buildLayerOptions(
+      this.props.selectedLayoutOptions!,
+      this.props.layoutLabels!
+    );
+
+    const json: StoreKeymapData = {
+      labelLang,
+      layoutOptions,
+      keycodes,
+    };
+    return json;
+  }
+
+  private onClickDeleteButton() {
+    this.props.onDelete(this.props.id!);
+  }
+
+  private onClickSaveButton() {
+    const data = this.buildCurrentKeymapData();
+    const save: StoreKeymap = {
+      id: this.props.id || '',
+      title: this.state.title,
+      desc: this.state.desc,
+      data,
+    };
+    this.props.onSave(save);
+  }
+
+  render() {
+    return (
+      <Dialog
+        open={this.props.open}
+        maxWidth={'md'}
+        PaperComponent={PaperComponent}
+        className="keymap-save-dialog"
+        onEnter={this.onEnter.bind(this)}
+      >
+        <DialogTitle id="draggable-dialog-title" style={{ cursor: 'move' }}>
+          {this.props.edit ? 'Edit saved keymap' : 'Save a new keymap'}
+          <div className="close-dialog">
+            <CloseIcon onClick={this.props.onClose} />
+          </div>
+        </DialogTitle>
+        <DialogContent dividers className="keymap-save-content">
+          <TextField
+            required
+            autoFocus
+            label="Title"
+            variant="outlined"
+            value={this.state.title}
+            onChange={(event) => {
+              this.setState({ title: event.target.value });
+            }}
+            className="keymap-save-textfield"
+          />
+          <TextField
+            label="Description"
+            variant="outlined"
+            value={this.state.desc}
+            onChange={(event) => {
+              this.setState({ desc: event.target.value });
+            }}
+            multiline
+            rows={2}
+            className="keymap-save-textfield"
+          />
+        </DialogContent>
+        <DialogActions className="keymap-save-footer">
+          {this.props.edit && (
+            <Button
+              onClick={() => {
+                this.onClickDeleteButton();
+              }}
+              color="secondary"
+            >
+              Delete
+            </Button>
+          )}
+          <Button
+            disabled={this.state.title.replace(/\s/g, '').length === 0}
+            onClick={() => {
+              this.onClickSaveButton();
+            }}
+            color="primary"
+            variant="contained"
+            className="keymap-save-savebtn"
+          >
+            Save
+          </Button>
+        </DialogActions>
+      </Dialog>
+    );
+  }
+}
+
+function PaperComponent(props: PaperProps) {
+  return (
+    <Draggable
+      handle="#draggable-dialog-title"
+      cancel={'[class*="MuiDialogContent-root"]'}
+    >
+      <Paper {...props} />
+    </Draggable>
+  );
+}

--- a/src/components/configure/keymaplist/KeymapSaveDialog.tsx
+++ b/src/components/configure/keymaplist/KeymapSaveDialog.tsx
@@ -21,9 +21,7 @@ import {
 import { IKeymap } from '../../../services/hid/Hid';
 import { KeyboardLabelLang } from '../../../services/labellang/KeyLabelLangs';
 import {
-  SavedRegisteredKeymapData,
   isSavedRegisteredKeymapData,
-  SavedUnregisteredKeymapData,
   SavedKeymapData,
 } from '../../../services/storage/Storage';
 
@@ -86,13 +84,9 @@ export default class LayoutOptionPopover extends React.Component<
   private onClickDeleteButton() {
     if (this.props.savedKeymapData) {
       if (isSavedRegisteredKeymapData(this.props.savedKeymapData)) {
-        this.props.deleteSavedRegisteredKeymap!(
-          this.props.savedKeymapData as SavedRegisteredKeymapData
-        );
+        this.props.deleteSavedRegisteredKeymap!(this.props.savedKeymapData);
       } else {
-        this.props.deleteSavedUnregisteredKeymap!(
-          this.props.savedKeymapData as SavedUnregisteredKeymapData
-        );
+        this.props.deleteSavedUnregisteredKeymap!(this.props.savedKeymapData);
       }
       this.props.onClose();
     }
@@ -107,13 +101,9 @@ export default class LayoutOptionPopover extends React.Component<
       };
 
       if (isSavedRegisteredKeymapData(save)) {
-        this.props.updateSavedRegisteredKeymap!(
-          save as SavedRegisteredKeymapData
-        );
+        this.props.updateSavedRegisteredKeymap!(save);
       } else {
-        this.props.updateSavedUnregisteredKeymap!(
-          save as SavedUnregisteredKeymapData
-        );
+        this.props.updateSavedUnregisteredKeymap!(save);
       }
     } else {
       this.createSavedKeymap();
@@ -127,7 +117,7 @@ export default class LayoutOptionPopover extends React.Component<
       [pos: string]: number;
     }[] = this.buildCurrentKeymapKeycodes();
 
-    const keymapData: SavedKeymapData = {
+    const data = {
       author_uid: this.props.authorUid,
       title: this.state.title,
       desc: this.state.desc,
@@ -136,16 +126,19 @@ export default class LayoutOptionPopover extends React.Component<
       keycodes,
     };
     if (this.props.keyboardDefinitionDocument) {
-      const save: SavedRegisteredKeymapData = {
-        ...keymapData,
-        definition_id: this.props.keyboardDefinitionDocument.id,
+      const doc = this.props.keyboardDefinitionDocument;
+      const save: SavedKeymapData = {
+        ...data,
+        definition_id: doc.id,
+        vendor_id: doc.vendorId,
+        product_id: doc.productId,
+        product_name: doc.productName,
       };
-
       this.props.createSavedRegisteredKeymap!(save);
     } else {
       const info = this.props.keyboard!.getInformation();
-      const save: SavedUnregisteredKeymapData = {
-        ...keymapData,
+      const save: SavedKeymapData = {
+        ...data,
         vendor_id: info.vendorId,
         product_id: info.productId,
         product_name: info.productName,

--- a/src/components/configure/keymaplist/KeymapSaveDialog.tsx
+++ b/src/components/configure/keymaplist/KeymapSaveDialog.tsx
@@ -120,14 +120,14 @@ export default class LayoutOptionPopover extends React.Component<
 
     const savedKeymap: SavedKeymapData = {
       status: 'private',
-      vendorId: info.vendorId,
-      productId: info.productId,
-      productName: info.productName,
-      authorUid: this.props.authorUid,
+      vendor_id: info.vendorId,
+      product_id: info.productId,
+      product_name: info.productName,
+      author_uid: this.props.authorUid,
       title: this.state.title,
       desc: this.state.desc,
-      labelLang: labelLang,
-      layoutOptions: this.props.selectedLayoutOptions!,
+      label_lang: labelLang,
+      layout_options: this.props.selectedLayoutOptions!,
       keycodes,
     };
     this.props.createSavedKeymap!(savedKeymap);

--- a/src/components/configure/keymaplist/KeymapSaveDialog.tsx
+++ b/src/components/configure/keymaplist/KeymapSaveDialog.tsx
@@ -20,7 +20,10 @@ import {
 } from './KeymapSaveDialog.container';
 import { IKeymap } from '../../../services/hid/Hid';
 import { KeyboardLabelLang } from '../../../services/labellang/KeyLabelLangs';
-import { SavedKeymapData } from '../../../services/storage/Storage';
+import {
+  isApprovedKeyboard,
+  SavedKeymapData,
+} from '../../../services/storage/Storage';
 
 const MAX_TITLE_TEXT_COUNT = 52;
 const MAX_DESC_TEXT_COUNT = 200;
@@ -106,14 +109,11 @@ export default class LayoutOptionPopover extends React.Component<
     }[] = this.buildCurrentKeymapKeycodes();
 
     let info: { vendorId: number; productId: number; productName: string };
-    if (
-      this.props.keyboardDefinitionDocument &&
-      this.props.keyboardDefinitionDocument.status == 'approved'
-    ) {
+    if (isApprovedKeyboard(this.props.keyboardDefinitionDocument)) {
       /**
        * Only approved keyboard definition is trusted uniquness data(vendor_id/product_id/product_name)
        */
-      info = this.props.keyboardDefinitionDocument;
+      info = this.props.keyboardDefinitionDocument!;
     } else {
       info = this.props.keyboard!.getInformation();
     }

--- a/src/components/configure/keymaplist/KeymapSaveDialog.tsx
+++ b/src/components/configure/keymaplist/KeymapSaveDialog.tsx
@@ -120,14 +120,14 @@ export default class LayoutOptionPopover extends React.Component<
 
     const savedKeymap: SavedKeymapData = {
       status: 'private',
-      vendor_id: info.vendorId,
-      product_id: info.productId,
-      product_name: info.productName,
-      author_uid: this.props.authorUid,
+      vendorId: info.vendorId,
+      productId: info.productId,
+      productName: info.productName,
+      authorUid: this.props.authorUid,
       title: this.state.title,
       desc: this.state.desc,
-      label_lang: labelLang,
-      layout_options: this.props.selectedLayoutOptions!,
+      labelLang: labelLang,
+      layoutOptions: this.props.selectedLayoutOptions!,
       keycodes,
     };
     this.props.createSavedKeymap!(savedKeymap);

--- a/src/components/configure/keymaplist/KeymapSaveDialog.tsx
+++ b/src/components/configure/keymaplist/KeymapSaveDialog.tsx
@@ -106,7 +106,13 @@ export default class LayoutOptionPopover extends React.Component<
     }[] = this.buildCurrentKeymapKeycodes();
 
     let info: { vendorId: number; productId: number; productName: string };
-    if (this.props.keyboardDefinitionDocument) {
+    if (
+      this.props.keyboardDefinitionDocument &&
+      this.props.keyboardDefinitionDocument.status == 'approved'
+    ) {
+      /**
+       * Only approved keyboard definition is trusted uniquness data(vendor_id/product_id/product_name)
+       */
       info = this.props.keyboardDefinitionDocument;
     } else {
       info = this.props.keyboard!.getInformation();

--- a/src/components/configure/keymaplist/KeymapSaveDialog.tsx
+++ b/src/components/configure/keymaplist/KeymapSaveDialog.tsx
@@ -27,6 +27,9 @@ import {
   SavedKeymapData,
 } from '../../../services/storage/Storage';
 
+const MAX_TITLE_TEXT_COUNT = 52;
+const MAX_DESC_TEXT_COUNT = 200;
+
 type OwnProps = {
   open: boolean;
   savedKeymapData: SavedKeymapData | null;
@@ -174,21 +177,31 @@ export default class LayoutOptionPopover extends React.Component<
             variant="outlined"
             value={this.state.title}
             onChange={(event) => {
-              this.setState({ title: event.target.value });
+              this.setState({
+                title: event.target.value.slice(0, MAX_TITLE_TEXT_COUNT),
+              });
             }}
             className="keymap-save-textfield"
           />
+          <div className="keymap-save-text-counter">
+            {`${this.state.title.length}/${MAX_TITLE_TEXT_COUNT}`}
+          </div>
           <TextField
             label="Description"
             variant="outlined"
             value={this.state.desc}
             onChange={(event) => {
-              this.setState({ desc: event.target.value });
+              this.setState({
+                desc: event.target.value.slice(0, MAX_DESC_TEXT_COUNT),
+              });
             }}
             multiline
             rows={2}
             className="keymap-save-textfield"
           />
+          <div className="keymap-save-text-counter">
+            {`${this.state.desc.length}/${MAX_DESC_TEXT_COUNT}`}
+          </div>
         </DialogContent>
         <DialogActions className="keymap-save-footer">
           {this.isEdit && (

--- a/src/components/configure/layoutoption/LayoutOptionPopover.container.ts
+++ b/src/components/configure/layoutoption/LayoutOptionPopover.container.ts
@@ -13,8 +13,10 @@ export type LayoutOptionPopoverStateType = ReturnType<typeof mapStateToProps>;
 
 const mapDispatchToProps = (_dispatch: any) => {
   return {
-    setLayoutOption: (optionIndex: number, option: string | null) => {
-      _dispatch(LayoutOptionsActions.updateSelectedOption(optionIndex, option));
+    setLayoutOption: (option: number, optionChoice: number) => {
+      _dispatch(
+        LayoutOptionsActions.updateSelectedOption(option, optionChoice)
+      );
     },
   };
 };

--- a/src/components/configure/layoutoption/LayoutOptionPopover.tsx
+++ b/src/components/configure/layoutoption/LayoutOptionPopover.tsx
@@ -52,7 +52,13 @@ export default class LayoutOptionPopover extends React.Component<
     return { left: left, top: y };
   }
 
-  private onEnter() {}
+  private getSelectedOptionChoice(option: number): number {
+    const layoutOption = this.props.selectedLayoutOptions!.find((options) => {
+      return options.option === option;
+    });
+
+    return layoutOption ? layoutOption.optionChoice : 0;
+  }
 
   render() {
     if (
@@ -69,7 +75,6 @@ export default class LayoutOptionPopover extends React.Component<
         open={this.props.open}
         anchorReference="anchorPosition"
         anchorPosition={this.position}
-        onEnter={this.onEnter.bind(this)}
         onClose={() => {
           this.props.onClose();
         }}
@@ -87,16 +92,29 @@ export default class LayoutOptionPopover extends React.Component<
           </Grid>
           <Grid container spacing={1} className="layout-option-content">
             {labels.map((options, index) => {
-              return (
-                <OptionRowComponent
-                  key={index}
-                  options={options}
-                  selectedOption={this.props.selectedLayoutOptions![index]}
-                  onChange={(choice: string | null) => {
-                    this.props.setLayoutOption!(index, choice);
-                  }}
-                />
-              );
+              if (typeof options == 'string') {
+                return (
+                  <OptionRowSwitchComponent
+                    key={`layout-option-row${index}`}
+                    optionLabel={options}
+                    selectedOptionChoice={this.getSelectedOptionChoice(index)}
+                    onChange={(choice: number) => {
+                      this.props.setLayoutOption!(index, choice);
+                    }}
+                  />
+                );
+              } else {
+                return (
+                  <OptionRowSelectComponent
+                    key={`layout-option-row${index}`}
+                    optionLabels={options}
+                    selectedOptionChoice={this.getSelectedOptionChoice(index)}
+                    onChange={(choice: number) => {
+                      this.props.setLayoutOption!(index, choice);
+                    }}
+                  />
+                );
+              }
             })}
           </Grid>
         </div>
@@ -105,53 +123,58 @@ export default class LayoutOptionPopover extends React.Component<
   }
 }
 
-type OptionRowType = {
-  options: string | string[];
-  selectedOption: string | null;
+type OptionRowSwitchType = {
+  optionLabel: string;
+  selectedOptionChoice: number;
   // eslint-disable-next-line no-unused-vars
-  onChange: (value: string | null) => void;
+  onChange: (optionChoice: number) => void;
 };
-function OptionRowComponent(props: OptionRowType) {
-  if (typeof props.options == 'string') {
-    const option: string = props.options;
-    return (
-      <React.Fragment>
-        <Grid item xs={8} className="option-label">
-          {props.options}
-        </Grid>
-        <Grid item xs={4} className="option-value">
-          <Switch
-            checked={!!props.selectedOption}
-            onChange={(e) => {
-              props.onChange(e.target.checked ? option : null);
-            }}
-            color="primary"
-            name="checkedB"
-            inputProps={{ 'aria-label': 'primary checkbox' }}
-          />
-        </Grid>
-      </React.Fragment>
-    );
-  }
-
-  const label = props.options[0];
-  const choices: string[] = props.options.slice(1);
+function OptionRowSwitchComponent(props: OptionRowSwitchType) {
   return (
     <React.Fragment>
       <Grid item xs={8} className="option-label">
-        {props.options[0]}
+        {props.optionLabel}
+      </Grid>
+      <Grid item xs={4} className="option-value">
+        <Switch
+          checked={props.selectedOptionChoice === 1}
+          onChange={(e) => {
+            props.onChange(e.target.checked ? 1 : 0);
+          }}
+          color="primary"
+          name="checkedB"
+          inputProps={{ 'aria-label': 'primary checkbox' }}
+        />
+      </Grid>
+    </React.Fragment>
+  );
+}
+
+type OptionRowSelectType = {
+  optionLabels: string[];
+  selectedOptionChoice: number;
+  // eslint-disable-next-line no-unused-vars
+  onChange: (optionChoice: number) => void;
+};
+function OptionRowSelectComponent(props: OptionRowSelectType) {
+  const label = props.optionLabels[0];
+  const choices: string[] = props.optionLabels.slice(1);
+  return (
+    <React.Fragment>
+      <Grid item xs={8} className="option-label">
+        {label}
       </Grid>
       <Grid item xs={4} className="option-value">
         <Select
-          value={props.selectedOption}
+          value={props.selectedOptionChoice}
           onChange={(e) => {
-            props.onChange(e.target.value as string);
+            props.onChange(Number(e.target.value));
           }}
           className="option-value-select"
         >
           {choices.map((choice, index) => {
             return (
-              <MenuItem key={`${label}${index}`} value={choice}>
+              <MenuItem key={`${label}${index}`} value={index}>
                 {choice}
               </MenuItem>
             );

--- a/src/components/keyboards/header/Header.tsx
+++ b/src/components/keyboards/header/Header.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable no-undef */
 import React from 'react';
 import './Header.scss';
 import { HeaderActionsType, HeaderStateType } from './Header.container';

--- a/src/models/KeyboardModel.ts
+++ b/src/models/KeyboardModel.ts
@@ -1,6 +1,7 @@
 import { KeyOp } from '../gen/types/KeyboardDefinition';
 import KeyModel, { OPTION_DEFAULT } from './KeyModel';
 import { hasProperty } from '../utils/ObjectUtils';
+import { LayoutOption } from '../components/configure/keymap/Keymap';
 
 class Current {
   x = 0;
@@ -169,7 +170,7 @@ export default class KeyboardModel {
   }
 
   getKeymap(
-    options?: { option: string; optionChoice: string }[]
+    options?: LayoutOption[]
   ): { keymaps: KeyModel[]; width: number; height: number; left: number } {
     let keymaps = this._keyModels;
     if (options) {
@@ -179,7 +180,8 @@ export default class KeyboardModel {
           0 <=
             options.findIndex(
               (op) =>
-                op.option == item.option && op.optionChoice == item.optionChoice
+                op.option == Number(item.option) &&
+                op.optionChoice == Number(item.optionChoice)
             )
         );
       });

--- a/src/services/pdf/KeymapPdfGenerator.ts
+++ b/src/services/pdf/KeymapPdfGenerator.ts
@@ -18,6 +18,7 @@ import { buildModLabel } from '../../components/configure/customkey/Modifiers';
 import { isDoubleWidthString } from '../../utils/StringUtils';
 import { Key } from '../../components/configure/keycodekey/KeyGen';
 import { KeyboardLabelLang, KeyLabelLangs } from '../labellang/KeyLabelLangs';
+import { LayoutOption } from '../../components/configure/keymap/Keymap';
 
 type KeymapType = ((string | KeyOp)[] | { name: string })[];
 export class KeymapPdfGenerator {
@@ -55,10 +56,7 @@ export class KeymapPdfGenerator {
     this.labelLang = labelLang;
   }
 
-  async genPdf(
-    name: string,
-    options?: { option: string; optionChoice: string }[]
-  ) {
+  async genPdf(name: string, options?: LayoutOption[]) {
     const { keymaps, width, height, left } = this.model.getKeymap(options);
     const keyboardHeight = height + this.kbdR * 2;
 

--- a/src/services/provider/Firebase.ts
+++ b/src/services/provider/Firebase.ts
@@ -16,8 +16,6 @@ import {
 import { IAuth, IAuthenticationResult } from '../auth/Auth';
 import { IFirmwareCodePlace } from '../../store/state';
 import { IDeviceInformation } from '../hid/Hid';
-import { KeyboardLabelLang } from '../labellang/KeyLabelLangs';
-import { LayoutOption } from '../../components/configure/keymap/Keymap';
 
 const config = {
   apiKey: process.env.REACT_APP_FIREBASE_API_KEY,

--- a/src/services/provider/Firebase.ts
+++ b/src/services/provider/Firebase.ts
@@ -8,6 +8,8 @@ import {
   IFetchMyKeyboardDefinitionDocumentsResult,
   IKeyboardDefinitionDocument,
   IKeyboardDefinitionStatus,
+  ISavedKeymapData,
+  IKeymapDataResule,
   IResult,
   IStorage,
 } from '../storage/Storage';
@@ -499,5 +501,34 @@ export class FirebaseProvider implements IStorage, IAuth {
 
   async signOut(): Promise<void> {
     await this.auth.signOut();
+  }
+
+  async fetchMySavedKeymapDataList(
+    authorUid: string,
+    vendorId: number,
+    productId: number,
+    productName: string
+  ): Promise<IKeymapDataResule> {
+    console.log(`${authorUid},${vendorId},${productId},${productName}`);
+    const keymap: ISavedKeymapData = {
+      id: 'hoge',
+      title: 'title',
+      desc: 'desc',
+      data: { labelLang: 'ja-jp', layoutOptions: undefined, keycodes: [] },
+    };
+
+    return { success: true, keymaps: [keymap] };
+  }
+
+  async createMySavedKeymapData(
+    authorUid: string,
+    vendorId: number,
+    productId: number,
+    productName: string,
+    keymap: ISavedKeymapData
+  ): Promise<IResult> {
+    console.log(`${authorUid},${vendorId},${productId},${productName}`);
+    console.log(keymap);
+    return { success: true };
   }
 }

--- a/src/services/provider/Firebase.ts
+++ b/src/services/provider/Firebase.ts
@@ -529,9 +529,10 @@ export class FirebaseProvider implements IStorage, IAuth {
       /**
        * The device's ProductName might be different by using OS.
        * This is the WebHID bug.
+       * https://bugs.chromium.org/p/chromium/issues/detail?id=1167093
        *
        * The ProductName is defined text by #PRODUCT in config.h/info.h.
-       * However with Windows, the ProductName is a combination of defined text with #MANUFACTURER and #PRODUCT.
+       * However with Linux, the ProductName is a combination of defined text with #MANUFACTURER and #PRODUCT.
        *
        * ex)
        * Lunakey Mini (macOS, Windows)
@@ -569,7 +570,6 @@ export class FirebaseProvider implements IStorage, IAuth {
 
       return { success: true };
     } catch (error) {
-      console.error(error);
       return {
         success: false,
         error: 'Creating a new Keymap failed.',
@@ -595,7 +595,6 @@ export class FirebaseProvider implements IStorage, IAuth {
 
       return { success: true };
     } catch (error) {
-      console.error(error);
       return {
         success: false,
         error: 'Updating a new Keymap failed.',
@@ -615,7 +614,6 @@ export class FirebaseProvider implements IStorage, IAuth {
 
       return { success: true };
     } catch (error) {
-      console.error(error);
       return {
         success: false,
         error: 'Deleting a new Keymap failed.',

--- a/src/services/provider/Firebase.ts
+++ b/src/services/provider/Firebase.ts
@@ -16,6 +16,8 @@ import {
 import { IAuth, IAuthenticationResult } from '../auth/Auth';
 import { IFirmwareCodePlace } from '../../store/state';
 import { IDeviceInformation } from '../hid/Hid';
+import { KeyboardLabelLang } from '../labellang/KeyLabelLangs';
+import { LayoutOption } from '../../components/configure/keymap/Keymap';
 
 const config = {
   apiKey: process.env.REACT_APP_FIREBASE_API_KEY,
@@ -523,8 +525,22 @@ export class FirebaseProvider implements IStorage, IAuth {
     const deviceProductName = info.productName;
     const keymaps: SavedKeymapData[] = [];
     snapshot.docs.forEach((doc) => {
-      const data: SavedKeymapData = doc.data() as SavedKeymapData;
-      const savedProductName = data.product_name;
+      const data: SavedKeymapData = {
+        id: doc.id,
+        status: doc.data().status,
+        authorUid: doc.data().author_uid, //  auth.uid
+        vendorId: doc.data().vendor_id, // Definition.vendorId if registered, otherwise DeviceInformation.vendorId
+        productId: doc.data().product_id, // Definition.productId if registered, otherwise DeviceInformation.productId
+        productName: doc.data().product_name, // Definition.productName if registered, otherwise DeviceInformation.productName
+        title: doc.data().title,
+        desc: doc.data().desc,
+        labelLang: doc.data().label_lang,
+        layoutOptions: doc.data().layout_options,
+        keycodes: doc.data().keycodes,
+        createdAt: doc.data().created_at,
+        updatedAt: doc.data().updated_at,
+      };
+      const savedProductName = data.productName;
 
       /**
        * The device's ProductName might be different by using OS.
@@ -544,7 +560,6 @@ export class FirebaseProvider implements IStorage, IAuth {
         deviceProductName.endsWith(savedProductName) ||
         savedProductName.endsWith(deviceProductName)
       ) {
-        data.id = doc.id;
         keymaps.push(data);
       }
     });
@@ -563,7 +578,16 @@ export class FirebaseProvider implements IStorage, IAuth {
         .doc('v1')
         .collection('saved-keymaps')
         .add({
-          ...keymapData,
+          status: keymapData.status,
+          author_uid: keymapData.authorUid, //  auth.uid
+          vendor_id: keymapData.vendorId, // Definition.vendorId if registered, otherwise DeviceInformation.vendorId
+          product_id: keymapData.productId, // Definition.productId if registered, otherwise DeviceInformation.productId
+          product_name: keymapData.productName, // Definition.productName if registered, otherwise DeviceInformation.productName
+          title: keymapData.title,
+          desc: keymapData.desc,
+          label_lang: keymapData.labelLang,
+          layout_options: keymapData.layoutOptions,
+          keycodes: keymapData.keycodes,
           created_at: now,
           updated_at: now,
         });

--- a/src/services/provider/Firebase.ts
+++ b/src/services/provider/Firebase.ts
@@ -525,20 +525,9 @@ export class FirebaseProvider implements IStorage, IAuth {
     snapshot.docs.forEach((doc) => {
       const data: SavedKeymapData = {
         id: doc.id,
-        status: doc.data().status,
-        authorUid: doc.data().author_uid, //  auth.uid
-        vendorId: doc.data().vendor_id, // Definition.vendorId if registered, otherwise DeviceInformation.vendorId
-        productId: doc.data().product_id, // Definition.productId if registered, otherwise DeviceInformation.productId
-        productName: doc.data().product_name, // Definition.productName if registered, otherwise DeviceInformation.productName
-        title: doc.data().title,
-        desc: doc.data().desc,
-        labelLang: doc.data().label_lang,
-        layoutOptions: doc.data().layout_options,
-        keycodes: doc.data().keycodes,
-        createdAt: doc.data().created_at,
-        updatedAt: doc.data().updated_at,
+        ...(doc.data() as SavedKeymapData),
       };
-      const savedProductName = data.productName;
+      const savedProductName = data.product_name;
 
       /**
        * The device's ProductName might be different by using OS.
@@ -576,16 +565,7 @@ export class FirebaseProvider implements IStorage, IAuth {
         .doc('v1')
         .collection('saved-keymaps')
         .add({
-          status: keymapData.status,
-          author_uid: keymapData.authorUid, //  auth.uid
-          vendor_id: keymapData.vendorId, // Definition.vendorId if registered, otherwise DeviceInformation.vendorId
-          product_id: keymapData.productId, // Definition.productId if registered, otherwise DeviceInformation.productId
-          product_name: keymapData.productName, // Definition.productName if registered, otherwise DeviceInformation.productName
-          title: keymapData.title,
-          desc: keymapData.desc,
-          label_lang: keymapData.labelLang,
-          layout_options: keymapData.layoutOptions,
-          keycodes: keymapData.keycodes,
+          ...keymapData,
           created_at: now,
           updated_at: now,
         });

--- a/src/services/storage/Storage.ts
+++ b/src/services/storage/Storage.ts
@@ -1,4 +1,5 @@
 import { IFirmwareCodePlace } from '../../store/state';
+import { KeyboardLabelLang } from '../labellang/KeyLabelLangs';
 
 export interface IResult {
   readonly success: boolean;
@@ -43,6 +44,19 @@ export interface IKeyboardDefinitionDocument {
   readonly updatedAt: Date;
 }
 
+export type IKeycodeData = {
+  labelLang: KeyboardLabelLang;
+  layoutOptions: { option: string; optionChoice: string }[] | undefined;
+  keycodes: { [pos: string]: number }[];
+};
+
+export interface ISavedKeymapData {
+  id: string;
+  title: string;
+  desc: string;
+  data: IKeycodeData;
+}
+
 export interface IExistsResult extends IResult {
   exists?: boolean;
 }
@@ -57,6 +71,10 @@ export interface IFetchMyKeyboardDefinitionDocumentsResult extends IResult {
 
 export interface ICreateKeyboardDefinitionDocumentResult extends IResult {
   definitionId?: string;
+}
+
+export interface IKeymapDataResule extends IResult {
+  keymaps: ISavedKeymapData[];
 }
 
 /* eslint-disable no-unused-vars */
@@ -111,5 +129,20 @@ export interface IStorage {
     jsonStr: string
   ): Promise<IResult>;
   deleteKeyboardDefinitionDocument(definitionId: string): Promise<IResult>;
+
+  fetchMySavedKeymapDataList(
+    authorUid: string,
+    vendorId: number,
+    productId: number,
+    productName: string
+  ): Promise<IKeymapDataResule>;
+
+  createMySavedKeymapData(
+    authorUid: string,
+    vendorId: number,
+    productId: number,
+    productName: string,
+    keymap: ISavedKeymapData
+  ): Promise<IResult>;
 }
 /* eslint-enable no-unused-vars */

--- a/src/services/storage/Storage.ts
+++ b/src/services/storage/Storage.ts
@@ -1,4 +1,6 @@
+import { LayoutOption } from '../../components/configure/keymap/Keymap';
 import { IFirmwareCodePlace } from '../../store/state';
+import { IDeviceInformation } from '../hid/Hid';
 import { KeyboardLabelLang } from '../labellang/KeyLabelLangs';
 
 export interface IResult {
@@ -20,6 +22,8 @@ export const KeyboardDefinitionStatus: {
   rejected: 'rejected',
   approved: 'approved',
 };
+
+export type SavedKeymapCollection = 'registereds' | 'unregistereds';
 
 export interface IKeyboardDefinitionDocument {
   readonly id: string;
@@ -44,18 +48,33 @@ export interface IKeyboardDefinitionDocument {
   readonly updatedAt: Date;
 }
 
-export type ISavedKeymapData = {
+export type SavedKeymapData = {
   id?: string; // this entity's id
   author_uid: string; //  auth.uid
-  definition_id: string; // /keyboards/v2/definitions/{ID}
   title: string;
   desc: string;
   label_lang: KeyboardLabelLang;
-  layout_options: { option: string; optionChoice: string }[] | null;
+  layout_options: LayoutOption[];
   keycodes: { [pos: string]: number }[];
   created_at?: Date;
   updated_at?: Date;
 };
+
+export type SavedRegisteredKeymapData = {
+  definition_id: string; // /keyboards/v2/definitions/{ID}
+} & SavedKeymapData;
+
+export type SavedUnregisteredKeymapData = {
+  vendor_id: number;
+  product_id: number;
+  product_name: string;
+} & SavedKeymapData;
+
+export function isSavedRegisteredKeymapData(
+  arg: any
+): arg is SavedRegisteredKeymapData {
+  return arg.definition_id != undefined;
+}
 
 export interface IExistsResult extends IResult {
   exists?: boolean;
@@ -73,8 +92,8 @@ export interface ICreateKeyboardDefinitionDocumentResult extends IResult {
   definitionId?: string;
 }
 
-export interface IKeymapDataResule extends IResult {
-  savedKeymapDataList: ISavedKeymapData[];
+export interface ISavedKeymapResule extends IResult {
+  savedKeymaps: SavedRegisteredKeymapData[] | SavedUnregisteredKeymapData[];
 }
 
 /* eslint-disable no-unused-vars */
@@ -130,9 +149,24 @@ export interface IStorage {
   ): Promise<IResult>;
   deleteKeyboardDefinitionDocument(definitionId: string): Promise<IResult>;
 
-  fetchSavedKeymapDataList(definitionId: string): Promise<IKeymapDataResule>;
-  createSavedKeymapData(keymapData: ISavedKeymapData): Promise<IResult>;
-  updateSavedKeymapData(keymapData: ISavedKeymapData): Promise<IResult>;
-  deleteSavedKeymapData(savedKeymapId: string): Promise<IResult>;
+  fetchSavedRegisteredKeymaps(
+    definitionId: string
+  ): Promise<ISavedKeymapResule>;
+  createSavedKeymap(
+    keymapData: SavedKeymapData,
+    targetCollection: SavedKeymapCollection
+  ): Promise<IResult>;
+  updateSavedKeymap(
+    keymapData: SavedKeymapData,
+    targetCollection: SavedKeymapCollection
+  ): Promise<IResult>;
+  deleteSavedKeymap(
+    savedKeymapId: string,
+    targetCollection: SavedKeymapCollection
+  ): Promise<IResult>;
+
+  fetchUnregisteredKeymaps(
+    info: IDeviceInformation
+  ): Promise<ISavedKeymapResule>;
 }
 /* eslint-enable no-unused-vars */

--- a/src/services/storage/Storage.ts
+++ b/src/services/storage/Storage.ts
@@ -23,8 +23,6 @@ export const KeyboardDefinitionStatus: {
   approved: 'approved',
 };
 
-export type SavedKeymapCollection = 'registereds' | 'unregistereds';
-
 export interface IKeyboardDefinitionDocument {
   readonly id: string;
   readonly authorUid: string;
@@ -48,9 +46,11 @@ export interface IKeyboardDefinitionDocument {
   readonly updatedAt: Date;
 }
 
+type SavedKeymapSatus = 'private' | 'shared';
+
 export type SavedKeymapData = {
   id?: string; // this entity's id
-  definition_id?: string; // /keyboards/v2/definitions/{ID} if the keyboard is registered
+  status: SavedKeymapSatus;
   author_uid: string; //  auth.uid
   vendor_id: number; // Definition.vendorId if registered, otherwise DeviceInformation.vendorId
   product_id: number; // Definition.productId if registered, otherwise DeviceInformation.productId
@@ -63,10 +63,6 @@ export type SavedKeymapData = {
   created_at?: Date;
   updated_at?: Date;
 };
-
-export function isSavedRegisteredKeymapData(data: SavedKeymapData) {
-  return data.definition_id != undefined;
-}
 
 export interface IExistsResult extends IResult {
   exists?: boolean;
@@ -141,21 +137,9 @@ export interface IStorage {
   ): Promise<IResult>;
   deleteKeyboardDefinitionDocument(definitionId: string): Promise<IResult>;
 
-  fetchSavedKeymaps(
-    info: IDeviceInformation,
-    targetCollection: SavedKeymapCollection
-  ): Promise<ISavedKeymapResult>;
-  createSavedKeymap(
-    keymapData: SavedKeymapData,
-    targetCollection: SavedKeymapCollection
-  ): Promise<IResult>;
-  updateSavedKeymap(
-    keymapData: SavedKeymapData,
-    targetCollection: SavedKeymapCollection
-  ): Promise<IResult>;
-  deleteSavedKeymap(
-    savedKeymapId: string,
-    targetCollection: SavedKeymapCollection
-  ): Promise<IResult>;
+  fetchMySavedKeymaps(info: IDeviceInformation): Promise<ISavedKeymapResult>;
+  createSavedKeymap(keymapData: SavedKeymapData): Promise<IResult>;
+  updateSavedKeymap(keymapData: SavedKeymapData): Promise<IResult>;
+  deleteSavedKeymap(savedKeymapId: string): Promise<IResult>;
 }
 /* eslint-enable no-unused-vars */

--- a/src/services/storage/Storage.ts
+++ b/src/services/storage/Storage.ts
@@ -46,6 +46,16 @@ export interface IKeyboardDefinitionDocument {
   readonly updatedAt: Date;
 }
 
+export function isApprovedKeyboard(
+  keyboardDefDocument: IKeyboardDefinitionDocument | null | undefined
+) {
+  if (keyboardDefDocument) {
+    return keyboardDefDocument.status === 'approved';
+  } else {
+    return false;
+  }
+}
+
 type SavedKeymapSatus = 'private' | 'shared';
 
 export type SavedKeymapData = {

--- a/src/services/storage/Storage.ts
+++ b/src/services/storage/Storage.ts
@@ -61,17 +61,17 @@ type SavedKeymapSatus = 'private' | 'shared';
 export type SavedKeymapData = {
   id?: string; // this entity's id
   status: SavedKeymapSatus;
-  author_uid: string; //  auth.uid
-  vendor_id: number; // Definition.vendorId if registered, otherwise DeviceInformation.vendorId
-  product_id: number; // Definition.productId if registered, otherwise DeviceInformation.productId
-  product_name: string; // Definition.productName if registered, otherwise DeviceInformation.productName
+  authorUid: string; //  auth.uid
+  vendorId: number; // Definition.vendorId if registered, otherwise DeviceInformation.vendorId
+  productId: number; // Definition.productId if registered, otherwise DeviceInformation.productId
+  productName: string; // Definition.productName if registered, otherwise DeviceInformation.productName
   title: string;
   desc: string;
-  label_lang: KeyboardLabelLang;
-  layout_options: LayoutOption[];
+  labelLang: KeyboardLabelLang;
+  layoutOptions: LayoutOption[];
   keycodes: { [pos: string]: number }[];
-  created_at?: Date;
-  updated_at?: Date;
+  createdAt?: Date;
+  updatedAt?: Date;
 };
 
 export interface IExistsResult extends IResult {

--- a/src/services/storage/Storage.ts
+++ b/src/services/storage/Storage.ts
@@ -50,7 +50,11 @@ export interface IKeyboardDefinitionDocument {
 
 export type SavedKeymapData = {
   id?: string; // this entity's id
+  definition_id?: string; // /keyboards/v2/definitions/{ID} if the keyboard is registered
   author_uid: string; //  auth.uid
+  vendor_id: number; // Definition.vendorId if registered, otherwise DeviceInformation.vendorId
+  product_id: number; // Definition.productId if registered, otherwise DeviceInformation.productId
+  product_name: string; // Definition.productName if registered, otherwise DeviceInformation.productName
   title: string;
   desc: string;
   label_lang: KeyboardLabelLang;
@@ -60,20 +64,8 @@ export type SavedKeymapData = {
   updated_at?: Date;
 };
 
-export type SavedRegisteredKeymapData = {
-  definition_id: string; // /keyboards/v2/definitions/{ID}
-} & SavedKeymapData;
-
-export type SavedUnregisteredKeymapData = {
-  vendor_id: number;
-  product_id: number;
-  product_name: string;
-} & SavedKeymapData;
-
-export function isSavedRegisteredKeymapData(
-  arg: any
-): arg is SavedRegisteredKeymapData {
-  return arg.definition_id != undefined;
+export function isSavedRegisteredKeymapData(data: SavedKeymapData) {
+  return data.definition_id != undefined;
 }
 
 export interface IExistsResult extends IResult {
@@ -92,8 +84,8 @@ export interface ICreateKeyboardDefinitionDocumentResult extends IResult {
   definitionId?: string;
 }
 
-export interface ISavedKeymapResule extends IResult {
-  savedKeymaps: SavedRegisteredKeymapData[] | SavedUnregisteredKeymapData[];
+export interface ISavedKeymapResult extends IResult {
+  savedKeymaps: SavedKeymapData[];
 }
 
 /* eslint-disable no-unused-vars */
@@ -149,9 +141,10 @@ export interface IStorage {
   ): Promise<IResult>;
   deleteKeyboardDefinitionDocument(definitionId: string): Promise<IResult>;
 
-  fetchSavedRegisteredKeymaps(
-    definitionId: string
-  ): Promise<ISavedKeymapResule>;
+  fetchSavedKeymaps(
+    info: IDeviceInformation,
+    targetCollection: SavedKeymapCollection
+  ): Promise<ISavedKeymapResult>;
   createSavedKeymap(
     keymapData: SavedKeymapData,
     targetCollection: SavedKeymapCollection
@@ -164,9 +157,5 @@ export interface IStorage {
     savedKeymapId: string,
     targetCollection: SavedKeymapCollection
   ): Promise<IResult>;
-
-  fetchUnregisteredKeymaps(
-    info: IDeviceInformation
-  ): Promise<ISavedKeymapResule>;
 }
 /* eslint-enable no-unused-vars */

--- a/src/services/storage/Storage.ts
+++ b/src/services/storage/Storage.ts
@@ -61,17 +61,17 @@ type SavedKeymapSatus = 'private' | 'shared';
 export type SavedKeymapData = {
   id?: string; // this entity's id
   status: SavedKeymapSatus;
-  authorUid: string; //  auth.uid
-  vendorId: number; // Definition.vendorId if registered, otherwise DeviceInformation.vendorId
-  productId: number; // Definition.productId if registered, otherwise DeviceInformation.productId
-  productName: string; // Definition.productName if registered, otherwise DeviceInformation.productName
+  author_uid: string; //  auth.uid
+  vendor_id: number; // Definition.vendorId if registered, otherwise DeviceInformation.vendorId
+  product_id: number; // Definition.productId if registered, otherwise DeviceInformation.productId
+  product_name: string; // Definition.productName if registered, otherwise DeviceInformation.productName
   title: string;
   desc: string;
-  labelLang: KeyboardLabelLang;
-  layoutOptions: LayoutOption[];
+  label_lang: KeyboardLabelLang;
+  layout_options: LayoutOption[];
   keycodes: { [pos: string]: number }[];
-  createdAt?: Date;
-  updatedAt?: Date;
+  created_at?: Date;
+  updated_at?: Date;
 };
 
 export interface IExistsResult extends IResult {

--- a/src/services/storage/Storage.ts
+++ b/src/services/storage/Storage.ts
@@ -44,18 +44,18 @@ export interface IKeyboardDefinitionDocument {
   readonly updatedAt: Date;
 }
 
-export type IKeycodeData = {
-  labelLang: KeyboardLabelLang;
-  layoutOptions: { option: string; optionChoice: string }[] | undefined;
-  keycodes: { [pos: string]: number }[];
-};
-
-export interface ISavedKeymapData {
-  id: string;
+export type ISavedKeymapData = {
+  id?: string; // this entity's id
+  author_uid: string; //  auth.uid
+  definition_id: string; // /keyboards/v2/definitions/{ID}
   title: string;
   desc: string;
-  data: IKeycodeData;
-}
+  label_lang: KeyboardLabelLang;
+  layout_options: { option: string; optionChoice: string }[] | null;
+  keycodes: { [pos: string]: number }[];
+  created_at?: Date;
+  updated_at?: Date;
+};
 
 export interface IExistsResult extends IResult {
   exists?: boolean;
@@ -74,7 +74,7 @@ export interface ICreateKeyboardDefinitionDocumentResult extends IResult {
 }
 
 export interface IKeymapDataResule extends IResult {
-  keymaps: ISavedKeymapData[];
+  savedKeymapDataList: ISavedKeymapData[];
 }
 
 /* eslint-disable no-unused-vars */
@@ -130,19 +130,9 @@ export interface IStorage {
   ): Promise<IResult>;
   deleteKeyboardDefinitionDocument(definitionId: string): Promise<IResult>;
 
-  fetchMySavedKeymapDataList(
-    authorUid: string,
-    vendorId: number,
-    productId: number,
-    productName: string
-  ): Promise<IKeymapDataResule>;
-
-  createMySavedKeymapData(
-    authorUid: string,
-    vendorId: number,
-    productId: number,
-    productName: string,
-    keymap: ISavedKeymapData
-  ): Promise<IResult>;
+  fetchSavedKeymapDataList(definitionId: string): Promise<IKeymapDataResule>;
+  createSavedKeymapData(keymapData: ISavedKeymapData): Promise<IResult>;
+  updateSavedKeymapData(keymapData: ISavedKeymapData): Promise<IResult>;
+  deleteSavedKeymapData(savedKeymapId: string): Promise<IResult>;
 }
 /* eslint-enable no-unused-vars */

--- a/src/store/reducers.ts
+++ b/src/store/reducers.ts
@@ -39,6 +39,7 @@ import {
   APP_UPDATE_KEYBOARD_SIZE,
   APP_UPDATE_LANG_LABEL,
   APP_UPDATE_SIGNED_IN,
+  APP_REMAPS_SET_KEYS,
 } from '../actions/actions';
 import {
   HID_ACTIONS,
@@ -54,6 +55,7 @@ import {
   STORAGE_UPDATE_KEYBOARD_DEFINITION,
   STORAGE_UPDATE_KEYBOARD_DEFINITION_DOCUMENT,
   STORAGE_UPDATE_KEYBOARD_DEFINITION_DOCUMENTS,
+  STORAGE_UPDATE_MY_SAVED_KEYMAPDATA_LIST,
 } from '../actions/storage.action';
 import { AnyKey } from '../components/configure/keycodekey/KeycodeKey';
 import { KeycodeInfo } from '../components/configure/keycodekey/KeycodeKey.container';
@@ -298,6 +300,10 @@ const storageReducer = (action: Action, draft: WritableDraft<RootState>) => {
       draft.entities.keyboardDefinitionDocument = action.value;
       break;
     }
+    case STORAGE_UPDATE_MY_SAVED_KEYMAPDATA_LIST: {
+      draft.entities.savedKeymaps = action.value;
+      break;
+    }
   }
 };
 
@@ -314,6 +320,10 @@ const appReducer = (action: Action, draft: WritableDraft<RootState>) => {
     case APP_REMAPS_SET_KEY: {
       const layer = action.value.layer;
       draft.app.remaps[layer][action.value.pos] = action.value.keymap;
+      break;
+    }
+    case APP_REMAPS_SET_KEYS: {
+      draft.app.remaps = action.value;
       break;
     }
     case APP_REMAPS_REMOVE_KEY: {

--- a/src/store/reducers.ts
+++ b/src/store/reducers.ts
@@ -56,8 +56,7 @@ import {
   STORAGE_UPDATE_KEYBOARD_DEFINITION,
   STORAGE_UPDATE_KEYBOARD_DEFINITION_DOCUMENT,
   STORAGE_UPDATE_KEYBOARD_DEFINITION_DOCUMENTS,
-  STORAGE_UPDATE_SAVED_REGISTERED_KEYMAPS,
-  STORAGE_UPDATE_SAVED_UNREGISTERED_KEYMAPS,
+  STORAGE_UPDATE_SAVED_KEYMAPS,
 } from '../actions/storage.action';
 import { AnyKey } from '../components/configure/keycodekey/KeycodeKey';
 import { KeycodeInfo } from '../components/configure/keycodekey/KeycodeKey.container';
@@ -303,12 +302,8 @@ const storageReducer = (action: Action, draft: WritableDraft<RootState>) => {
       draft.entities.keyboardDefinitionDocument = action.value;
       break;
     }
-    case STORAGE_UPDATE_SAVED_REGISTERED_KEYMAPS: {
-      draft.entities.savedRegisteredKeymaps = action.value;
-      break;
-    }
-    case STORAGE_UPDATE_SAVED_UNREGISTERED_KEYMAPS: {
-      draft.entities.savedUnregisteredKeymaps = action.value;
+    case STORAGE_UPDATE_SAVED_KEYMAPS: {
+      draft.entities.savedKeymaps = action.value;
       break;
     }
   }

--- a/src/store/reducers.ts
+++ b/src/store/reducers.ts
@@ -40,6 +40,7 @@ import {
   APP_UPDATE_LANG_LABEL,
   APP_UPDATE_SIGNED_IN,
   APP_REMAPS_SET_KEYS,
+  LAYOUT_OPTIONS_RESTORE_SELECTED_OPTIONS,
 } from '../actions/actions';
 import {
   HID_ACTIONS,
@@ -55,7 +56,8 @@ import {
   STORAGE_UPDATE_KEYBOARD_DEFINITION,
   STORAGE_UPDATE_KEYBOARD_DEFINITION_DOCUMENT,
   STORAGE_UPDATE_KEYBOARD_DEFINITION_DOCUMENTS,
-  STORAGE_UPDATE_MY_SAVED_KEYMAPDATA_LIST,
+  STORAGE_UPDATE_SAVED_REGISTERED_KEYMAPS,
+  STORAGE_UPDATE_SAVED_UNREGISTERED_KEYMAPS,
 } from '../actions/storage.action';
 import { AnyKey } from '../components/configure/keycodekey/KeycodeKey';
 import { KeycodeInfo } from '../components/configure/keycodekey/KeycodeKey.container';
@@ -96,6 +98,7 @@ import {
   KEYBOARDS_EDIT_DEFINITION_UPDATE_QMK_REPOSITORY_FIRST_PULL_REQUEST_URL,
 } from '../actions/keyboards.actions';
 import { MOD_LEFT } from '../services/hid/Composition';
+import { LayoutOption } from '../components/configure/keymap/Keymap';
 
 export type Action = { type: string; value: any };
 
@@ -300,8 +303,12 @@ const storageReducer = (action: Action, draft: WritableDraft<RootState>) => {
       draft.entities.keyboardDefinitionDocument = action.value;
       break;
     }
-    case STORAGE_UPDATE_MY_SAVED_KEYMAPDATA_LIST: {
-      draft.entities.savedKeymaps = action.value;
+    case STORAGE_UPDATE_SAVED_REGISTERED_KEYMAPS: {
+      draft.entities.savedRegisteredKeymaps = action.value;
+      break;
+    }
+    case STORAGE_UPDATE_SAVED_UNREGISTERED_KEYMAPS: {
+      draft.entities.savedUnregisteredKeymaps = action.value;
       break;
     }
   }
@@ -521,11 +528,15 @@ const layoutOptionsReducer = (
   draft: WritableDraft<RootState>
 ) => {
   switch (action.type) {
+    case LAYOUT_OPTIONS_RESTORE_SELECTED_OPTIONS: {
+      draft.configure.layoutOptions.selectedOptions = action.value;
+      break;
+    }
     case LAYOUT_OPTIONS_UPDATE_SELECTED_OPTION: {
-      const { optionIndex, option } = action.value;
+      const { option, optionChoice } = action.value;
       draft.configure.layoutOptions.selectedOptions = draft.configure.layoutOptions.selectedOptions.map(
-        (value, index) => {
-          return index == optionIndex ? option : value;
+        (value: LayoutOption) => {
+          return value.option == option ? { option, optionChoice } : value;
         }
       );
       break;

--- a/src/store/state.ts
+++ b/src/store/state.ts
@@ -5,14 +5,16 @@ import { WebHid } from '../services/hid/WebHid';
 import { FirebaseProvider } from '../services/provider/Firebase';
 import {
   IKeyboardDefinitionDocument,
-  ISavedKeymapData,
+  SavedRegisteredKeymapData,
   IStorage,
+  SavedUnregisteredKeymapData,
 } from '../services/storage/Storage';
 import { IAuth } from '../services/auth/Auth';
 import { KeyboardDefinitionSchema } from '../gen/types/KeyboardDefinition';
 import { GitHub, IGitHub } from '../services/github/GitHub';
 import buildInfo from '../assets/files/build-info.json';
 import { KeyboardLabelLang } from '../services/labellang/KeyLabelLangs';
+import { LayoutOption } from '../components/configure/keymap/Keymap';
 
 export type ISetupPhase =
   | 'init'
@@ -78,7 +80,8 @@ export type RootState = {
     keyboardDefinition: KeyboardDefinitionSchema | null;
     keyboardDefinitionDocuments: IKeyboardDefinitionDocument[];
     keyboardDefinitionDocument: IKeyboardDefinitionDocument | null;
-    savedKeymaps: ISavedKeymapData[];
+    savedRegisteredKeymaps: SavedRegisteredKeymapData[];
+    savedUnregisteredKeymaps: SavedUnregisteredKeymapData[];
   };
   app: {
     package: {
@@ -118,7 +121,7 @@ export type RootState = {
       destination: IKeymap | null;
     };
     layoutOptions: {
-      selectedOptions: (string | null)[];
+      selectedOptions: LayoutOption[];
     };
   };
   keyboards: {
@@ -201,7 +204,8 @@ export const INIT_STATE: RootState = {
     keyboardDefinition: null,
     keyboardDefinitionDocuments: [],
     keyboardDefinitionDocument: null,
-    savedKeymaps: [],
+    savedRegisteredKeymaps: [],
+    savedUnregisteredKeymaps: [],
   },
   app: {
     package: {

--- a/src/store/state.ts
+++ b/src/store/state.ts
@@ -5,6 +5,7 @@ import { WebHid } from '../services/hid/WebHid';
 import { FirebaseProvider } from '../services/provider/Firebase';
 import {
   IKeyboardDefinitionDocument,
+  ISavedKeymapData,
   IStorage,
 } from '../services/storage/Storage';
 import { IAuth } from '../services/auth/Auth';
@@ -77,6 +78,7 @@ export type RootState = {
     keyboardDefinition: KeyboardDefinitionSchema | null;
     keyboardDefinitionDocuments: IKeyboardDefinitionDocument[];
     keyboardDefinitionDocument: IKeyboardDefinitionDocument | null;
+    savedKeymaps: ISavedKeymapData[];
   };
   app: {
     package: {
@@ -199,6 +201,7 @@ export const INIT_STATE: RootState = {
     keyboardDefinition: null,
     keyboardDefinitionDocuments: [],
     keyboardDefinitionDocument: null,
+    savedKeymaps: [],
   },
   app: {
     package: {

--- a/src/store/state.ts
+++ b/src/store/state.ts
@@ -5,9 +5,8 @@ import { WebHid } from '../services/hid/WebHid';
 import { FirebaseProvider } from '../services/provider/Firebase';
 import {
   IKeyboardDefinitionDocument,
-  SavedRegisteredKeymapData,
   IStorage,
-  SavedUnregisteredKeymapData,
+  SavedKeymapData,
 } from '../services/storage/Storage';
 import { IAuth } from '../services/auth/Auth';
 import { KeyboardDefinitionSchema } from '../gen/types/KeyboardDefinition';
@@ -80,8 +79,8 @@ export type RootState = {
     keyboardDefinition: KeyboardDefinitionSchema | null;
     keyboardDefinitionDocuments: IKeyboardDefinitionDocument[];
     keyboardDefinitionDocument: IKeyboardDefinitionDocument | null;
-    savedRegisteredKeymaps: SavedRegisteredKeymapData[];
-    savedUnregisteredKeymaps: SavedUnregisteredKeymapData[];
+    savedRegisteredKeymaps: SavedKeymapData[];
+    savedUnregisteredKeymaps: SavedKeymapData[];
   };
   app: {
     package: {

--- a/src/store/state.ts
+++ b/src/store/state.ts
@@ -79,8 +79,7 @@ export type RootState = {
     keyboardDefinition: KeyboardDefinitionSchema | null;
     keyboardDefinitionDocuments: IKeyboardDefinitionDocument[];
     keyboardDefinitionDocument: IKeyboardDefinitionDocument | null;
-    savedRegisteredKeymaps: SavedKeymapData[];
-    savedUnregisteredKeymaps: SavedKeymapData[];
+    savedKeymaps: SavedKeymapData[];
   };
   app: {
     package: {
@@ -203,8 +202,7 @@ export const INIT_STATE: RootState = {
     keyboardDefinition: null,
     keyboardDefinitionDocuments: [],
     keyboardDefinitionDocument: null,
-    savedRegisteredKeymaps: [],
-    savedUnregisteredKeymaps: [],
+    savedKeymaps: [],
   },
   app: {
     package: {


### PR DESCRIPTION
Enable to save/restore the current device keymap. 
Keymap data is stored in Firebase at /keymaps/v1/saved-keymaps/{id}.
The data structure is as follow:

```
type SavedKeymap = {
  id?: string; // this entity's id
  author_uid: string; //  auth.uid
  title: string;
  desc: string;
  label_lang: KeyboardLabelLang;
  layout_options: { option: string; optionChoice: string }[] | null;
  keycodes: { [pos: string]: number }[];
  created_at?: Date;
  updated_at?: Date;
  vendor_id: number;
  product_id: number;
  product_name: number;
};
```

If the connected keyboard is registered and approved to Remap, the vendor_id/product_id/product_name are from its KeyboardDefinitionDocument. Otherwise they are from device information.

The **title** and **desc** are shown in the Popup to recognize what map it is.

<img width="1362" alt="スクリーンショット 2021-03-16 18 45 53" src="https://user-images.githubusercontent.com/316463/111289472-892c7b00-8688-11eb-8656-c39df5aa2c72.png">
<img width="1363" alt="スクリーンショット 2021-03-16 18 46 15" src="https://user-images.githubusercontent.com/316463/111289483-8cc00200-8688-11eb-8c63-d6669f44d4b5.png">

