### PR TITLE
Adjust the style definition for the keyboard name on the header.

### DIFF
--- a/src/components/configure/header/Header.scss
+++ b/src/components/configure/header/Header.scss
@@ -27,6 +27,10 @@
 
         h2 {
           margin: 0;
+          max-width: calc(100vw / 3);
+          overflow: hidden;
+          white-space: nowrap;
+          text-overflow: ellipsis;
         }
         .ids {
           font-size: $font-xs;

--- a/src/components/configure/header/Header.tsx
+++ b/src/components/configure/header/Header.tsx
@@ -303,7 +303,7 @@ export default class Header extends React.Component<HeaderProps, HeaderState> {
           >
             <div className="kbd-select">
               <div className="kbd-name" onClick={this.onClickDevice.bind(this)}>
-                <h2>{this.props.productName}</h2>
+                <h2 title={this.props.productName}>{this.props.productName}</h2>
                 <div className="ids">
                   VID: {hexadecimal(this.props.vendorId!, 4)} / PID:{' '}
                   {hexadecimal(this.props.productId!, 4)}


### PR DESCRIPTION
Fix the issue #502.

![Screenshot_20210716_121725](https://user-images.githubusercontent.com/261787/125889775-460b650b-98c4-4601-86b2-7aa3900e8127.png)
