### PR TITLE
Change the Lang1 and Lang2 key labels.

### DIFF
--- a/src/services/hid/KeycodeInfoList.ts
+++ b/src/services/hid/KeycodeInfoList.ts
@@ -1597,7 +1597,7 @@ export const keyInfoList: KeyInfo[] = [
         long: 'KC_LANG1',
         short: 'KC_HAEN',
       },
-      label: 'Ha/En',
+      label: 'Lang 1',
     },
   },
   {
@@ -1608,7 +1608,7 @@ export const keyInfoList: KeyInfo[] = [
         long: 'KC_LANG2',
         short: 'KC_HANJ',
       },
-      label: '한자',
+      label: 'Lang 2',
     },
   },
   {

--- a/src/services/hid/assets/keycodes.json
+++ b/src/services/hid/assets/keycodes.json
@@ -1157,7 +1157,7 @@
       "long": "KC_LANG1",
       "short": "KC_HAEN"
     },
-    "label": "Ha/En"
+    "label": "Lang 1"
   },
   {
     "code": 145,
@@ -1165,7 +1165,7 @@
       "long": "KC_LANG2",
       "short": "KC_HANJ"
     },
-    "label": "한자"
+    "label": "Lang 2"
   },
   {
     "code": 146,


### PR DESCRIPTION
Fix #446 

This pull request changes some key labels. For instance, two labels (Lang 1 and Lang 2) are changed.

<img width="375" alt="スクリーンショット 2021-04-28 6 33 10" src="https://user-images.githubusercontent.com/261787/116315594-b4f46200-a7eb-11eb-91c0-28827f87079c.png">

<img width="484" alt="スクリーンショット 2021-04-28 6 33 27" src="https://user-images.githubusercontent.com/261787/116315611-b9b91600-a7eb-11eb-96f9-2b8cbfa4feaa.png">
