### PR TITLE
Fix the error when the length of saved key mappings is different from the layer count of the connected keyboard

### DIFF
--- a/src/components/configure/keymaplist/KeymapListPopover.tsx
+++ b/src/components/configure/keymaplist/KeymapListPopover.tsx
@@ -110,6 +110,7 @@ export default class KeymapListPopover extends React.Component<
       // When the savedKeycodes was stored for BMP MCU, the length may be 11.
       // Therefore, the target layer must be checked to ensure that the value
       // is less than the savedKeycodes length.
+      // See: https://github.com/remap-keys/remap/issues/454
       if (i < savedKeycodes.length) {
         Object.keys(keymap).forEach((pos) => {
           if (keymap[pos].code != savedCode[pos]) {

--- a/src/components/configure/keymaplist/KeymapListPopover.tsx
+++ b/src/components/configure/keymaplist/KeymapListPopover.tsx
@@ -107,11 +107,16 @@ export default class KeymapListPopover extends React.Component<
       const keymap = keymaps[i];
       const savedCode = savedKeycodes[i];
       const changes: { [pos: string]: IKeymap } = {};
-      Object.keys(keymap).forEach((pos) => {
-        if (keymap[pos].code != savedCode[pos]) {
-          changes[pos] = KeycodeList.getKeymap(savedCode[pos], labelLang);
-        }
-      });
+      // When the savedKeycodes was stored for BMP MCU, the length may be 11.
+      // Therefore, the target layer must be checked to ensure that the value
+      // is less than the savedKeycodes length.
+      if (i < savedKeycodes.length) {
+        Object.keys(keymap).forEach((pos) => {
+          if (keymap[pos].code != savedCode[pos]) {
+            changes[pos] = KeycodeList.getKeymap(savedCode[pos], labelLang);
+          }
+        });
+      }
       keycodes.push(changes);
     }
 


### PR DESCRIPTION
Fix #454 

When using the latest firmware of BLE Micro Pro (BMP), it provides layers which the size is 11. But, generally, almost keyboards using ProMicro has layers which the size is equal or less than 4.

For example. when a keyboard with ProMicro has 4 layers and the user saves the key mappings, the size of the key mappings is 4 in the Remap database. Then, if the user changes the ProMicto to BMP and both have same a VENDOR ID and a PRODUCT ID, the size of layers of the keyboard is 11.

In the situation above, if the user tries to restore the key mappings against the keyboard which has BMP, the current Remap code tries to apply 11 key mappings. However, the size of the saved key mappings is only 4. As the result, the Remap can't get the key mapping for the 5th layer, and the error below occurs:

`Cannot read property '0,0' of undefined at Object.keys(keymap).forEach( (components/configure/keymaplist/KeymapListPopover.tsx:111:42)`

To avoid the error, we need to add the check logic to avoid to retrieve non-existing key mapping data over the max length of the saved key mappings.