### PR TITLE
Fix the issue which can't operate the toolbar icons at specific keyboard layout option

### DIFF
--- a/src/components/configure/keymapToolbar/KeymapToolbar.scss
+++ b/src/components/configure/keymapToolbar/KeymapToolbar.scss
@@ -7,6 +7,8 @@
   justify-content: center;
   align-items: flex-start;
   padding: 8px 16px;
+  z-index: 2;
+
   .keymap-menu-item {
     margin-bottom: $space-m;
 


### PR DESCRIPTION
This pull request is to fix #493.

When specifying some keyboard layout option, the toolbar icons can't be operated (for instance, we can't click them). I investigated this issue, then I found the cause of this issue.

![Screenshot_20210712_092827](https://user-images.githubusercontent.com/261787/125215290-06de5b80-e2f6-11eb-84dd-aa0f891f27b3.png)

In the target JSON file and specifying the keyboard layout option, the `left` value of the `keyboard-frame` class becomes non-zero. However, the width of the class is the same as other normal keyboard layout option. As the result, the pane with the `keyboard-frame` class is put over the toolbar pane.

Unfortunately, I don't have enough knowledges to fix the calculation logic to become the `left` value is always kept by zero. But, to add a new style definition `z-index: 2` can fix this issue. I guess that we should fix the calculate logic to become the `left` value is always normal, but I also think the `z-index` approach is not bad.