### PR TITLE
added BMP category in keycodes and custom key popover

### DIFF
--- a/src/components/configure/customkey/CustomKey.stories.tsx
+++ b/src/components/configure/customkey/CustomKey.stories.tsx
@@ -90,6 +90,7 @@ class CustomKeyStory extends React.Component<{}, State> {
           layerCount={4}
           position={{ left: 200, top: 200, side: 'above' }}
           labelLang="en-us"
+          bleMicroPro={true}
           onClose={this.onClose.bind(this)}
           onChange={(key: Key) => {
             this.setKey(key);

--- a/src/components/configure/customkey/CustomKey.tsx
+++ b/src/components/configure/customkey/CustomKey.tsx
@@ -40,6 +40,7 @@ type OwnProps = {
   open: boolean;
   position: PopoverPosition;
   labelLang: KeyboardLabelLang;
+  bleMicroPro: boolean;
   onClose: () => void;
   // eslint-disable-next-line no-unused-vars
   onChange: (newKey: Key) => void;
@@ -329,6 +330,7 @@ export default class CustomKey extends React.Component<OwnProps, OwnState> {
               layerCount={this.props.layerCount}
               hexCode={this.state.hexCode}
               labelLang={this.props.labelLang}
+              bleMicroPro={this.props.bleMicroPro}
               onChangeKey={(opt: IKeymap) => {
                 this.onChangeKey(opt);
               }}

--- a/src/components/configure/customkey/TabKey.tsx
+++ b/src/components/configure/customkey/TabKey.tsx
@@ -23,6 +23,7 @@ type OwnProps = {
   layerCount: number;
   hexCode: string;
   labelLang: KeyboardLabelLang;
+  bleMicroPro: boolean;
   onChangeKey: (
     // eslint-disable-next-line no-unused-vars
     opt: IKeymap
@@ -96,8 +97,9 @@ export default class TabKey extends React.Component<OwnProps, OwnState> {
     return factory.isLayerMod();
   }
 
-  get basicKeymaps() {
+  private getBasicKeymaps() {
     const labelLang = this.props.labelLang;
+
     if (Object.prototype.hasOwnProperty.call(TabKey.basicKeymaps, labelLang)) {
       return TabKey.basicKeymaps[labelLang];
     }
@@ -113,8 +115,18 @@ export default class TabKey extends React.Component<OwnProps, OwnState> {
       ...KeyCategory.device(labelLang),
       // ...KeyCategory.macro(),
     ];
+
     TabKey.basicKeymaps[labelLang] = keymaps;
     return keymaps;
+  }
+
+  get basicKeymapsWithBmp() {
+    if (this.props.bleMicroPro) {
+      const extendKeymaps = KeyCategory.bmp();
+      return [...this.getBasicKeymaps(), ...extendKeymaps];
+    } else {
+      return this.getBasicKeymaps();
+    }
   }
 
   private emitOnChange(opt: IKeymap, direction: IModDirection, mods: IMod[]) {
@@ -161,7 +173,7 @@ export default class TabKey extends React.Component<OwnProps, OwnState> {
       <React.Fragment>
         <AutocompleteKeys
           label="Keycode"
-          keycodeOptions={this.basicKeymaps}
+          keycodeOptions={this.basicKeymapsWithBmp}
           keycodeInfo={this.props.value}
           onChange={(opt) => {
             this.onChangeKeycode(opt);

--- a/src/components/configure/keycodekey/KeyGen.ts
+++ b/src/components/configure/keycodekey/KeyGen.ts
@@ -30,12 +30,12 @@ type KeytopWithShiftRightALt = {
   meta: string; // label with shift(show the label at top-center)
   metaRight: string; // label with RightAlt(show the label at mid-right)
 };
-export const KetopWithShiftLangs: KeyboardLabelLang[] = [
+export const KeytopWithShiftLangs: KeyboardLabelLang[] = [
   'en-us',
   'ja-jp',
   'en-gb',
 ];
-export const KetopWithShiftRightAltLangs: KeyboardLabelLang[] = [];
+export const KeytopWithShiftRightAltLangs: KeyboardLabelLang[] = [];
 
 const MOD_SHORT_LABELS = ['0', 'C', 'S', '3', 'A', '5', '6', '7', 'W'];
 
@@ -118,13 +118,13 @@ export const genKey = (keymap: IKeymap, lang: KeyboardLabelLang): Key => {
       keymap,
     };
   } else {
-    if (KetopWithShiftLangs.includes(lang)) {
+    if (KeytopWithShiftLangs.includes(lang)) {
       const keytop: KeytopWithShift = findKeytopWithShift(
         keymap,
         KeyLabelLangs.getKeyLabels(lang)
       );
       return { label: keytop.label, meta: keytop.meta, keymap };
-    } else if (KetopWithShiftRightAltLangs.includes(lang)) {
+    } else if (KeytopWithShiftRightAltLangs.includes(lang)) {
       const keytop: KeytopWithShiftRightALt = findKeytopWithShiftRightAlt(
         keymap,
         KeyLabelLangs.getKeyLabels(lang)

--- a/src/components/configure/keycodes/Keycodes.container.ts
+++ b/src/components/configure/keycodes/Keycodes.container.ts
@@ -11,6 +11,7 @@ const mapStateToProps = (state: RootState) => {
     selectedKey: state.configure.keycodeKey.selectedKey,
     layerCount: state.entities.device.layerCount,
     labelLang: state.app.labelLang,
+    bleMicroPro: state.entities.device.bleMicroPro,
   };
 };
 export type KeycodesStateType = ReturnType<typeof mapStateToProps>;

--- a/src/components/configure/keycodes/Keycodes.tsx
+++ b/src/components/configure/keycodes/Keycodes.tsx
@@ -8,6 +8,7 @@ import { IKeycodeCategory } from '../../../services/hid/Hid';
 import KeycodeAddKey from '../keycodekey/any/AddAnyKeycodeKey.container';
 import { KeyCategory } from '../../../services/hid/KeyCategoryList';
 import { genKeys, Key } from '../keycodekey/KeyGen';
+import { CATEGORY_LABEL_BMP } from '../../../services/hid/KeycodeInfoListBmp';
 
 type OwnProps = {};
 
@@ -17,42 +18,62 @@ type KeycodesProps = OwnProps &
 
 type OwnState = {
   category: string;
+  categoryKeys: { [category: string]: Key[] };
 };
 
 export default class Keycodes extends React.Component<KeycodesProps, OwnState> {
-  private categoryKeys: { [category: string]: Key[] } = {};
   constructor(props: KeycodesProps | Readonly<KeycodesProps>) {
     super(props);
     this.state = {
       category: 'Basic',
+      categoryKeys: {
+        Basic: genKeys(
+          KeyCategory.basic(this.props.labelLang!),
+          this.props.labelLang!
+        ),
+        Symbol: genKeys(
+          KeyCategory.symbol(this.props.labelLang!),
+          this.props.labelLang!
+        ),
+        Functions: genKeys(
+          KeyCategory.functions(this.props.labelLang!),
+          this.props.labelLang!
+        ),
+        Layer: genKeys(
+          KeyCategory.layer(this.props.layerCount!),
+          this.props.labelLang!
+        ),
+        Device: genKeys(
+          KeyCategory.device(this.props.labelLang!),
+          this.props.labelLang!
+        ),
+        // Macro: genKeys(KeyCategory.macro()),
+        Special: genKeys(
+          KeyCategory.special(this.props.labelLang!),
+          this.props.labelLang!
+        ),
+      },
     };
-    this.categoryKeys = {
-      Basic: genKeys(
-        KeyCategory.basic(this.props.labelLang!),
+  }
+
+  private addBmpCategory() {
+    const bmpLabel: string = CATEGORY_LABEL_BMP;
+    const categoryKeys = this.state.categoryKeys;
+    if (!Object.prototype.hasOwnProperty.call(categoryKeys, bmpLabel)) {
+      categoryKeys[bmpLabel] = genKeys(
+        KeyCategory.bmp(),
         this.props.labelLang!
-      ),
-      Symbol: genKeys(
-        KeyCategory.symbol(this.props.labelLang!),
-        this.props.labelLang!
-      ),
-      Functions: genKeys(
-        KeyCategory.functions(this.props.labelLang!),
-        this.props.labelLang!
-      ),
-      Layer: genKeys(
-        KeyCategory.layer(this.props.layerCount!),
-        this.props.labelLang!
-      ),
-      Device: genKeys(
-        KeyCategory.device(this.props.labelLang!),
-        this.props.labelLang!
-      ),
-      // Macro: genKeys(KeyCategory.macro()),
-      Special: genKeys(
-        KeyCategory.special(this.props.labelLang!),
-        this.props.labelLang!
-      ),
-    };
+      );
+      this.setState({ categoryKeys: categoryKeys });
+    }
+  }
+  private removeBmpCategory() {
+    const bmpLabel: string = CATEGORY_LABEL_BMP;
+    const categoryKeys = this.state.categoryKeys;
+    if (Object.prototype.hasOwnProperty.call(categoryKeys, bmpLabel)) {
+      delete categoryKeys[bmpLabel];
+      this.setState({ categoryKeys: categoryKeys });
+    }
   }
 
   // eslint-disable-next-line no-unused-vars
@@ -62,9 +83,19 @@ export default class Keycodes extends React.Component<KeycodesProps, OwnState> {
         KeyCategory.layer(nextProps.layerCount!),
         this.props.labelLang!
       );
-      this.categoryKeys['Layer'] = keys;
+      const categoryKeys = this.state.categoryKeys;
+      categoryKeys['Layer'] = keys;
+      this.setState({ categoryKeys: categoryKeys });
     }
     return true;
+  }
+
+  componentDidMount() {
+    if (this.props.bleMicroPro) {
+      this.addBmpCategory();
+    } else {
+      this.removeBmpCategory();
+    }
   }
 
   selectCategory = (category: string) => {
@@ -74,14 +105,14 @@ export default class Keycodes extends React.Component<KeycodesProps, OwnState> {
   render() {
     let keys: Key[];
     if (this.state.category) {
-      keys = this.categoryKeys[this.state.category] || [];
+      keys = this.state.categoryKeys[this.state.category] || [];
     } else {
       keys = [];
     }
     return (
       <React.Fragment>
         <div className="key-categories">
-          {Object.keys(this.categoryKeys).map((cat, index) => {
+          {Object.keys(this.state.categoryKeys).map((cat, index) => {
             return (
               <div className="key-category" key={index}>
                 <Button

--- a/src/components/configure/keymap/Keymap.container.ts
+++ b/src/components/configure/keymap/Keymap.container.ts
@@ -13,6 +13,7 @@ import { KeyboardLabelLang } from '../../../services/labellang/KeyLabelLangs';
 
 const mapStateToProps = (state: RootState) => {
   return {
+    bleMicroPro: state.entities.device.bleMicroPro,
     draggingKey: state.configure.keycodeKey.draggingKey,
     keyboardKeymap: state.entities.keyboardDefinition?.layouts.keymap,
     keyboardLabels: state.entities.keyboardDefinition?.layouts.labels,

--- a/src/components/configure/keymap/Keymap.tsx
+++ b/src/components/configure/keymap/Keymap.tsx
@@ -212,6 +212,7 @@ export default class Keymap extends React.Component<
             value={this.state.selectedKey!}
             layerCount={this.props.layerCount!}
             labelLang={this.props.labelLang!}
+            bleMicroPro={this.props.bleMicroPro!}
             onClose={this.onCloseCustomKeyPopup.bind(this)}
             onChange={(key: Key) => {
               this.onChangeKeymap(key);

--- a/src/services/hid/Composition.ts
+++ b/src/services/hid/Composition.ts
@@ -1348,46 +1348,62 @@ export class LooseKeycodeComposition implements ILooseKeycodeComposition {
     return JSON.parse(JSON.stringify(this.key));
   }
 
+  static genExtendKeymaps(
+    infoList: KeyInfo[],
+    kinds: KeymapCategory[]
+  ): IKeymap[] {
+    return infoList.map((info) => {
+      return {
+        code: info.keycodeInfo.code,
+        isAny: false,
+        direction: MOD_LEFT,
+        modifiers: [],
+        keycodeInfo: info.keycodeInfo,
+        kinds: kinds,
+        desc: info.desc,
+      };
+    });
+  }
+
   static genKeymaps(): IKeymap[] {
     if (LooseKeycodeComposition._looseKeycodeKeymaps)
       return LooseKeycodeComposition._looseKeycodeKeymaps;
 
-    const getKinds = (code: number): KeymapCategory[] => {
-      const list: IKeycodeCategoryInfo[] = [
-        KEY_SUB_CATEGORY_GRAVE_ESCAPE,
-        KEY_SUB_CATEGORY_SPACE_CADET,
-        KEY_SUB_CATEGORY_KEYBOARD,
-        KEY_SUB_CATEGORY_BOOTMAGIC,
-        KEY_SUB_CATEGORY_SOUND,
-        KEY_SUB_CATEGORY_BACKLIGHT,
-        KEY_SUB_CATEGORY_UNDERGLOW,
-        KEY_SUB_CATEGORY_MACRO,
-      ];
-
-      let kinds: KeymapCategory[] = [];
-      for (let i = 0; i < list.length; i++) {
-        const cat = list[i];
-        const index = cat.codes.indexOf(code);
-        if (0 <= index) {
-          kinds = cat.kinds;
-          break;
-        }
-      }
-      return kinds;
+    const getKeyInfo = (code: number): KeyInfo | undefined => {
+      return keyInfoList.find((info) => info.keycodeInfo.code === code);
     };
 
-    LooseKeycodeComposition._looseKeycodeKeymaps = keyInfoList.map((item) => {
-      const code = item.keycodeInfo.code;
-      return {
-        code: code,
-        isAny: false,
-        direction: MOD_LEFT,
-        modifiers: [],
-        keycodeInfo: item.keycodeInfo,
-        kinds: getKinds(code),
-        desc: item.desc,
-      };
+    const categoryInfoList: IKeycodeCategoryInfo[] = [
+      KEY_SUB_CATEGORY_GRAVE_ESCAPE,
+      KEY_SUB_CATEGORY_SPACE_CADET,
+      KEY_SUB_CATEGORY_KEYBOARD,
+      KEY_SUB_CATEGORY_BOOTMAGIC,
+      KEY_SUB_CATEGORY_SOUND,
+      KEY_SUB_CATEGORY_BACKLIGHT,
+      KEY_SUB_CATEGORY_UNDERGLOW,
+      KEY_SUB_CATEGORY_MACRO,
+    ];
+
+    LooseKeycodeComposition._looseKeycodeKeymaps = [];
+    categoryInfoList.forEach((cat: IKeycodeCategoryInfo) => {
+      const kinds = cat.kinds;
+      cat.codes.forEach((code) => {
+        const info = getKeyInfo(code);
+        if (info) {
+          const keymap: IKeymap = {
+            code: code,
+            isAny: false,
+            direction: MOD_LEFT,
+            modifiers: [],
+            keycodeInfo: info.keycodeInfo,
+            kinds: kinds,
+            desc: info.desc,
+          };
+          LooseKeycodeComposition._looseKeycodeKeymaps.push(keymap);
+        }
+      });
     });
+
     return LooseKeycodeComposition._looseKeycodeKeymaps;
   }
 

--- a/src/services/hid/KeyCategoryList.ts
+++ b/src/services/hid/KeyCategoryList.ts
@@ -11,6 +11,7 @@ import {
   ToggleLayerComposition,
 } from './Composition';
 import { IKeycodeCategoryInfo, IKeymap } from './Hid';
+import { bmpKeyInfoList } from './KeycodeInfoListBmp';
 
 export class KeyCategory {
   private static _basic: { [pos: string]: IKeymap[] } = {};
@@ -19,6 +20,7 @@ export class KeyCategory {
   private static _layer: { [layerCount: number]: IKeymap[] } = {};
   private static _special: { [pos: string]: IKeymap[] } = {};
   private static _device: { [pos: string]: IKeymap[] } = {};
+  private static _bmp: IKeymap[];
   private static _macro: IKeymap[];
 
   static basic(labelLang: KeyboardLabelLang): IKeymap[] {
@@ -147,6 +149,19 @@ export class KeyCategory {
     );
     KeyCategory._device[labelLang] = [...basicKeymaps, ...looseKeymaps];
     return KeyCategory._device[labelLang];
+  }
+
+  static bmp(): IKeymap[] {
+    if (KeyCategory._bmp) {
+      return KeyCategory._bmp;
+    }
+
+    const looseKeymaps: IKeymap[] = LooseKeycodeComposition.genExtendKeymaps(
+      bmpKeyInfoList,
+      ['extends', 'bmp']
+    );
+    KeyCategory._bmp = looseKeymaps;
+    return KeyCategory._bmp;
   }
 
   static macro(): IKeymap[] {

--- a/src/services/hid/KeycodeInfoListBmp.ts
+++ b/src/services/hid/KeycodeInfoListBmp.ts
@@ -1,0 +1,358 @@
+import { KeyInfo } from './KeycodeInfoList';
+
+export const CATEGORY_LABEL_BMP = 'BMP';
+
+export const bmpKeyInfoList: KeyInfo[] = [
+  {
+    desc: 'Disable BLE HID sending',
+    keycodeInfo: {
+      code: 24064,
+      name: {
+        long: 'BLE_DIS',
+        short: 'BLE_DIS',
+      },
+      label: 'BLE DIS',
+    },
+  },
+  {
+    desc: 'Enable BLE HID sending',
+    keycodeInfo: {
+      code: 24065,
+      name: {
+        long: 'BLE_EN',
+        short: 'BLE_EN',
+      },
+      label: 'BLE EN',
+    },
+  },
+  {
+    desc: 'Disable USB HID sending',
+    keycodeInfo: {
+      code: 24066,
+      name: {
+        long: 'USB_DIS',
+        short: 'USB_DIS',
+      },
+      label: 'USB DIS',
+    },
+  },
+  {
+    desc: 'Enable USB HID sending',
+    keycodeInfo: {
+      code: 24067,
+      name: {
+        long: 'USB_EN',
+        short: 'USB_EN',
+      },
+      label: 'USB EN',
+    },
+  },
+  {
+    desc: 'Enable BLE and disable USB',
+    keycodeInfo: {
+      code: 24068,
+      name: {
+        long: 'SEL_BLE',
+        short: 'SEL_BLE',
+      },
+      label: 'SEL BLE',
+    },
+  },
+  {
+    desc: 'Enable USB and disable BLE',
+    keycodeInfo: {
+      code: 24069,
+      name: {
+        long: 'SEL_USB',
+        short: 'SEL_USB',
+      },
+      label: 'SEL USB',
+    },
+  },
+  {
+    desc: 'Start advertising to PeerID 0',
+    keycodeInfo: {
+      code: 24070,
+      name: {
+        long: 'ADV_ID0',
+        short: 'ADV_ID0',
+      },
+      label: 'ADV ID0',
+    },
+  },
+  {
+    desc: 'Start advertising to PeerID 1',
+    keycodeInfo: {
+      code: 24071,
+      name: {
+        long: 'ADV_ID1',
+        short: 'ADV_ID1',
+      },
+      label: 'ADV ID1',
+    },
+  },
+  {
+    desc: 'Start advertising to PeerID 2',
+    keycodeInfo: {
+      code: 24072,
+      name: {
+        long: 'ADV_ID2',
+        short: 'ADV_ID2',
+      },
+      label: 'ADV ID2',
+    },
+  },
+  {
+    desc: 'Start advertising to PeerID 3',
+    keycodeInfo: {
+      code: 24073,
+      name: {
+        long: 'ADV_ID3',
+        short: 'ADV_ID3',
+      },
+      label: 'ADV ID3',
+    },
+  },
+  {
+    desc: 'Start advertising to PeerID 4',
+    keycodeInfo: {
+      code: 24074,
+      name: {
+        long: 'ADV_ID4',
+        short: 'ADV_ID4',
+      },
+      label: 'ADV ID4',
+    },
+  },
+  {
+    desc: 'Start advertising to PeerID 5',
+    keycodeInfo: {
+      code: 24075,
+      name: {
+        long: 'ADV_ID5',
+        short: 'ADV_ID5',
+      },
+      label: 'ADV ID5',
+    },
+  },
+  {
+    desc: 'Start advertising to PeerID 6',
+    keycodeInfo: {
+      code: 24076,
+      name: {
+        long: 'ADV_ID6',
+        short: 'ADV_ID6',
+      },
+      label: 'ADV ID6',
+    },
+  },
+  {
+    desc: 'Start advertising to PeerID 7',
+    keycodeInfo: {
+      code: 24077,
+      name: {
+        long: 'ADV_ID7',
+        short: 'ADV_ID7',
+      },
+      label: 'ADV ID7',
+    },
+  },
+  {
+    desc: 'Start advertising without whitelist',
+    keycodeInfo: {
+      code: 24078,
+      name: {
+        long: 'AD_WO_L',
+        short: 'AD_WO_L',
+      },
+      label: 'AD WO L',
+    },
+  },
+  {
+    desc: 'Delete bonding of PeerID 0',
+    keycodeInfo: {
+      code: 24079,
+      name: {
+        long: 'DEL_ID0',
+        short: 'DEL_ID0',
+      },
+      label: 'DEL ID0',
+    },
+  },
+  {
+    desc: 'Delete bonding of PeerID 1',
+    keycodeInfo: {
+      code: 24080,
+      name: {
+        long: 'DEL_ID1',
+        short: 'DEL_ID1',
+      },
+      label: 'DEL ID1',
+    },
+  },
+  {
+    desc: 'Delete bonding of PeerID 2',
+    keycodeInfo: {
+      code: 24081,
+      name: {
+        long: 'DEL_ID2',
+        short: 'DEL_ID2',
+      },
+      label: 'DEL ID2',
+    },
+  },
+  {
+    desc: 'Delete bonding of PeerID 3',
+    keycodeInfo: {
+      code: 24082,
+      name: {
+        long: 'DEL_ID3',
+        short: 'DEL_ID3',
+      },
+      label: 'DEL ID3',
+    },
+  },
+  {
+    desc: 'Delete bonding of PeerID 4',
+    keycodeInfo: {
+      code: 24083,
+      name: {
+        long: 'DEL_ID4',
+        short: 'DEL_ID4',
+      },
+      label: 'DEL ID4',
+    },
+  },
+  {
+    desc: 'Delete bonding of PeerID 5',
+    keycodeInfo: {
+      code: 24084,
+      name: {
+        long: 'DEL_ID5',
+        short: 'DEL_ID5',
+      },
+      label: 'DEL ID5',
+    },
+  },
+  {
+    desc: 'Delete bonding of PeerID 6',
+    keycodeInfo: {
+      code: 24085,
+      name: {
+        long: 'DEL_ID6',
+        short: 'DEL_ID6',
+      },
+      label: 'DEL ID6',
+    },
+  },
+  {
+    desc: 'Delete bonding of PeerID 7',
+    keycodeInfo: {
+      code: 24086,
+      name: {
+        long: 'DEL_ID7',
+        short: 'DEL_ID7',
+      },
+      label: 'DEL ID7',
+    },
+  },
+  {
+    desc: 'Delete all bonding',
+    keycodeInfo: {
+      code: 24087,
+      name: {
+        long: 'DELBNDS',
+        short: 'DELBNDS',
+      },
+      label: 'DELBNDS',
+    },
+  },
+  {
+    desc: 'Start bootloader',
+    keycodeInfo: {
+      code: 24088,
+      name: {
+        long: 'ENT_DFU',
+        short: 'ENT_DFU',
+      },
+      label: 'ENT DFU',
+    },
+  },
+  {
+    desc: 'Start web configurator',
+    keycodeInfo: {
+      code: 24089,
+      name: {
+        long: 'ENT_WEB',
+        short: 'ENT_WEB',
+      },
+      label: 'ENT WEB',
+    },
+  },
+  {
+    desc: 'Deep sleep mode',
+    keycodeInfo: {
+      code: 24090,
+      name: {
+        long: 'ENT_SLP',
+        short: 'ENT_SLP',
+      },
+      label: 'ENT SLP',
+    },
+  },
+  {
+    desc: 'Display battery level in milli volts',
+    keycodeInfo: {
+      code: 24091,
+      name: {
+        long: 'BATT_LV',
+        short: 'BATT_LV',
+      },
+      label: 'BATT LV',
+    },
+  },
+  {
+    desc: 'Save EEPROM emulation',
+    keycodeInfo: {
+      code: 24092,
+      name: {
+        long: 'SAVE_EE',
+        short: 'SAVE_EE',
+      },
+      label: 'BLE DIS',
+    },
+  },
+  {
+    desc: 'Delete EEPROM emulation',
+    keycodeInfo: {
+      code: 24093,
+      name: {
+        long: 'DEL_EE',
+        short: 'DEL_EE',
+      },
+      label: 'BLE DIS',
+    },
+  },
+  {
+    desc: 'Send Alt+` or LANG1',
+    keycodeInfo: {
+      code: 24094,
+      name: {
+        long: 'xEISU',
+        short: 'xEISU',
+      },
+      label: 'xEISU',
+    },
+  },
+  {
+    desc: 'Send Alt+` or LANG2',
+    keycodeInfo: {
+      code: 24095,
+      name: {
+        long: 'xKANA',
+        short: 'xKANA',
+      },
+      label: 'xKANA',
+    },
+  },
+];

--- a/src/services/hid/KeycodeList.ts
+++ b/src/services/hid/KeycodeList.ts
@@ -38,7 +38,9 @@ export type KeymapCategory =
   | 'special'
   | 'symbol'
   | 'underglow'
-  | 'us-symbol';
+  | 'us-symbol'
+  | 'extends'
+  | 'bmp';
 
 function isDefinedKey(ret: {
   value: IKeymap | null | undefined;


### PR DESCRIPTION
If the firmware of the connected keyboard is BLE Micro Pro(BMP), Remap shows some specific keycodes which are supported by BMP.

<img width="1677" alt="スクリーンショット 2021-03-24 12 39 44" src="https://user-images.githubusercontent.com/316463/112259496-c2c63d00-8cab-11eb-8d8a-6b29a7c43def.png">
<img width="1679" alt="スクリーンショット 2021-03-24 12 40 05" src="https://user-images.githubusercontent.com/316463/112259503-c4900080-8cab-11eb-8b62-475fbe7c86a7.png">
