### PR TITLE
Close the sub menu after clicking the import def file menu.

### DIFF
--- a/src/components/configure/keymapToolbar/KeymapToolbar.tsx
+++ b/src/components/configure/keymapToolbar/KeymapToolbar.tsx
@@ -96,7 +96,7 @@ export default class KeymapMenu extends React.Component<
   }
 
   private onClickOpenImportDefFileDialog() {
-    this.setState({ openImportDefDialog: true });
+    this.setState({ subMenuAnchorEl: null, openImportDefDialog: true });
   }
 
   private onCloseImportDefFileDialog() {
@@ -290,13 +290,6 @@ export default class KeymapMenu extends React.Component<
                 </ListItemIcon>
                 <ListItemText primary="Import keyboard definition file" />
               </MenuItem>
-              <ImportDefDialog
-                open={this.state.openImportDefDialog}
-                onClose={this.onCloseImportDefFileDialog.bind(this)}
-                vendorId={vendorId}
-                productId={productId}
-                productName={productName}
-              />
             </Menu>
           </div>
         </div>
@@ -307,6 +300,13 @@ export default class KeymapMenu extends React.Component<
           onClose={() => {
             this.setState({ openLightingDialog: false });
           }}
+        />
+        <ImportDefDialog
+          open={this.state.openImportDefDialog}
+          onClose={this.onCloseImportDefFileDialog.bind(this)}
+          vendorId={vendorId}
+          productId={productId}
+          productName={productName}
         />
       </React.Fragment>
     );


### PR DESCRIPTION
After releasing the #414, users can use the sub menu UI. When clicking the import def file menu in the sub menu, the dialog is opened, but the sub menu is remaining. As good UX, I hope that the sub menu should be hidden after opening the dialog.