### PR TITLE
prioritize the result with the image

### DIFF
--- a/src/actions/storage.action.ts
+++ b/src/actions/storage.action.ts
@@ -793,17 +793,22 @@ export const storageActionsThunk = {
       const matchedFeaturesCount = (
         doc: IKeyboardDefinitionDocument
       ): number => {
-        return doc.features.reduce<number>((result, feature) => {
-          return features!.includes(feature) ? result + 1 : result;
+        let count = doc.features.reduce<number>((result, feature) => {
+          return features!.includes(feature) ? result + 2 : result; // added 2 points because matching features is more important than the kbd has an image
         }, 0);
+        if (doc.imageUrl) {
+          count += 1; // sort higher if the keyboard has an image
+        }
+        return count;
       };
-      const sortedSearchResult = definitionDocs.slice().sort((a, b) => {
+      const sortedSearchResult = Array.from(definitionDocs).sort((a, b) => {
         const countA = matchedFeaturesCount(a);
         const countB = matchedFeaturesCount(b);
+
         if (countA === countB) {
           return Math.random() - 0.5;
         } else {
-          return matchedFeaturesCount(a) - matchedFeaturesCount(b);
+          return countB - countA;
         }
       });
       dispatch(

--- a/src/components/catalog/search/CatalogSearch.tsx
+++ b/src/components/catalog/search/CatalogSearch.tsx
@@ -200,6 +200,20 @@ class CatalogSearch extends React.Component<
         }) || CONDITION_NOT_SELECTED
       );
     };
+
+    const searchResultsWithImage: IKeyboardDefinitionDocument[] = [];
+    const searchResultsWithoutImage: IKeyboardDefinitionDocument[] = [];
+    this.props.searchResult!.forEach((result) => {
+      if (result.imageUrl) {
+        searchResultsWithImage.push(result);
+      } else {
+        searchResultsWithoutImage.push(result);
+      }
+    });
+    const searchResult = searchResultsWithImage.concat(
+      searchResultsWithoutImage
+    );
+
     return (
       <div className="catalog-search-wrapper">
         <div className="catalog-search-container">
@@ -387,7 +401,7 @@ class CatalogSearch extends React.Component<
               </div>
             </Grid>
             <Grid item sm={9}>
-              <SearchResult definitionDocuments={this.props.searchResult!} />
+              <SearchResult definitionDocuments={searchResult} />
             </Grid>
           </Grid>
         </div>

--- a/src/components/catalog/search/CatalogSearch.tsx
+++ b/src/components/catalog/search/CatalogSearch.tsx
@@ -201,19 +201,6 @@ class CatalogSearch extends React.Component<
       );
     };
 
-    const searchResultsWithImage: IKeyboardDefinitionDocument[] = [];
-    const searchResultsWithoutImage: IKeyboardDefinitionDocument[] = [];
-    this.props.searchResult!.forEach((result) => {
-      if (result.imageUrl) {
-        searchResultsWithImage.push(result);
-      } else {
-        searchResultsWithoutImage.push(result);
-      }
-    });
-    const searchResult = searchResultsWithImage.concat(
-      searchResultsWithoutImage
-    );
-
     return (
       <div className="catalog-search-wrapper">
         <div className="catalog-search-container">
@@ -401,7 +388,7 @@ class CatalogSearch extends React.Component<
               </div>
             </Grid>
             <Grid item sm={9}>
-              <SearchResult definitionDocuments={searchResult} />
+              <SearchResult definitionDocuments={this.props.searchResult!} />
             </Grid>
           </Grid>
         </div>

--- a/yarn.lock
+++ b/yarn.lock
@@ -5035,9 +5035,9 @@ caniuse-api@^3.0.0:
     lodash.uniq "^4.5.0"
 
 caniuse-lite@^1.0.0, caniuse-lite@^1.0.30000981, caniuse-lite@^1.0.30001035, caniuse-lite@^1.0.30001109, caniuse-lite@^1.0.30001125, caniuse-lite@^1.0.30001173:
-  version "1.0.30001179"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001179.tgz#b0803883b4471a6c62066fb1752756f8afc699c8"
-  integrity sha512-blMmO0QQujuUWZKyVrD1msR4WNDAqb/UPO1Sw2WWsQ7deoM5bJiicKnWJ1Y0NS/aGINSnKPIWBMw5luX+NDUCA==
+  version "1.0.30001248"
+  resolved "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001248.tgz"
+  integrity sha512-NwlQbJkxUFJ8nMErnGtT0QTM2TJ33xgz4KXJSMIrjXIbDVdaYueGyjOrLKRtJC+rTiWfi6j5cnZN1NBiSBJGNw==
 
 capture-exit@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
The result of a keyboard with an image will be listed higher.

<img width="1041" alt="スクリーンショット 2021-07-30 13 51 55" src="https://user-images.githubusercontent.com/316463/127604113-96649a01-65b5-4e68-9b6c-498a5776f86b.png">

<img width="1044" alt="スクリーンショット 2021-07-30 13 59 29" src="https://user-images.githubusercontent.com/316463/127604134-8bcf896e-dc88-47f8-8e8d-889c59312d5c.png">
