### PR TITLE
fix how to check its file type

### DIFF
--- a/src/services/storage/Validator.ts
+++ b/src/services/storage/Validator.ts
@@ -23,7 +23,7 @@ export type ValidateKeyboardDefinitionSchemaResult = {
 };
 
 export const isJsonFile = (file: File): boolean => {
-  return file.type.endsWith('/json');
+  return file.name.endsWith('.json');
 };
 
 export const validateIds = (


### PR DESCRIPTION
see #449 

First, I thought to fix `isJsonFile`something like this, because we cannot detect whether an input file is JSON or not without parsing.
```js
function isJSON(json){
    try {
        JSON.parse(json);
        return true;
    } catch (e) {
        return false;
    }
}
```

but this app already handles JSON parse thing here.
https://github.com/remap-keys/remap/blob/0d2e71c347021f9f444b40aadb8b47d1e34cee99/src/components/common/keyboarddefformpart/KeyboardDefinitionFormPart.tsx#L104-L115

So I changed like this pull req.
it just checks its ext.