### PR TITLE
AND search for the keybaord catalog

### DIFF
--- a/src/actions/storage.action.ts
+++ b/src/actions/storage.action.ts
@@ -790,20 +790,20 @@ export const storageActionsThunk = {
       const definitionDocs = result.documents!.filter((doc) =>
         doc.name.toLowerCase().includes(keyword.toLowerCase())
       );
-      const matchedFeaturesCount = (
-        doc: IKeyboardDefinitionDocument
-      ): number => {
-        let count = doc.features.reduce<number>((result, feature) => {
-          return features!.includes(feature) ? result + 2 : result; // added 2 points because matching features is more important than the kbd has an image
-        }, 0);
-        if (doc.imageUrl) {
-          count += 1; // sort higher if the keyboard has an image
-        }
-        return count;
-      };
-      const sortedSearchResult = Array.from(definitionDocs).sort((a, b) => {
-        const countA = matchedFeaturesCount(a);
-        const countB = matchedFeaturesCount(b);
+      const filteredDocs = definitionDocs.filter((doc) => {
+        if (features.length === 0) return true;
+
+        let allMatch = true;
+        features.forEach((feat) => {
+          allMatch = allMatch && doc.features.includes(feat);
+        });
+
+        return allMatch;
+      });
+
+      filteredDocs.sort((a, b) => {
+        const countA = a.imageUrl ? 1 : 0; //matchedFeaturesCount(a);
+        const countB = b.imageUrl ? 1 : 0; //matchedFeaturesCount(b);
 
         if (countA === countB) {
           return Math.random() - 0.5;
@@ -813,7 +813,7 @@ export const storageActionsThunk = {
       });
       dispatch(
         StorageActions.updateSearchResultKeyboardDefinitionDocument(
-          sortedSearchResult
+          filteredDocs
         )
       );
     } else {

--- a/src/actions/storage.action.ts
+++ b/src/actions/storage.action.ts
@@ -802,8 +802,8 @@ export const storageActionsThunk = {
       });
 
       filteredDocs.sort((a, b) => {
-        const countA = a.imageUrl ? 1 : 0; //matchedFeaturesCount(a);
-        const countB = b.imageUrl ? 1 : 0; //matchedFeaturesCount(b);
+        const countA = a.imageUrl ? 1 : 0; // sort higher with a image
+        const countB = b.imageUrl ? 1 : 0; // sort higher with a image
 
         if (countA === countB) {
           return Math.random() - 0.5;

--- a/src/components/catalog/search/CatalogSearch.tsx
+++ b/src/components/catalog/search/CatalogSearch.tsx
@@ -448,7 +448,7 @@ function KeyboardCard(props: KeyboardCardProps) {
 
   return (
     <Card className="catalog-search-result-card" onClick={onClickCard}>
-      {props.definition.thumbnailImageUrl ? (
+      {props.definition.imageUrl ? (
         <CardMedia
           image={props.definition.imageUrl}
           className="catalog-search-result-card-image"


### PR DESCRIPTION
Before (OR search)
<img width="1044" alt="スクリーンショット 2021-07-30 17 10 20" src="https://user-images.githubusercontent.com/316463/127632694-09f52648-3f3b-4669-9114-0a9bcf9c8ce6.png">


After (AND search)
<img width="1061" alt="スクリーンショット 2021-07-30 18 27 29" src="https://user-images.githubusercontent.com/316463/127632711-642700f8-cae7-4708-a80c-cc031c69582e.png">
