### PR TITLE
relocated the left menu of keymap in keyboard catalog

### DIFF
--- a/src/components/catalog/keyboard/CatalogKeymap.scss
+++ b/src/components/catalog/keyboard/CatalogKeymap.scss
@@ -45,7 +45,7 @@
 
   &-wrapper {
     display: flex;
-    flex-direction: row;
+    flex-direction: column;
   }
 
   &-keyboards {
@@ -80,18 +80,37 @@
   &-option {
     &-container {
       display: flex;
-      flex-direction: column;
+      flex-direction: row;
       justify-content: center;
       align-items: center;
-      padding-right: $space-l;
+      padding: $space-l $space-l 0 $space-l;
+
+      .catalog-keymap-layer-wrapper {
+        flex-direction: row;
+        min-height: 0;
+      }
+    }
+
+    &-side {
+      display: flex;
+      width: 70px;
+    }
+
+    &-side-left {
+      display: flex;
+      margin-right: auto;
+    }
+
+    &-side-right {
+      display: flex;
+      margin-left: auto;
     }
 
     &-lang {
-      margin-bottom: 16px;
+      margin-left: 16px;
     }
 
     &-pdf {
-      margin-top: 16px;
     }
   }
 

--- a/src/components/catalog/keyboard/Catalogkeymap.tsx
+++ b/src/components/catalog/keyboard/Catalogkeymap.tsx
@@ -134,38 +134,6 @@ export default class CatalogKeymap extends React.Component<
             definitionDocument={this.props.definitionDocument!}
           />
           <div className="catalog-keymap-wrapper">
-            {this.props.keymaps!.length > 0 ? (
-              <div className="catalog-keymap-option-container">
-                <div className="catalog-keymap-option-lang">
-                  <Typography variant="subtitle1">
-                    {
-                      KeyLabelLangs.KeyLabelLangMenus.find(
-                        (m) => m.labelLang === this.props.langLabel
-                      )!.menuLabel
-                    }
-                  </Typography>
-                </div>
-                <Layer
-                  layerCount={this.props.keymaps!.length}
-                  selectedLayer={this.props.selectedLayer!}
-                  onClickLayer={this.props.updateSelectedLayer!}
-                />
-                <div className="catalog-keymap-option-pdf">
-                  <Tooltip
-                    arrow={true}
-                    placement="top"
-                    title="Get keymap cheat sheet (PDF)"
-                  >
-                    <IconButton
-                      size="small"
-                      onClick={this.onClickGetCheatsheet.bind(this)}
-                    >
-                      <PictureAsPdfRoundedIcon />
-                    </IconButton>
-                  </Tooltip>
-                </div>
-              </div>
-            ) : null}
             <div
               className="catalog-keymap-keyboards"
               style={{ margin: '0 auto' }}
@@ -205,6 +173,43 @@ export default class CatalogKeymap extends React.Component<
                   })}
                 </div>
               </div>
+            </div>
+            <div className="catalog-keymap-option-container">
+              {this.props.keymaps!.length > 0 ? (
+                <>
+                  <div className="catalog-keymap-option-side catalog-keymap-option-side-left"></div>
+                  <Layer
+                    layerCount={this.props.keymaps!.length}
+                    selectedLayer={this.props.selectedLayer!}
+                    onClickLayer={this.props.updateSelectedLayer!}
+                  />
+                  <div className="catalog-keymap-option-side catalog-keymap-option-side-right">
+                    <div className="catalog-keymap-option-pdf">
+                      <Tooltip
+                        arrow={true}
+                        placement="top"
+                        title="Get keymap cheat sheet (PDF)"
+                      >
+                        <IconButton
+                          size="small"
+                          onClick={this.onClickGetCheatsheet.bind(this)}
+                        >
+                          <PictureAsPdfRoundedIcon />
+                        </IconButton>
+                      </Tooltip>
+                    </div>
+                    <div className="catalog-keymap-option-lang">
+                      <Typography variant="subtitle1">
+                        {
+                          KeyLabelLangs.KeyLabelLangMenus.find(
+                            (m) => m.labelLang === this.props.langLabel
+                          )!.menuLabel
+                        }
+                      </Typography>
+                    </div>
+                  </div>
+                </>
+              ) : null}
             </div>
           </div>
           <Paper elevation={0} className="catalog-keymap-content">

--- a/src/components/configure/layoutoption/LayoutOptionComponentList.tsx
+++ b/src/components/configure/layoutoption/LayoutOptionComponentList.tsx
@@ -78,7 +78,7 @@ export default class LayoutOptionComponentList extends React.Component<
         </Grid>
       );
     } else {
-      return <div>Layout Option not supported.</div>;
+      return <div>There is no Layout Option.</div>;
     }
   }
 }


### PR DESCRIPTION
Locate the left-side menu to the bottom as bellow:
<img width="1279" alt="スクリーンショット 2021-08-02 14 32 45" src="https://user-images.githubusercontent.com/316463/127809070-72153dd1-0b55-43e2-bafb-78f5de27270d.png">
