### PR TITLE
show the side scroll bar and crop the CSS expanded area

### DIFF
--- a/src/components/configure/Configure.scss
+++ b/src/components/configure/Configure.scss
@@ -1,7 +1,6 @@
 @import '../../_variables.scss';
 
 .configure-main {
-  overflow-y: hidden;
 }
 
 .message-box-wrapper {

--- a/src/components/configure/remap/Remap.scss
+++ b/src/components/configure/remap/Remap.scss
@@ -5,6 +5,7 @@
   width: 100%;
   margin-top: calc(var(--key-height));
   z-index: 1;
+  overflow-y: hidden;
   .controller {
     display: flex;
     flex-direction: row;


### PR DESCRIPTION
Works fine, I believe!
<img width="1042" alt="スクリーンショット 2021-03-17 18 49 17" src="https://user-images.githubusercontent.com/316463/111448705-08d24c80-8752-11eb-989e-ba87bbfb4c95.png">
