### PR TITLE
Show shared keymaps and already applied keymaps dialog.

### DIFF
--- a/src/components/configure/content/Content.container.ts
+++ b/src/components/configure/content/Content.container.ts
@@ -19,6 +19,7 @@ const mapDispatchToProps = (_dispatch: any) => {
     fetchSavedKeymaps: (info: IDeviceInformation) => {
       _dispatch(storageActionsThunk.fetchMySavedKeymaps(info));
       _dispatch(storageActionsThunk.fetchSharedKeymaps(info));
+      _dispatch(storageActionsThunk.fetchMyAppliedKeymaps(info));
     },
   };
 };

--- a/src/components/configure/keymaplist/KeymapListPopover.container.ts
+++ b/src/components/configure/keymaplist/KeymapListPopover.container.ts
@@ -9,10 +9,7 @@ import {
 import { KeyboardLabelLang } from '../../../services/labellang/KeyLabelLangs';
 import { IKeymap } from '../../../services/hid/Hid';
 import { LayoutOption } from '../keymap/Keymap';
-import {
-  AbstractKeymapData,
-  SavedKeymapData,
-} from '../../../services/storage/Storage';
+import { AbstractKeymapData } from '../../../services/storage/Storage';
 import { storageActionsThunk } from '../../../actions/storage.action';
 
 // eslint-disable-next-line no-unused-vars

--- a/src/components/configure/keymaplist/KeymapListPopover.container.ts
+++ b/src/components/configure/keymaplist/KeymapListPopover.container.ts
@@ -9,7 +9,10 @@ import {
 import { KeyboardLabelLang } from '../../../services/labellang/KeyLabelLangs';
 import { IKeymap } from '../../../services/hid/Hid';
 import { LayoutOption } from '../keymap/Keymap';
-import { SavedKeymapData } from '../../../services/storage/Storage';
+import {
+  AbstractKeymapData,
+  SavedKeymapData,
+} from '../../../services/storage/Storage';
 import { storageActionsThunk } from '../../../actions/storage.action';
 
 // eslint-disable-next-line no-unused-vars
@@ -37,7 +40,7 @@ const mapDispatchToProps = (_dispatch: any) => {
       _dispatch(AppActions.remapsSetKeys(keymaps));
       _dispatch(LayoutOptionsActions.restoreLayoutOptions(layoutOptions));
     },
-    createOrUpdateAppliedKeymap: (savedKeymapData: SavedKeymapData) => {
+    createOrUpdateAppliedKeymap: (savedKeymapData: AbstractKeymapData) => {
       _dispatch(
         storageActionsThunk.createOrUpdateAppliedKeymap(savedKeymapData)
       );

--- a/src/components/configure/keymaplist/KeymapListPopover.scss
+++ b/src/components/configure/keymaplist/KeymapListPopover.scss
@@ -29,12 +29,6 @@
         /* Chrome, Safari  */
         display: none;
       }
-      .no-saved-keymap {
-        padding-bottom: $space-l;
-        .keymaplist-warning {
-          color: $warning;
-        }
-      }
       .my-keymaplist-header {
         display: flex;
         flex-direction: row;

--- a/src/components/configure/keymaplist/KeymapListPopover.scss
+++ b/src/components/configure/keymaplist/KeymapListPopover.scss
@@ -2,7 +2,7 @@
 
 .keymaplist-root {
   .keymaplist {
-    padding: 0 $space-l;
+    padding: 0 $space-l $space-m $space-l;
   }
   .keymaplist-popover {
     width: 330px;

--- a/src/components/configure/keymaplist/KeymapListPopover.tsx
+++ b/src/components/configure/keymaplist/KeymapListPopover.tsx
@@ -25,6 +25,7 @@ import { KeycodeList } from '../../../services/hid/KeycodeList';
 import AuthProviderDialog from '../auth/AuthProviderDialog.container';
 import { sendEventToGoogleAnalytics } from '../../../utils/GoogleAnalytics';
 import { SupervisorAccount } from '@material-ui/icons';
+import SharedKeymapsDialog from './SharedKeymapsDialog';
 
 type PopoverPosition = {
   left: number;
@@ -46,6 +47,7 @@ type OwnState = {
   savedKeymapData: SavedKeymapData | null;
   openAuthProviderDialog: boolean;
   popoverPosition: PopoverPosition;
+  openSharedKeymapsDialog: boolean;
 };
 
 export default class KeymapListPopover extends React.Component<
@@ -60,6 +62,7 @@ export default class KeymapListPopover extends React.Component<
       savedKeymapData: null,
       openAuthProviderDialog: false,
       popoverPosition: { top: 0, left: 0 },
+      openSharedKeymapsDialog: false,
     };
     this.popoverRef = React.createRef<HTMLDivElement>();
   }
@@ -135,6 +138,14 @@ export default class KeymapListPopover extends React.Component<
     this.setState({ openAuthProviderDialog: false });
   }
 
+  private onClickMore() {
+    this.setState({ openSharedKeymapsDialog: true });
+  }
+
+  private onCloseSharedKeymapsDialog() {
+    this.setState({ openSharedKeymapsDialog: false });
+  }
+
   render() {
     if (!this.props.position) {
       return <></>;
@@ -167,6 +178,7 @@ export default class KeymapListPopover extends React.Component<
                 onClickApplySavedKeymapData={this.onClickApplySavedKeymapData.bind(
                   this
                 )}
+                onClickMore={this.onClickMore.bind(this)}
               />
               <KeymapSaveDialog
                 open={this.state.openKeymapSaveDialog}
@@ -177,6 +189,12 @@ export default class KeymapListPopover extends React.Component<
                 }
                 onClose={() => {
                   this.onCloseKeymapSaveDialog();
+                }}
+              />
+              <SharedKeymapsDialog
+                open={this.state.openSharedKeymapsDialog}
+                onClose={() => {
+                  this.onCloseSharedKeymapsDialog();
                 }}
               />
             </>
@@ -203,6 +221,7 @@ type KeymapListProps = {
   ) => void;
   // eslint-disable-next-line no-unused-vars
   onClickApplySavedKeymapData: (savedKeymapData: SavedKeymapData) => void;
+  onClickMore: () => void;
 };
 
 function KeymapList(props: KeymapListProps) {
@@ -250,6 +269,7 @@ function KeymapList(props: KeymapListProps) {
           <SharedKeymapList
             sharedKeymaps={props.sharedKeymaps}
             onClickApplySavedKeymapData={props.onClickApplySavedKeymapData}
+            onClickMore={props.onClickMore}
           />
         )}
       </div>
@@ -261,6 +281,7 @@ type ISharedKeymapListProps = {
   sharedKeymaps: SavedKeymapData[];
   // eslint-disable-next-line no-unused-vars
   onClickApplySavedKeymapData: (savedKeymapData: SavedKeymapData) => void;
+  onClickMore: () => void;
 };
 function SharedKeymapList(props: ISharedKeymapListProps) {
   return (
@@ -305,7 +326,7 @@ function SharedKeymapList(props: ISharedKeymapListProps) {
       {props.sharedKeymaps!.length === 0 && (
         <div className="no-saved-keymap">There is no shared keymaps.</div>
       )}
-      <Button>more...</Button>
+      <Button onClick={() => props.onClickMore()}>more...</Button>
     </React.Fragment>
   );
 }

--- a/src/components/configure/keymaplist/KeymapListPopover.tsx
+++ b/src/components/configure/keymaplist/KeymapListPopover.tsx
@@ -21,7 +21,6 @@ import EditRoundedIcon from '@material-ui/icons/EditRounded';
 import KeymapSaveDialog from './KeymapSaveDialog.container';
 import {
   AbstractKeymapData,
-  AppliedKeymapData,
   SavedKeymapData,
 } from '../../../services/storage/Storage';
 import { IKeymap } from '../../../services/hid/Hid';

--- a/src/components/configure/keymaplist/KeymapListPopover.tsx
+++ b/src/components/configure/keymaplist/KeymapListPopover.tsx
@@ -266,43 +266,46 @@ function SharedKeymapList(props: ISharedKeymapListProps) {
   return (
     <React.Fragment>
       <List dense={true}>
-        {props.sharedKeymaps.map((item: SavedKeymapData, index) => {
-          return (
-            <ListItem
-              key={`keymaplist-keymap${index}`}
-              button
-              onClick={() => {
-                props.onClickApplySavedKeymapData(item);
-              }}
-            >
-              <ListItemText
-                primary={
-                  <React.Fragment>
-                    <Typography
-                      component="span"
-                      variant="body1"
-                      color="textPrimary"
-                    >
-                      {item.title}
-                    </Typography>
-                    <Typography
-                      component="span"
-                      variant="body2"
-                      color="textSecondary"
-                    >
-                      {` by ${item.author_display_name}`}
-                    </Typography>
-                  </React.Fragment>
-                }
-                secondary={item.desc}
-              />
-            </ListItem>
-          );
-        })}
+        {props.sharedKeymaps
+          .slice(0, 10)
+          .map((item: SavedKeymapData, index) => {
+            return (
+              <ListItem
+                key={`keymaplist-keymap${index}`}
+                button
+                onClick={() => {
+                  props.onClickApplySavedKeymapData(item);
+                }}
+              >
+                <ListItemText
+                  primary={
+                    <React.Fragment>
+                      <Typography
+                        component="span"
+                        variant="body1"
+                        color="textPrimary"
+                      >
+                        {item.title}
+                      </Typography>
+                      <Typography
+                        component="span"
+                        variant="body2"
+                        color="textSecondary"
+                      >
+                        {` by ${item.author_display_name}`}
+                      </Typography>
+                    </React.Fragment>
+                  }
+                  secondary={item.desc}
+                />
+              </ListItem>
+            );
+          })}
       </List>
       {props.sharedKeymaps!.length === 0 && (
         <div className="no-saved-keymap">There is no shared keymaps.</div>
       )}
+      <Button>more...</Button>
     </React.Fragment>
   );
 }

--- a/src/components/configure/keymaplist/KeymapListPopover.tsx
+++ b/src/components/configure/keymaplist/KeymapListPopover.tsx
@@ -19,7 +19,11 @@ import {
 } from '@material-ui/core';
 import EditRoundedIcon from '@material-ui/icons/EditRounded';
 import KeymapSaveDialog from './KeymapSaveDialog.container';
-import { SavedKeymapData } from '../../../services/storage/Storage';
+import {
+  AbstractKeymapData,
+  AppliedKeymapData,
+  SavedKeymapData,
+} from '../../../services/storage/Storage';
 import { IKeymap } from '../../../services/hid/Hid';
 import { KeycodeList } from '../../../services/hid/KeycodeList';
 import AuthProviderDialog from '../auth/AuthProviderDialog.container';
@@ -91,7 +95,7 @@ export default class KeymapListPopover extends React.Component<
     }
   }
 
-  private onClickApplySavedKeymapData(savedKeymapData: SavedKeymapData) {
+  private onClickApplySavedKeymapData(savedKeymapData: AbstractKeymapData) {
     sendEventToGoogleAnalytics('configure/restore_keymap', {
       vendor_id: savedKeymapData.vendor_id,
       product_id: savedKeymapData.product_id,
@@ -224,7 +228,7 @@ type KeymapListProps = {
     savedKeymapData: SavedKeymapData | null
   ) => void;
   // eslint-disable-next-line no-unused-vars
-  onClickApplySavedKeymapData: (savedKeymapData: SavedKeymapData) => void;
+  onClickApplySavedKeymapData: (savedKeymapData: AbstractKeymapData) => void;
   onClickMore: () => void;
 };
 

--- a/src/components/configure/keymaplist/KeymapListPopover.tsx
+++ b/src/components/configure/keymaplist/KeymapListPopover.tsx
@@ -275,6 +275,7 @@ function KeymapList(props: KeymapListProps) {
             onClickApplySavedKeymapData={props.onClickApplySavedKeymapData}
             showMore={true}
             onClickMore={props.onClickMore}
+            limit={10}
           />
         )}
       </div>

--- a/src/components/configure/keymaplist/KeymapListPopover.tsx
+++ b/src/components/configure/keymaplist/KeymapListPopover.tsx
@@ -25,7 +25,8 @@ import { KeycodeList } from '../../../services/hid/KeycodeList';
 import AuthProviderDialog from '../auth/AuthProviderDialog.container';
 import { sendEventToGoogleAnalytics } from '../../../utils/GoogleAnalytics';
 import { SupervisorAccount } from '@material-ui/icons';
-import SharedKeymapsDialog from './SharedKeymapsDialog';
+import SharedKeymapsDialog from './SharedKeymapsDialog.container';
+import { SharedKeymapList } from './SharedKeymapList';
 
 type PopoverPosition = {
   left: number;
@@ -196,6 +197,9 @@ export default class KeymapListPopover extends React.Component<
                 onClose={() => {
                   this.onCloseSharedKeymapsDialog();
                 }}
+                onClickApplySavedKeymapData={this.onClickApplySavedKeymapData.bind(
+                  this
+                )}
               />
             </>
           ) : (
@@ -269,65 +273,12 @@ function KeymapList(props: KeymapListProps) {
           <SharedKeymapList
             sharedKeymaps={props.sharedKeymaps}
             onClickApplySavedKeymapData={props.onClickApplySavedKeymapData}
+            showMore={true}
             onClickMore={props.onClickMore}
           />
         )}
       </div>
     </>
-  );
-}
-
-type ISharedKeymapListProps = {
-  sharedKeymaps: SavedKeymapData[];
-  // eslint-disable-next-line no-unused-vars
-  onClickApplySavedKeymapData: (savedKeymapData: SavedKeymapData) => void;
-  onClickMore: () => void;
-};
-function SharedKeymapList(props: ISharedKeymapListProps) {
-  return (
-    <React.Fragment>
-      <List dense={true}>
-        {props.sharedKeymaps
-          .slice(0, 10)
-          .map((item: SavedKeymapData, index) => {
-            return (
-              <ListItem
-                key={`keymaplist-keymap${index}`}
-                button
-                onClick={() => {
-                  props.onClickApplySavedKeymapData(item);
-                }}
-              >
-                <ListItemText
-                  primary={
-                    <React.Fragment>
-                      <Typography
-                        component="span"
-                        variant="body1"
-                        color="textPrimary"
-                      >
-                        {item.title}
-                      </Typography>
-                      <Typography
-                        component="span"
-                        variant="body2"
-                        color="textSecondary"
-                      >
-                        {` by ${item.author_display_name}`}
-                      </Typography>
-                    </React.Fragment>
-                  }
-                  secondary={item.desc}
-                />
-              </ListItem>
-            );
-          })}
-      </List>
-      {props.sharedKeymaps!.length === 0 && (
-        <div className="no-saved-keymap">There is no shared keymaps.</div>
-      )}
-      <Button onClick={() => props.onClickMore()}>more...</Button>
-    </React.Fragment>
   );
 }
 

--- a/src/components/configure/keymaplist/KeymapSaveDialog.tsx
+++ b/src/components/configure/keymaplist/KeymapSaveDialog.tsx
@@ -48,7 +48,7 @@ type OwnState = {
   desc: string;
   shared: boolean;
 };
-export default class LayoutOptionPopover extends React.Component<
+export default class KeymapSaveDialog extends React.Component<
   KeymapSaveDialogProps,
   OwnState
 > {

--- a/src/components/configure/keymaplist/SharedKeymapList.scss
+++ b/src/components/configure/keymaplist/SharedKeymapList.scss
@@ -1,0 +1,5 @@
+@import '../../../variables';
+
+.shared-keymap-list-no-saved-keymap {
+  padding-bottom: $space-l;
+}

--- a/src/components/configure/keymaplist/SharedKeymapList.tsx
+++ b/src/components/configure/keymaplist/SharedKeymapList.tsx
@@ -1,7 +1,4 @@
-import {
-  AbstractKeymapData,
-  SavedKeymapData,
-} from '../../../services/storage/Storage';
+import { AbstractKeymapData } from '../../../services/storage/Storage';
 import React from 'react';
 import {
   Button,
@@ -28,7 +25,7 @@ export function SharedKeymapList(props: ISharedKeymapListProps) {
   return (
     <React.Fragment>
       <List dense={true}>
-        {sharedKeymaps.map((item: AbstractKeymapData, index) => {
+        {sharedKeymaps.map((item: AbstractKeymapData) => {
           return (
             <ListItem
               key={`shared-keymap-item-${item.id}`}

--- a/src/components/configure/keymaplist/SharedKeymapList.tsx
+++ b/src/components/configure/keymaplist/SharedKeymapList.tsx
@@ -1,0 +1,68 @@
+import { SavedKeymapData } from '../../../services/storage/Storage';
+import React from 'react';
+import {
+  Button,
+  List,
+  ListItem,
+  ListItemText,
+  Typography,
+} from '@material-ui/core';
+import './SharedKeymapList.scss';
+
+type ISharedKeymapListProps = {
+  sharedKeymaps: SavedKeymapData[];
+  // eslint-disable-next-line no-unused-vars
+  onClickApplySavedKeymapData: (savedKeymapData: SavedKeymapData) => void;
+  showMore: boolean;
+  onClickMore?: () => void;
+};
+
+export function SharedKeymapList(props: ISharedKeymapListProps) {
+  return (
+    <React.Fragment>
+      <List dense={true}>
+        {props.sharedKeymaps.map((item: SavedKeymapData, index) => {
+          return (
+            <ListItem
+              key={`shared-keymap-list-${index}`}
+              button
+              onClick={() => {
+                props.onClickApplySavedKeymapData(item);
+              }}
+            >
+              <ListItemText
+                primary={
+                  <React.Fragment>
+                    <Typography
+                      component="span"
+                      variant="body1"
+                      color="textPrimary"
+                    >
+                      {item.title}
+                    </Typography>
+                    <Typography
+                      component="span"
+                      variant="body2"
+                      color="textSecondary"
+                    >
+                      {` by ${item.author_display_name}`}
+                    </Typography>
+                  </React.Fragment>
+                }
+                secondary={item.desc}
+              />
+            </ListItem>
+          );
+        })}
+      </List>
+      {props.sharedKeymaps!.length === 0 && (
+        <div className="shared-keymap-list-no-saved-keymap">
+          There is no shared keymaps.
+        </div>
+      )}
+      {props.showMore ? (
+        <Button onClick={() => props.onClickMore!()}>more...</Button>
+      ) : null}
+    </React.Fragment>
+  );
+}

--- a/src/components/configure/keymaplist/SharedKeymapList.tsx
+++ b/src/components/configure/keymaplist/SharedKeymapList.tsx
@@ -15,13 +15,17 @@ type ISharedKeymapListProps = {
   onClickApplySavedKeymapData: (savedKeymapData: SavedKeymapData) => void;
   showMore: boolean;
   onClickMore?: () => void;
+  limit?: number;
 };
 
 export function SharedKeymapList(props: ISharedKeymapListProps) {
+  const sharedKeymaps = props.limit
+    ? props.sharedKeymaps.slice(0, props.limit)
+    : props.sharedKeymaps;
   return (
     <React.Fragment>
       <List dense={true}>
-        {props.sharedKeymaps.map((item: SavedKeymapData, index) => {
+        {sharedKeymaps.map((item: SavedKeymapData, index) => {
           return (
             <ListItem
               key={`shared-keymap-list-${index}`}

--- a/src/components/configure/keymaplist/SharedKeymapList.tsx
+++ b/src/components/configure/keymaplist/SharedKeymapList.tsx
@@ -1,4 +1,7 @@
-import { SavedKeymapData } from '../../../services/storage/Storage';
+import {
+  AbstractKeymapData,
+  SavedKeymapData,
+} from '../../../services/storage/Storage';
 import React from 'react';
 import {
   Button,
@@ -10,9 +13,9 @@ import {
 import './SharedKeymapList.scss';
 
 type ISharedKeymapListProps = {
-  sharedKeymaps: SavedKeymapData[];
+  sharedKeymaps: AbstractKeymapData[];
   // eslint-disable-next-line no-unused-vars
-  onClickApplySavedKeymapData: (savedKeymapData: SavedKeymapData) => void;
+  onClickApplySavedKeymapData: (savedKeymapData: AbstractKeymapData) => void;
   showMore: boolean;
   onClickMore?: () => void;
   limit?: number;
@@ -25,10 +28,10 @@ export function SharedKeymapList(props: ISharedKeymapListProps) {
   return (
     <React.Fragment>
       <List dense={true}>
-        {sharedKeymaps.map((item: SavedKeymapData, index) => {
+        {sharedKeymaps.map((item: AbstractKeymapData, index) => {
           return (
             <ListItem
-              key={`shared-keymap-list-${index}`}
+              key={`shared-keymap-item-${item.id}`}
               button
               onClick={() => {
                 props.onClickApplySavedKeymapData(item);
@@ -61,7 +64,7 @@ export function SharedKeymapList(props: ISharedKeymapListProps) {
       </List>
       {props.sharedKeymaps!.length === 0 && (
         <div className="shared-keymap-list-no-saved-keymap">
-          There is no shared keymaps.
+          There is no keymap.
         </div>
       )}
       {props.showMore ? (

--- a/src/components/configure/keymaplist/SharedKeymapsDialog.container.ts
+++ b/src/components/configure/keymaplist/SharedKeymapsDialog.container.ts
@@ -3,7 +3,9 @@ import SharedKeymapsDialog from './SharedKeymapsDialog';
 import { RootState } from '../../../store/state';
 
 const mapStateToProps = (state: RootState) => {
-  return {};
+  return {
+    sharedKeymaps: state.entities.sharedKeymaps,
+  };
 };
 export type SharedKeymapsDialogStateType = ReturnType<typeof mapStateToProps>;
 

--- a/src/components/configure/keymaplist/SharedKeymapsDialog.container.ts
+++ b/src/components/configure/keymaplist/SharedKeymapsDialog.container.ts
@@ -10,6 +10,7 @@ const mapStateToProps = (state: RootState) => {
 };
 export type SharedKeymapsDialogStateType = ReturnType<typeof mapStateToProps>;
 
+// eslint-disable-next-line no-unused-vars
 const mapDispatchToProps = (_dispatch: any) => {
   return {};
 };

--- a/src/components/configure/keymaplist/SharedKeymapsDialog.container.ts
+++ b/src/components/configure/keymaplist/SharedKeymapsDialog.container.ts
@@ -5,6 +5,7 @@ import { RootState } from '../../../store/state';
 const mapStateToProps = (state: RootState) => {
   return {
     sharedKeymaps: state.entities.sharedKeymaps,
+    appliedKeymaps: state.entities.appliedKeymaps,
   };
 };
 export type SharedKeymapsDialogStateType = ReturnType<typeof mapStateToProps>;

--- a/src/components/configure/keymaplist/SharedKeymapsDialog.container.ts
+++ b/src/components/configure/keymaplist/SharedKeymapsDialog.container.ts
@@ -1,0 +1,21 @@
+import { connect } from 'react-redux';
+import SharedKeymapsDialog from './SharedKeymapsDialog';
+import { RootState } from '../../../store/state';
+
+const mapStateToProps = (state: RootState) => {
+  return {};
+};
+export type SharedKeymapsDialogStateType = ReturnType<typeof mapStateToProps>;
+
+const mapDispatchToProps = (_dispatch: any) => {
+  return {};
+};
+
+export type SharedKeymapsDialogActionsType = ReturnType<
+  typeof mapDispatchToProps
+>;
+
+export default connect(
+  mapStateToProps,
+  mapDispatchToProps
+)(SharedKeymapsDialog);

--- a/src/components/configure/keymaplist/SharedKeymapsDialog.scss
+++ b/src/components/configure/keymaplist/SharedKeymapsDialog.scss
@@ -16,5 +16,11 @@
     width: 540px;
     display: flex;
     flex-direction: column;
+
+    .shared-keymaps-dialog-filter-row {
+      display: flex;
+      flex-direction: row;
+      justify-content: flex-end;
+    }
   }
 }

--- a/src/components/configure/keymaplist/SharedKeymapsDialog.scss
+++ b/src/components/configure/keymaplist/SharedKeymapsDialog.scss
@@ -1,0 +1,20 @@
+@import '../../../variables';
+
+.shared-keymaps-dialog {
+  .close-dialog {
+    position: absolute;
+    top: 20px;
+    right: 20px;
+
+    &:hover {
+      color: $primary-light;
+      cursor: pointer;
+    }
+  }
+
+  .shared-keymaps-dialog-content {
+    width: 540px;
+    display: flex;
+    flex-direction: column;
+  }
+}

--- a/src/components/configure/keymaplist/SharedKeymapsDialog.scss
+++ b/src/components/configure/keymaplist/SharedKeymapsDialog.scss
@@ -14,8 +14,16 @@
 
   .shared-keymaps-dialog-content {
     width: 540px;
+    height: 440px;
     display: flex;
-    flex-direction: column;
+    flex-direction: row;
+
+    &-body {
+      display: flex;
+      flex-direction: column;
+      flex: 1 1;
+      margin-left: 16px;
+    }
 
     .shared-keymaps-dialog-filter-row {
       display: flex;

--- a/src/components/configure/keymaplist/SharedKeymapsDialog.tsx
+++ b/src/components/configure/keymaplist/SharedKeymapsDialog.tsx
@@ -15,13 +15,16 @@ import {
 } from '@material-ui/core';
 import CloseIcon from '@material-ui/icons/Close';
 import { SharedKeymapList } from './SharedKeymapList';
-import { SavedKeymapData } from '../../../services/storage/Storage';
+import {
+  AbstractKeymapData,
+  SavedKeymapData,
+} from '../../../services/storage/Storage';
 
 type OwnProps = {
   open: boolean;
   onClose: () => void;
   // eslint-disable-next-line no-unused-vars
-  onClickApplySavedKeymapData: (savedKeymapData: SavedKeymapData) => void;
+  onClickApplySavedKeymapData: (savedKeymapData: AbstractKeymapData) => void;
 };
 
 type SharedKeymapsDialogProps = OwnProps &
@@ -129,7 +132,15 @@ export default class SharedKeymapsDialog extends React.Component<
                   showMore={false}
                 />
               </React.Fragment>
-            ) : null}
+            ) : (
+              <SharedKeymapList
+                sharedKeymaps={this.props.appliedKeymaps!}
+                onClickApplySavedKeymapData={
+                  this.props.onClickApplySavedKeymapData
+                }
+                showMore={false}
+              />
+            )}
           </div>
         </DialogContent>
       </Dialog>

--- a/src/components/configure/keymaplist/SharedKeymapsDialog.tsx
+++ b/src/components/configure/keymaplist/SharedKeymapsDialog.tsx
@@ -5,8 +5,20 @@ import {
   SharedKeymapsDialogActionsType,
   SharedKeymapsDialogStateType,
 } from './SharedKeymapsDialog.container';
+import {
+  Dialog,
+  DialogContent,
+  DialogTitle,
+  Paper,
+  PaperProps,
+} from '@material-ui/core';
+import Draggable from 'react-draggable';
+import CloseIcon from '@material-ui/icons/Close';
 
-type OwnProps = {};
+type OwnProps = {
+  open: boolean;
+  onClose: () => void;
+};
 
 type SharedKeymapsDialogProps = OwnProps &
   Partial<SharedKeymapsDialogActionsType> &
@@ -21,4 +33,41 @@ export default class SharedKeymapsDialog extends React.Component<
     super(props);
     this.state = {};
   }
+
+  private onEnter() {
+    this.setState({});
+  }
+
+  render() {
+    return (
+      <Dialog
+        open={this.props.open}
+        maxWidth={'md'}
+        PaperComponent={PaperComponent}
+        className="shared-keymaps-dialog"
+        onEnter={this.onEnter.bind(this)}
+      >
+        <DialogTitle>
+          Shared Keymaps
+          <div className="close-dialog">
+            <CloseIcon onClick={this.props.onClose} />
+          </div>
+        </DialogTitle>
+        <DialogContent dividers className="shared-keymaps-dialog-content">
+          xxx
+        </DialogContent>
+      </Dialog>
+    );
+  }
+}
+
+function PaperComponent(props: PaperProps) {
+  return (
+    <Draggable
+      handle="#draggable-dialog-title"
+      cancel={'[class*="MuiDialogContent-root"]'}
+    >
+      <Paper {...props} />
+    </Draggable>
+  );
 }

--- a/src/components/configure/keymaplist/SharedKeymapsDialog.tsx
+++ b/src/components/configure/keymaplist/SharedKeymapsDialog.tsx
@@ -30,6 +30,7 @@ type SharedKeymapsDialogProps = OwnProps &
 
 type OwnState = {
   activeTabIndex: number;
+  filterKeyword: string;
 };
 export default class SharedKeymapsDialog extends React.Component<
   SharedKeymapsDialogProps,
@@ -39,11 +40,15 @@ export default class SharedKeymapsDialog extends React.Component<
     super(props);
     this.state = {
       activeTabIndex: 0,
+      filterKeyword: '',
     };
   }
 
   private onEnter() {
-    this.setState({});
+    this.setState({
+      filterKeyword: '',
+      activeTabIndex: 0,
+    });
   }
 
   private onActiveTabIndexChange(
@@ -53,7 +58,33 @@ export default class SharedKeymapsDialog extends React.Component<
     this.setState({ activeTabIndex: newValue });
   }
 
+  private onFilterChanged(event: React.ChangeEvent<HTMLInputElement>) {
+    this.setState({
+      filterKeyword: event.target.value,
+    });
+  }
+
   render() {
+    let sharedKeymaps: SavedKeymapData[];
+    if (this.props.sharedKeymaps) {
+      sharedKeymaps = this.state.filterKeyword
+        ? this.props.sharedKeymaps!.filter((sharedKeymap) => {
+            return (
+              sharedKeymap.title
+                .toLowerCase()
+                .includes(this.state.filterKeyword.toLowerCase()) ||
+              sharedKeymap.desc
+                .toLowerCase()
+                .includes(this.state.filterKeyword.toLowerCase()) ||
+              sharedKeymap.author_display_name
+                ?.toLowerCase()
+                .includes(this.state.filterKeyword.toLowerCase())
+            );
+          })
+        : this.props.sharedKeymaps;
+    } else {
+      sharedKeymaps = [];
+    }
     return (
       <Dialog
         open={this.props.open}
@@ -74,30 +105,32 @@ export default class SharedKeymapsDialog extends React.Component<
             indicatorColor="primary"
             textColor="primary"
             aria-label="shared-keymaps"
+            orientation="vertical"
           >
             <Tab label="Shared Keymaps" />
             <Tab label="Applied History" />
           </Tabs>
-          {this.state.activeTabIndex === 0 ? (
-            <React.Fragment>
-              <div className="shared-keymaps-dialog-filter-row">
-                <TextField
-                  label="Filter"
-                  // value={this.props.nameFilter}
-                  // onChange={(e) => this.props.updateNameFilter!(e.target.value)}
+          <div className="shared-keymaps-dialog-content-body">
+            {this.state.activeTabIndex === 0 ? (
+              <React.Fragment>
+                <div className="shared-keymaps-dialog-filter-row">
+                  <TextField
+                    label="Filter"
+                    size="small"
+                    value={this.state.filterKeyword}
+                    onChange={this.onFilterChanged.bind(this)}
+                  />
+                </div>
+                <SharedKeymapList
+                  sharedKeymaps={sharedKeymaps}
+                  onClickApplySavedKeymapData={
+                    this.props.onClickApplySavedKeymapData
+                  }
+                  showMore={false}
                 />
-              </div>
-              <SharedKeymapList
-                sharedKeymaps={this.props.sharedKeymaps!}
-                onClickApplySavedKeymapData={
-                  this.props.onClickApplySavedKeymapData
-                }
-                showMore={false}
-              />
-            </React.Fragment>
-          ) : (
-            <></>
-          )}
+              </React.Fragment>
+            ) : null}
+          </div>
         </DialogContent>
       </Dialog>
     );

--- a/src/components/configure/keymaplist/SharedKeymapsDialog.tsx
+++ b/src/components/configure/keymaplist/SharedKeymapsDialog.tsx
@@ -11,30 +11,46 @@ import {
   DialogTitle,
   Tab,
   Tabs,
+  TextField,
 } from '@material-ui/core';
 import CloseIcon from '@material-ui/icons/Close';
+import { SharedKeymapList } from './SharedKeymapList';
+import { SavedKeymapData } from '../../../services/storage/Storage';
 
 type OwnProps = {
   open: boolean;
   onClose: () => void;
+  // eslint-disable-next-line no-unused-vars
+  onClickApplySavedKeymapData: (savedKeymapData: SavedKeymapData) => void;
 };
 
 type SharedKeymapsDialogProps = OwnProps &
   Partial<SharedKeymapsDialogActionsType> &
   Partial<SharedKeymapsDialogStateType>;
 
-type OwnState = {};
+type OwnState = {
+  activeTabIndex: number;
+};
 export default class SharedKeymapsDialog extends React.Component<
   SharedKeymapsDialogProps,
   OwnState
 > {
   constructor(props: OwnProps | Readonly<OwnProps>) {
     super(props);
-    this.state = {};
+    this.state = {
+      activeTabIndex: 0,
+    };
   }
 
   private onEnter() {
     this.setState({});
+  }
+
+  private onActiveTabIndexChange(
+    event: React.ChangeEvent<{}>,
+    newValue: number
+  ) {
+    this.setState({ activeTabIndex: newValue });
   }
 
   render() {
@@ -53,7 +69,8 @@ export default class SharedKeymapsDialog extends React.Component<
         </DialogTitle>
         <DialogContent dividers className="shared-keymaps-dialog-content">
           <Tabs
-            value={0}
+            value={this.state.activeTabIndex}
+            onChange={this.onActiveTabIndexChange.bind(this)}
             indicatorColor="primary"
             textColor="primary"
             aria-label="shared-keymaps"
@@ -61,6 +78,26 @@ export default class SharedKeymapsDialog extends React.Component<
             <Tab label="Shared Keymaps" />
             <Tab label="Applied History" />
           </Tabs>
+          {this.state.activeTabIndex === 0 ? (
+            <React.Fragment>
+              <div className="shared-keymaps-dialog-filter-row">
+                <TextField
+                  label="Filter"
+                  // value={this.props.nameFilter}
+                  // onChange={(e) => this.props.updateNameFilter!(e.target.value)}
+                />
+              </div>
+              <SharedKeymapList
+                sharedKeymaps={this.props.sharedKeymaps!}
+                onClickApplySavedKeymapData={
+                  this.props.onClickApplySavedKeymapData
+                }
+                showMore={false}
+              />
+            </React.Fragment>
+          ) : (
+            <></>
+          )}
         </DialogContent>
       </Dialog>
     );

--- a/src/components/configure/keymaplist/SharedKeymapsDialog.tsx
+++ b/src/components/configure/keymaplist/SharedKeymapsDialog.tsx
@@ -1,0 +1,24 @@
+/* eslint-disable no-undef */
+import React from 'react';
+import './SharedKeymapsDialog.scss';
+import {
+  SharedKeymapsDialogActionsType,
+  SharedKeymapsDialogStateType,
+} from './SharedKeymapsDialog.container';
+
+type OwnProps = {};
+
+type SharedKeymapsDialogProps = OwnProps &
+  Partial<SharedKeymapsDialogActionsType> &
+  Partial<SharedKeymapsDialogStateType>;
+
+type OwnState = {};
+export default class SharedKeymapsDialog extends React.Component<
+  SharedKeymapsDialogProps,
+  OwnState
+> {
+  constructor(props: OwnProps | Readonly<OwnProps>) {
+    super(props);
+    this.state = {};
+  }
+}

--- a/src/components/configure/keymaplist/SharedKeymapsDialog.tsx
+++ b/src/components/configure/keymaplist/SharedKeymapsDialog.tsx
@@ -5,7 +5,13 @@ import {
   SharedKeymapsDialogActionsType,
   SharedKeymapsDialogStateType,
 } from './SharedKeymapsDialog.container';
-import { Dialog, DialogContent, DialogTitle } from '@material-ui/core';
+import {
+  Dialog,
+  DialogContent,
+  DialogTitle,
+  Tab,
+  Tabs,
+} from '@material-ui/core';
 import CloseIcon from '@material-ui/icons/Close';
 
 type OwnProps = {
@@ -45,10 +51,17 @@ export default class SharedKeymapsDialog extends React.Component<
             <CloseIcon onClick={this.props.onClose} />
           </div>
         </DialogTitle>
-        <DialogContent
-          dividers
-          className="shared-keymaps-dialog-content"
-        ></DialogContent>
+        <DialogContent dividers className="shared-keymaps-dialog-content">
+          <Tabs
+            value={0}
+            indicatorColor="primary"
+            textColor="primary"
+            aria-label="shared-keymaps"
+          >
+            <Tab label="Shared Keymaps" />
+            <Tab label="Applied History" />
+          </Tabs>
+        </DialogContent>
       </Dialog>
     );
   }

--- a/src/components/configure/keymaplist/SharedKeymapsDialog.tsx
+++ b/src/components/configure/keymaplist/SharedKeymapsDialog.tsx
@@ -5,14 +5,7 @@ import {
   SharedKeymapsDialogActionsType,
   SharedKeymapsDialogStateType,
 } from './SharedKeymapsDialog.container';
-import {
-  Dialog,
-  DialogContent,
-  DialogTitle,
-  Paper,
-  PaperProps,
-} from '@material-ui/core';
-import Draggable from 'react-draggable';
+import { Dialog, DialogContent, DialogTitle } from '@material-ui/core';
 import CloseIcon from '@material-ui/icons/Close';
 
 type OwnProps = {
@@ -43,7 +36,6 @@ export default class SharedKeymapsDialog extends React.Component<
       <Dialog
         open={this.props.open}
         maxWidth={'md'}
-        PaperComponent={PaperComponent}
         className="shared-keymaps-dialog"
         onEnter={this.onEnter.bind(this)}
       >
@@ -53,21 +45,11 @@ export default class SharedKeymapsDialog extends React.Component<
             <CloseIcon onClick={this.props.onClose} />
           </div>
         </DialogTitle>
-        <DialogContent dividers className="shared-keymaps-dialog-content">
-          xxx
-        </DialogContent>
+        <DialogContent
+          dividers
+          className="shared-keymaps-dialog-content"
+        ></DialogContent>
       </Dialog>
     );
   }
-}
-
-function PaperComponent(props: PaperProps) {
-  return (
-    <Draggable
-      handle="#draggable-dialog-title"
-      cancel={'[class*="MuiDialogContent-root"]'}
-    >
-      <Paper {...props} />
-    </Draggable>
-  );
 }

--- a/src/services/provider/Firebase.ts
+++ b/src/services/provider/Firebase.ts
@@ -546,7 +546,8 @@ export class FirebaseProvider implements IStorage, IAuth {
     const keymaps: SavedKeymapData[] = this.filterKeymapsByProductName<SavedKeymapData>(
       snapshot,
       info
-    ).filter((keymap) => keymap.author_uid !== this.auth.currentUser!.uid);
+    );
+    // ).filter((keymap) => keymap.author_uid !== this.auth.currentUser!.uid);
     return {
       success: true,
       savedKeymaps: keymaps,

--- a/src/services/provider/Firebase.ts
+++ b/src/services/provider/Firebase.ts
@@ -546,8 +546,7 @@ export class FirebaseProvider implements IStorage, IAuth {
     const keymaps: SavedKeymapData[] = this.filterKeymapsByProductName<SavedKeymapData>(
       snapshot,
       info
-    );
-    // ).filter((keymap) => keymap.author_uid !== this.auth.currentUser!.uid);
+    ).filter((keymap) => keymap.author_uid !== this.auth.currentUser!.uid);
     return {
       success: true,
       savedKeymaps: keymaps,

--- a/src/services/storage/Storage.ts
+++ b/src/services/storage/Storage.ts
@@ -83,6 +83,16 @@ export interface AppliedKeymapData extends AbstractKeymapData {
   saved_keymap_id: string;
 }
 
+export function isAppliedKeymapDataInstance(
+  arg: any
+): arg is AppliedKeymapData {
+  return (
+    arg !== null &&
+    typeof arg === 'object' &&
+    typeof arg.applied_uid === 'string'
+  );
+}
+
 export interface IExistsResult extends IResult {
   exists?: boolean;
 }
@@ -101,6 +111,10 @@ export interface ICreateKeyboardDefinitionDocumentResult extends IResult {
 
 export interface ISavedKeymapResult extends IResult {
   savedKeymaps: SavedKeymapData[];
+}
+
+export interface IAppliedKeymapsResult extends IResult {
+  appliedKeymaps: AppliedKeymapData[];
 }
 
 /* eslint-disable no-unused-vars */
@@ -161,6 +175,9 @@ export interface IStorage {
   updateSavedKeymap(keymapData: SavedKeymapData): Promise<IResult>;
   deleteSavedKeymap(savedKeymapId: string): Promise<IResult>;
   fetchSharedKeymaps(info: IDeviceInformation): Promise<ISavedKeymapResult>;
-  createOrUpdateAppliedKeymap(keymapData: SavedKeymapData): Promise<IResult>;
+  createOrUpdateAppliedKeymap(keymapData: AbstractKeymapData): Promise<IResult>;
+  fetchMyAppliedKeymaps(
+    info: IDeviceInformation
+  ): Promise<IAppliedKeymapsResult>;
 }
 /* eslint-enable no-unused-vars */

--- a/src/store/reducers.ts
+++ b/src/store/reducers.ts
@@ -54,6 +54,7 @@ import {
 } from '../actions/hid.action';
 import {
   STORAGE_ACTIONS,
+  STORAGE_UPDATE_APPLIED_KEYMAPS,
   STORAGE_UPDATE_KEYBOARD_DEFINITION,
   STORAGE_UPDATE_KEYBOARD_DEFINITION_DOCUMENT,
   STORAGE_UPDATE_KEYBOARD_DEFINITION_DOCUMENTS,
@@ -310,6 +311,10 @@ const storageReducer = (action: Action, draft: WritableDraft<RootState>) => {
     }
     case STORAGE_UPDATE_SHARED_KEYMAPS: {
       draft.entities.sharedKeymaps = action.value;
+      break;
+    }
+    case STORAGE_UPDATE_APPLIED_KEYMAPS: {
+      draft.entities.appliedKeymaps = action.value;
       break;
     }
   }

--- a/src/store/state.ts
+++ b/src/store/state.ts
@@ -4,6 +4,7 @@ import { IHid, IKeyboard, IKeymap } from '../services/hid/Hid';
 import { WebHid } from '../services/hid/WebHid';
 import { FirebaseProvider } from '../services/provider/Firebase';
 import {
+  AppliedKeymapData,
   IKeyboardDefinitionDocument,
   IStorage,
   SavedKeymapData,
@@ -82,6 +83,7 @@ export type RootState = {
     keyboardDefinitionDocument: IKeyboardDefinitionDocument | null;
     savedKeymaps: SavedKeymapData[];
     sharedKeymaps: SavedKeymapData[];
+    appliedKeymaps: AppliedKeymapData[];
   };
   app: {
     package: {
@@ -207,6 +209,7 @@ export const INIT_STATE: RootState = {
     keyboardDefinitionDocument: null,
     savedKeymaps: [],
     sharedKeymaps: [],
+    appliedKeymaps: [],
   },
   app: {
     package: {


### PR DESCRIPTION
This pull request adds a new dialog to display shared keymaps including filtering feature and to display already applied keymaps history.

The max count of the shared keymap list is limited equal less than 10. Add a new button "more..." to open the dialog on the bottom of the shared kemaps list:

![Screenshot_20210329_151440](https://user-images.githubusercontent.com/261787/112794298-9b9faf00-90a1-11eb-889f-9df836c4d5a4.png)

The new dialog has two tabs: Shared keymaps and applied history:

![Screenshot_20210329_151624](https://user-images.githubusercontent.com/261787/112794364-bc680480-90a1-11eb-8bdb-fe5cfba8b526.png)

When filling in some keyword, the list is filtered by it:

![Screenshot_20210329_151719](https://user-images.githubusercontent.com/261787/112794485-e4effe80-90a1-11eb-98bb-5342e9c89d77.png)

If clicking an applied keymap history, the keymap is applied again:

![Screenshot_20210329_151754](https://user-images.githubusercontent.com/261787/112794559-0650ea80-90a2-11eb-8e5c-29a26563e9ba.png)
