### PR TITLE
Save keymap permanently for BLE Micro Pro

### DIFF
--- a/src/actions/hid.action.ts
+++ b/src/actions/hid.action.ts
@@ -319,6 +319,15 @@ export const hidActionsThunk = {
         }
       }
     }
+    if (entities.device.bleMicroPro) {
+      const result = await keyboard.storeKeymapPersistentlyForBleMicroPro();
+      if (!result.success) {
+        console.error(result.cause);
+        dispatch(NotificationActions.addError(result.error!, result.cause));
+        dispatch(HeaderActions.updateFlashing(false));
+        return;
+      }
+    }
     const keymaps: IKeymaps[] = await loadKeymap(
       dispatch,
       keyboard,

--- a/src/actions/hid.action.ts
+++ b/src/actions/hid.action.ts
@@ -13,6 +13,8 @@ import {
 } from './actions';
 import { StorageActions, storageActionsThunk } from './storage.action';
 
+const PRODUCT_PREFIX_FOR_BLE_MICRO_PRO = '(BMP)';
+
 export const HID_ACTIONS = '@Hid';
 export const HID_CONNECT_KEYBOARD = `${HID_ACTIONS}/ConnectDevice`;
 export const HID_DISCONNECT_KEYBOARD = `${HID_ACTIONS}/DisconnectDevice`;
@@ -20,7 +22,7 @@ export const HID_UPDATE_KEYBOARD = `${HID_ACTIONS}/UpdateKeyboard`;
 export const HID_UPDATE_KEYBOARD_LAYER_COUNT = `${HID_ACTIONS}/UpdateKeyboardLayerCount`;
 export const HID_UPDATE_KEYBOARD_LIST = `${HID_ACTIONS}/UpdateKeyboardList`;
 export const HID_UPDATE_KEYMAPS = `${HID_ACTIONS}/UpdateKeymaps`;
-export const HID_OPEN_KEYBOARD = `${HID_ACTIONS}/OpenKeyboard`;
+export const HID_UPDATE_BLE_MICRO_PRO = `${HID_ACTIONS}/UpdateBleMicroPro`;
 export const HidActions = {
   connectKeyboard: (keyboard: IKeyboard) => {
     return {
@@ -61,6 +63,13 @@ export const HidActions = {
     return {
       type: HID_UPDATE_KEYMAPS,
       value: { keymaps: keymaps },
+    };
+  },
+
+  updateBleMicroPro: (bleMicroPro: boolean) => {
+    return {
+      type: HID_UPDATE_BLE_MICRO_PRO,
+      value: bleMicroPro,
     };
   },
 };
@@ -339,6 +348,13 @@ const initOpenedKeyboard = async (
   columnCount: number,
   labelLang: KeyboardLabelLang
 ) => {
+  dispatch(
+    HidActions.updateBleMicroPro(
+      keyboard
+        .getInformation()
+        .productName.includes(PRODUCT_PREFIX_FOR_BLE_MICRO_PRO)
+    )
+  );
   const layerResult = await keyboard.fetchLayerCount();
   if (!layerResult.success) {
     // TODO:show error message

--- a/src/services/hid/Commands.ts
+++ b/src/services/hid/Commands.ts
@@ -358,3 +358,30 @@ export class DynamicKeymapResetCommand extends AbstractCommand<
     return resultArray[0] === 0x06;
   }
 }
+
+export interface IBleMicroProStoreKeymapPersistentlyResponse
+  extends ICommandResponse {
+  resultCode: number;
+}
+
+export class BleMicroProStoreKeymapPersistentlyCommand extends AbstractCommand<
+  ICommandRequest,
+  IBleMicroProStoreKeymapPersistentlyResponse
+> {
+  createReport(): Uint8Array {
+    return new Uint8Array([0x03, 0xff]);
+  }
+
+  // eslint-disable-next-line no-unused-vars
+  createResponse(
+    resultArray: Uint8Array
+  ): IBleMicroProStoreKeymapPersistentlyResponse {
+    return {
+      resultCode: resultArray[2],
+    };
+  }
+
+  isSameRequest(resultArray: Uint8Array): boolean {
+    return resultArray[0] === 0x03 && resultArray[1] === 0xff;
+  }
+}

--- a/src/services/hid/Hid.mock.ts
+++ b/src/services/hid/Hid.mock.ts
@@ -7,6 +7,7 @@ import {
   IConnectParams,
   IHid,
   IKeyboard,
+  IResult,
 } from './Hid';
 
 export const IDeviceInformationMock = {
@@ -165,6 +166,11 @@ export const mockIKeyboad: IKeyboard = {
   },
   resetDynamicKeymap: () => {
     return new Promise((resolve) => {
+      resolve({ success: true });
+    });
+  },
+  storeKeymapPersistentlyForBleMicroPro: (): Promise<IResult> => {
+    return new Promise<IResult>((resolve) => {
       resolve({ success: true });
     });
   },

--- a/src/services/hid/Hid.ts
+++ b/src/services/hid/Hid.ts
@@ -136,6 +136,7 @@ export interface IKeyboard {
   updateRGBLightEffectSpeed(speed: number): Promise<IResult>;
   updateRGBLightColor(hue: number, sat: number): Promise<IResult>;
   resetDynamicKeymap(): Promise<IResult>;
+  storeKeymapPersistentlyForBleMicroPro(): Promise<IResult>;
 }
 
 export interface ICommand {

--- a/src/services/hid/WebHid.ts
+++ b/src/services/hid/WebHid.ts
@@ -20,6 +20,7 @@ import {
 import { KeycodeList } from './KeycodeList';
 
 import {
+  BleMicroProStoreKeymapPersistentlyCommand,
   DynamicKeymapGetLayerCountCommand,
   DynamicKeymapReadBufferCommand,
   DynamicKeymapResetCommand,
@@ -651,6 +652,37 @@ export class Keyboard implements IKeyboard {
           });
         }
       });
+      return this.enqueue(command);
+    });
+  }
+
+  storeKeymapPersistentlyForBleMicroPro(): Promise<IResult> {
+    return new Promise<IResult>((resolve) => {
+      const command = new BleMicroProStoreKeymapPersistentlyCommand(
+        {},
+        async (result) => {
+          if (result.success) {
+            if (result.response!.resultCode === 0x00) {
+              resolve({
+                success: true,
+              });
+            } else {
+              resolve({
+                success: false,
+                error: `Storing keymap persistently for BLE Micro Pro failed: ${
+                  result.response!.resultCode
+                }`,
+              });
+            }
+          } else {
+            resolve({
+              success: false,
+              error: result.error,
+              cause: result.cause,
+            });
+          }
+        }
+      );
       return this.enqueue(command);
     });
   }

--- a/src/store/reducers.ts
+++ b/src/store/reducers.ts
@@ -44,6 +44,7 @@ import {
   HID_ACTIONS,
   HID_CONNECT_KEYBOARD,
   HID_DISCONNECT_KEYBOARD,
+  HID_UPDATE_BLE_MICRO_PRO,
   HID_UPDATE_KEYBOARD,
   HID_UPDATE_KEYBOARD_LAYER_COUNT,
   HID_UPDATE_KEYBOARD_LIST,
@@ -379,6 +380,10 @@ const hidReducer = (action: Action, draft: WritableDraft<RootState>) => {
     }
     case HID_UPDATE_KEYMAPS: {
       draft.entities.device.keymaps = action.value.keymaps;
+      break;
+    }
+    case HID_UPDATE_BLE_MICRO_PRO: {
+      draft.entities.device.bleMicroPro = action.value;
       break;
     }
   }

--- a/src/store/state.ts
+++ b/src/store/state.ts
@@ -71,6 +71,7 @@ export type RootState = {
       macros: {
         [id: number]: string;
       };
+      bleMicroPro: boolean;
     };
     keyboards: IKeyboard[]; // authorized keyboard list
     keyboard: IKeyboard | null;
@@ -193,6 +194,7 @@ export const INIT_STATE: RootState = {
       columnCount: NaN,
       keymaps: [],
       macros: {},
+      bleMicroPro: false,
     },
     keyboards: [],
     keyboard: null, // hid.keyboards[i]


### PR DESCRIPTION
Fix #410 

In this pull request, the following features are implemented:

* When the keyboard is connected, determine whether the target is BMP and put the result in state.
* If the connection target is BMP, send a command to make the Dynamic Keymap persistent on the BMP side during FLASH.
