### PR TITLE
Fix the image ratio when displaying it on the catalog page.

### DIFF
--- a/src/components/catalog/keyboard/CatalogIntroduction.scss
+++ b/src/components/catalog/keyboard/CatalogIntroduction.scss
@@ -36,9 +36,12 @@
     justify-content: center;
     align-items: center;
 
-    & img {
+    &-container {
       width: 400px;
       height: 300px;
+      background-size: contain;
+      background-repeat: no-repeat;
+      background-position: center;
     }
 
     &-nothing {

--- a/src/components/catalog/keyboard/CatalogIntroduction.tsx
+++ b/src/components/catalog/keyboard/CatalogIntroduction.tsx
@@ -172,7 +172,6 @@ export default class CatalogIntroduction extends React.Component<
               <Grid item sm={6} className="catalog-introduction-column">
                 <div className="catalog-introduction-image">
                   {this.props.definitionDocument!.imageUrl ? (
-                    // <img src={this.props.definitionDocument!.imageUrl} />
                     <div
                       className="catalog-introduction-image-container"
                       style={{

--- a/src/components/catalog/keyboard/CatalogIntroduction.tsx
+++ b/src/components/catalog/keyboard/CatalogIntroduction.tsx
@@ -172,7 +172,15 @@ export default class CatalogIntroduction extends React.Component<
               <Grid item sm={6} className="catalog-introduction-column">
                 <div className="catalog-introduction-image">
                   {this.props.definitionDocument!.imageUrl ? (
-                    <img src={this.props.definitionDocument!.imageUrl} />
+                    // <img src={this.props.definitionDocument!.imageUrl} />
+                    <div
+                      className="catalog-introduction-image-container"
+                      style={{
+                        backgroundImage: `url(${
+                          this.props.definitionDocument!.imageUrl
+                        })`,
+                      }}
+                    />
                   ) : (
                     <div className="catalog-introduction-image-nothing">
                       No Image


### PR DESCRIPTION
As-is:

![Screenshot_20210729_111442](https://user-images.githubusercontent.com/261787/127421025-3c13930f-9a3d-42f9-966a-54e7a4e05c93.png)

To-be:

![Screenshot_20210729_111539](https://user-images.githubusercontent.com/261787/127421076-2454cf55-49c9-4cd9-aab7-312a8a1725de.png)
