### PR TITLE
Introduce w3c-web-hid type def and use the output report ID.

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -23,5 +23,8 @@
     "prettier/prettier": "warn",
     "no-unused-vars": "warn",
     "react/prop-types": "warn"
+  },
+  "globals": {
+    "HIDDevice": "readonly"
   }
 }

--- a/package.json
+++ b/package.json
@@ -79,6 +79,7 @@
     "@types/react-redux": "^7.1.14",
     "@types/react-router-dom": "^5.1.6",
     "@types/sinon": "^9.0.10",
+    "@types/w3c-web-hid": "^1.0.1",
     "@typescript-eslint/eslint-plugin": "^4.10.0",
     "@typescript-eslint/parser": "^4.10.0",
     "babel-eslint": "^10.1.0",

--- a/src/components/configure/Configure.tsx
+++ b/src/components/configure/Configure.tsx
@@ -121,7 +121,6 @@ class Configure extends React.Component<ConfigureProps, OwnState> {
   }
 
   componentDidUpdate() {
-    console.log(`componentDidUpdate: ${this.props.testMatrix}`);
     this.updateTitle();
     this.updateNotifications();
 

--- a/src/services/hid/Hid.mock.ts
+++ b/src/services/hid/Hid.mock.ts
@@ -38,7 +38,9 @@ export const IHidMock: IHid = {
 };
 
 export const mockIKeyboad: IKeyboard = {
-  getDevice: () => {},
+  getDevice: () => {
+    return new HIDDevice();
+  },
   getHid: () => {
     return IHidMock;
   },

--- a/src/services/hid/Hid.ts
+++ b/src/services/hid/Hid.ts
@@ -110,7 +110,7 @@ export interface IFetchLayoutOptionsResult extends IResult {
 }
 
 export interface IKeyboard {
-  getDevice(): any;
+  getDevice(): HIDDevice;
   getHid(): IHid;
   getInformation(): IDeviceInformation;
   open(): Promise<IResult>;

--- a/src/services/hid/WebHid.ts
+++ b/src/services/hid/WebHid.ts
@@ -1,4 +1,3 @@
-/* eslint-disable no-undef */
 import {
   ICommand,
   IConnectParams,
@@ -20,7 +19,6 @@ import {
   IFetchLayoutOptionsResult,
 } from './Hid';
 import { KeycodeList } from './KeycodeList';
-
 import {
   BleMicroProStoreKeymapPersistentlyCommand,
   DynamicKeymapGetLayerCountCommand,
@@ -44,10 +42,10 @@ import { KeyboardLabelLang } from '../labellang/KeyLabelLangs';
 
 export class Keyboard implements IKeyboard {
   private readonly hid: IHid;
-  private readonly device: any;
+  private readonly device: HIDDevice;
   private commandQueue: ICommand[];
 
-  constructor(hid: IHid, device: any) {
+  constructor(hid: IHid, device: HIDDevice) {
     this.hid = hid;
     this.commandQueue = [];
     this.device = device;
@@ -59,14 +57,14 @@ export class Keyboard implements IKeyboard {
 
   getInformation(): IDeviceInformation {
     return {
-      vendorId: this.device.vendorId,
-      productId: this.device.productId,
-      productName: this.device.productName,
+      vendorId: this.device.vendorId!,
+      productId: this.device.productId!,
+      productName: this.device.productName!,
     };
   }
 
   isOpened(): boolean {
-    return this.device.opened;
+    return this.device.opened!;
   }
 
   async close(): Promise<void> {
@@ -82,7 +80,7 @@ export class Keyboard implements IKeyboard {
     }
   }
 
-  getDevice(): any {
+  getDevice(): HIDDevice {
     return this.device;
   }
 
@@ -772,17 +770,17 @@ export class WebHid implements IHid {
   private handler?: IConnectionEventHandler;
 
   async detectKeyboards(): Promise<IKeyboard[]> {
-    const devices = await (navigator as any).hid.getDevices();
+    const devices = await navigator.hid.getDevices();
     return devices
-      .filter((device: any) => {
-        const collectionInfo = device.collections[0];
+      .filter((device: HIDDevice) => {
+        const collectionInfo = device.collections![0];
         return (
           collectionInfo &&
           collectionInfo.usage === 0x61 &&
           collectionInfo.usagePage === 0xff60
         );
       })
-      .map((device: any) => {
+      .map((device: HIDDevice) => {
         return new Keyboard(this, device);
       });
   }
@@ -792,7 +790,7 @@ export class WebHid implements IHid {
     try {
       let devices;
       if (connectParams) {
-        devices = await (navigator as any).hid.requestDevice({
+        devices = await navigator.hid.requestDevice({
           filters: [
             {
               vendorId: connectParams.vendorId,
@@ -803,7 +801,7 @@ export class WebHid implements IHid {
           ],
         });
       } else {
-        devices = await (navigator as any).hid.requestDevice({
+        devices = await navigator.hid.requestDevice({
           filters: [
             {
               usagePage: 0xff60,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -14,7 +14,8 @@
     "resolveJsonModule": true,
     "isolatedModules": true,
     "noEmit": true,
-    "jsx": "react-jsx"
+    "jsx": "react-jsx",
+    "typeRoots": ["node_modules/@types"]
   },
   "include": ["src"]
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -3270,6 +3270,11 @@
   resolved "https://registry.yarnpkg.com/@types/unist/-/unist-2.0.3.tgz#9c088679876f374eb5983f150d4787aa6fb32d7e"
   integrity sha512-FvUupuM3rlRsRtCN+fDudtmytGO6iHJuuRKS1Ss0pG5z8oX0diNEw94UEL7hgDbpN94rgaK5R7sWm6RrSkZuAQ==
 
+"@types/w3c-web-hid@^1.0.1":
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/@types/w3c-web-hid/-/w3c-web-hid-1.0.1.tgz#d7bc1af06f4d6a42aac008ff76d5b4ad8b851bc3"
+  integrity sha512-zdOo3wWpuxt3UHgx983TyRxkG17yMDjrvSwmVM4kC4ysLsxIjdNNP/jx4xG4LAm6ISu3WohD1ZEIu+p49ToEFA==
+
 "@types/webpack-env@^1.15.3":
   version "1.16.0"
   resolved "https://registry.yarnpkg.com/@types/webpack-env/-/webpack-env-1.16.0.tgz#8c0a9435dfa7b3b1be76562f3070efb3f92637b4"


### PR DESCRIPTION
This pull request fixes #480 

Currently the Remap is using the fixed value `0x00` as an output report ID. However, there are keyboards which are using other value as the output report ID. As mentioned in #480, we should use the output report ID which is included in the collections returned connecting a keyboard.

Also, to reduce bugs, I introduce the w3c-web-hid type definition.