### PR TITLE
Allow the draft keyboard definition to apply when using it by the applicant

### DIFF
--- a/src/actions/actions.ts
+++ b/src/actions/actions.ts
@@ -273,7 +273,7 @@ export const AppActionsThunk = {
     const { auth } = getState();
     await auth.instance!.signOut();
     dispatch(AppActions.updateSignedIn(false));
-    dispatch(await hidActionsThunk.closeOpenedKeyboard);
+    dispatch(await hidActionsThunk.closeOpenedKeyboard());
     dispatch(AppActions.updateSetupPhase(SetupPhase.keyboardNotSelected));
   },
   loginWithGitHubAccount: (): ThunkPromiseAction<void> => async (

--- a/src/actions/actions.ts
+++ b/src/actions/actions.ts
@@ -3,8 +3,9 @@ import { Key } from '../components/configure/keycodekey/KeyGen';
 import KeyModel from '../models/KeyModel';
 import { IKeymap } from '../services/hid/Hid';
 import { KeyboardLabelLang } from '../services/labellang/KeyLabelLangs';
-import { ISetupPhase, RootState } from '../store/state';
+import { ISetupPhase, RootState, SetupPhase } from '../store/state';
 import { ThunkAction, ThunkDispatch } from 'redux-thunk';
+import { hidActionsThunk } from './hid.action';
 
 export const KEYMAP_ACTIONS = '@Keymap';
 export const KEYMAP_CLEAR_SELECTED_POS = `${KEYMAP_ACTIONS}/ClearSelectedLayer`;
@@ -272,6 +273,8 @@ export const AppActionsThunk = {
     const { auth } = getState();
     await auth.instance!.signOut();
     dispatch(AppActions.updateSignedIn(false));
+    dispatch(await hidActionsThunk.closeOpenedKeyboard);
+    dispatch(AppActions.updateSetupPhase(SetupPhase.keyboardNotSelected));
   },
   loginWithGitHubAccount: (): ThunkPromiseAction<void> => async (
     dispatch: ThunkDispatch<RootState, undefined, ActionTypes>,

--- a/src/actions/storage.action.ts
+++ b/src/actions/storage.action.ts
@@ -206,16 +206,12 @@ export const storageActionsThunk = {
         );
         return;
       }
-      if (myKeyboardDefinitionDocumentsResult.documents!.length === 1) {
-        keyboardDefinitionDocument = myKeyboardDefinitionDocumentsResult.documents![0];
-      } else if (myKeyboardDefinitionDocumentsResult.documents!.length > 1) {
-        keyboardDefinitionDocument = myKeyboardDefinitionDocumentsResult.documents!.find(
-          (doc) =>
-            doc.vendorId === vendorId &&
-            doc.productId === productId &&
-            productName.endsWith(doc.productName)
-        );
-      }
+      keyboardDefinitionDocument = myKeyboardDefinitionDocumentsResult.documents!.find(
+        (doc) =>
+          doc.vendorId === vendorId &&
+          doc.productId === productId &&
+          productName.endsWith(doc.productName)
+      );
     }
 
     if (!keyboardDefinitionDocument) {

--- a/src/actions/storage.action.ts
+++ b/src/actions/storage.action.ts
@@ -155,7 +155,7 @@ export const storageActionsThunk = {
     dispatch: ThunkDispatch<RootState, undefined, ActionTypes>,
     getState: () => RootState
   ) => {
-    const { storage } = getState();
+    const { storage, app } = getState();
 
     if (storage.instance === null) {
       console.warn(
@@ -166,6 +166,8 @@ export const storageActionsThunk = {
       );
       return;
     }
+
+    let keyboardDefinitionDocument: IKeyboardDefinitionDocument | undefined;
 
     const fetchKeyboardDefinitionResult = await storage.instance!.fetchKeyboardDefinitionDocumentByDeviceInfo(
       vendorId,
@@ -182,23 +184,10 @@ export const storageActionsThunk = {
       );
       return;
     }
-
-    let keyboardDefinition: KeyboardDefinitionSchema;
     if (fetchKeyboardDefinitionResult.exists!) {
-      const jsonStr: string = fetchKeyboardDefinitionResult.document!.json;
-      try {
-        keyboardDefinition = JSON.parse(jsonStr);
-      } catch (error) {
-        dispatch(NotificationActions.addError('JSON parse error'));
-        return;
-      }
-      const validateResult = validateKeyboardDefinitionSchema(
-        keyboardDefinition
-      );
-      if (!validateResult.valid) {
-        dispatch(
-          NotificationActions.addError(validateResult.errors![0].message)
-        );
+      keyboardDefinitionDocument = fetchKeyboardDefinitionResult.document!;
+    } else {
+      if (!app.signedIn) {
         dispatch(
           AppActions.updateSetupPhase(
             SetupPhase.waitingKeyboardDefinitionUpload
@@ -206,27 +195,68 @@ export const storageActionsThunk = {
         );
         return;
       }
+      const myKeyboardDefinitionDocumentsResult = await storage.instance!.fetchMyKeyboardDefinitionDocuments();
+      if (!myKeyboardDefinitionDocumentsResult.success) {
+        console.error(myKeyboardDefinitionDocumentsResult.cause!);
+        dispatch(
+          NotificationActions.addError(
+            myKeyboardDefinitionDocumentsResult.error!,
+            myKeyboardDefinitionDocumentsResult.cause
+          )
+        );
+        return;
+      }
+      if (myKeyboardDefinitionDocumentsResult.documents!.length === 1) {
+        keyboardDefinitionDocument = myKeyboardDefinitionDocumentsResult.documents![0];
+      } else if (myKeyboardDefinitionDocumentsResult.documents!.length > 1) {
+        keyboardDefinitionDocument = myKeyboardDefinitionDocumentsResult.documents!.find(
+          (doc) =>
+            doc.vendorId === vendorId &&
+            doc.productId === productId &&
+            productName.endsWith(doc.productName)
+        );
+      }
+    }
 
-      dispatch(
-        StorageActions.updateKeyboardDefinitionDocument(
-          fetchKeyboardDefinitionResult.document!
-        )
-      );
-      dispatch(StorageActions.updateKeyboardDefinition(keyboardDefinition));
-      dispatch(
-        LayoutOptionsActions.initSelectedOptions(
-          keyboardDefinition.layouts.labels
-            ? keyboardDefinition.layouts.labels
-            : []
-        )
-      );
-      dispatch(AppActions.updateSetupPhase(SetupPhase.openingKeyboard));
-      await dispatch(hidActionsThunk.openKeyboard());
-    } else {
+    if (!keyboardDefinitionDocument) {
       dispatch(
         AppActions.updateSetupPhase(SetupPhase.waitingKeyboardDefinitionUpload)
       );
+      return;
     }
+
+    let keyboardDefinition: KeyboardDefinitionSchema;
+    const jsonStr: string = keyboardDefinitionDocument.json;
+    try {
+      keyboardDefinition = JSON.parse(jsonStr);
+    } catch (error) {
+      dispatch(NotificationActions.addError('JSON parse error'));
+      return;
+    }
+    const validateResult = validateKeyboardDefinitionSchema(keyboardDefinition);
+    if (!validateResult.valid) {
+      dispatch(NotificationActions.addError(validateResult.errors![0].message));
+      dispatch(
+        AppActions.updateSetupPhase(SetupPhase.waitingKeyboardDefinitionUpload)
+      );
+      return;
+    }
+
+    dispatch(
+      StorageActions.updateKeyboardDefinitionDocument(
+        keyboardDefinitionDocument
+      )
+    );
+    dispatch(StorageActions.updateKeyboardDefinition(keyboardDefinition));
+    dispatch(
+      LayoutOptionsActions.initSelectedOptions(
+        keyboardDefinition.layouts.labels
+          ? keyboardDefinition.layouts.labels
+          : []
+      )
+    );
+    dispatch(AppActions.updateSetupPhase(SetupPhase.openingKeyboard));
+    await dispatch(hidActionsThunk.openKeyboard());
   },
 
   fetchMyKeyboardDefinitionDocuments: (): ThunkPromiseAction<void> => async (

--- a/src/components/configure/header/Header.container.ts
+++ b/src/components/configure/header/Header.container.ts
@@ -13,6 +13,7 @@ const mapStateToProps = (state: RootState) => {
     flashing: state.configure.header.flashing,
     keyboards: state.entities.keyboards,
     keyboard: state.entities.keyboard,
+    keyboardDefinitionDocument: state.entities.keyboardDefinitionDocument,
     productId: info?.productId || NaN,
     productName: info?.productName || '',
     vendorId: info?.vendorId || NaN,

--- a/src/components/configure/header/Header.tsx
+++ b/src/components/configure/header/Header.tsx
@@ -15,6 +15,10 @@ import {
   getGitHubProviderData,
   getGoogleProviderData,
 } from '../../../services/auth/Auth';
+import {
+  IKeyboardDefinitionDocument,
+  KeyboardDefinitionStatus,
+} from '../../../services/storage/Storage';
 
 type HeaderState = {
   connectionStateEl: any;
@@ -368,9 +372,10 @@ export default class Header extends React.Component<HeaderProps, HeaderState> {
                 </Menu>
               </div>
             </div>
-            <IconButton onClick={this.onClickShowInfoDialog.bind(this)}>
-              <InfoIcon />
-            </IconButton>
+            <InfoDialogButton
+              keyboardDefinitionDocument={this.props.keyboardDefinitionDocument}
+              onClick={this.onClickShowInfoDialog.bind(this)}
+            />
           </div>
 
           <div className="header-logo">
@@ -416,3 +421,22 @@ export default class Header extends React.Component<HeaderProps, HeaderState> {
 
 const FlashButtonStates = ['disable', 'enable', 'flashing', 'success'] as const;
 type FlashButtonState = typeof FlashButtonStates[number];
+
+type IInfoDialogButton = {
+  keyboardDefinitionDocument: IKeyboardDefinitionDocument | null | undefined;
+  onClick: () => void;
+};
+
+function InfoDialogButton(props: IInfoDialogButton) {
+  const color = props.keyboardDefinitionDocument
+    ? props.keyboardDefinitionDocument.status ===
+      KeyboardDefinitionStatus.approved
+      ? 'primary'
+      : 'secondary'
+    : 'primary';
+  return (
+    <IconButton onClick={props.onClick}>
+      <InfoIcon color={color} />
+    </IconButton>
+  );
+}

--- a/src/components/configure/info/InfoDialog.container.ts
+++ b/src/components/configure/info/InfoDialog.container.ts
@@ -7,6 +7,7 @@ const mapStateToProps = (state: RootState) => {
     keyboard: state.entities.keyboard,
     keyboardDefinition: state.entities.keyboardDefinition,
     keyboardDefinitionDocument: state.entities.keyboardDefinitionDocument,
+    auth: state.auth.instance,
   };
 };
 export type InfoDialogStateType = ReturnType<typeof mapStateToProps>;

--- a/src/components/configure/info/InfoDialog.scss
+++ b/src/components/configure/info/InfoDialog.scss
@@ -11,4 +11,18 @@
       cursor: pointer;
     }
   }
+
+  &-information-message {
+    font-size: 90%;
+    line-height: 0.95rem;
+    color: $color-gray;
+    margin-bottom: $space-m;
+  }
+
+  &-warning-message {
+    font-size: 90%;
+    line-height: 0.95rem;
+    color: $error;
+    margin-bottom: $space-m;
+  }
 }


### PR DESCRIPTION
Fix #408 

Currently, the keyboard definition which the status is the draft never be applied for all users including the user who the definition registered. But, if the user who it registered can use the definition (that is, the behavior is same as the approved status), the user can confirm whether the keyboard definition information including VID, PID and PNAME are valid or not by connecting the keyboard (if they are invalid, the definition JSON file import is asked).

When a draft definition is applied, we should display the message to inform the definition status is draft to ask the review submission with the link to the management page.

When the user is not logged in and connects a keyboard which is not registered in Remap and a JSON file is not imported yet:

![Screenshot_from_2021-03-18_13-01-13](https://user-images.githubusercontent.com/261787/111617252-3688c580-8826-11eb-9c75-53c87a44ad0e.png)

When the user is not logged in and connects a keyboard which is not registered in Remap and a JSON file is imported:

![Screenshot_from_2021-03-18_13-02-20](https://user-images.githubusercontent.com/261787/111869870-b6e52d00-89c4-11eb-88cd-b5710d5e4364.png)

When the user is logged in and connects a keyboard which is registered in Remap (the status is draft or rejected):

![Screenshot_from_2021-03-18_13-03-54](https://user-images.githubusercontent.com/261787/111869919-ee53d980-89c4-11eb-9f50-d2381824f561.png)

![Screenshot_from_2021-03-18_13-05-30](https://user-images.githubusercontent.com/261787/111869934-04fa3080-89c5-11eb-99a7-cda3245b23bb.png)

When the user is logged in and connects a keyboard which is registered in Remap (the status is approved) by other user:

![Screenshot_from_2021-03-18_13-07-11](https://user-images.githubusercontent.com/261787/111869948-23f8c280-89c5-11eb-93e5-b520cbfc75cc.png)

When the user is logged in and connects a keyboard which is registered in Remap (the status is approved) by the user:

![Screenshot_from_2021-03-18_13-08-36](https://user-images.githubusercontent.com/261787/111869958-3115b180-89c5-11eb-986b-ee94314a03a3.png)
