### PR TITLE
Add options for the key count condition of keyboard catalog.

### DIFF
--- a/src/components/catalog/keyboard/CatalogIntroduction.tsx
+++ b/src/components/catalog/keyboard/CatalogIntroduction.tsx
@@ -24,13 +24,25 @@ const featureMap: { [p: string]: { [p: string]: string } } = {
     label: '100%',
     description: 'This keyboard has about 100 keys.',
   },
+  '90': {
+    label: '90%',
+    description: 'This keyboard has about 90 keys.',
+  },
   '80': {
     label: '80%',
     description: 'This keyboard has about 80 keys.',
   },
+  '70': {
+    label: '70%',
+    description: 'This keyboard has about 70 keys.',
+  },
   '60': {
     label: '60%',
     description: 'This keyboard has about 60 keys.',
+  },
+  '50': {
+    label: '50%',
+    description: 'This keyboard has about 50 keys.',
   },
   '40': {
     label: '40%',

--- a/src/components/catalog/search/CatalogSearch.tsx
+++ b/src/components/catalog/search/CatalogSearch.tsx
@@ -229,8 +229,11 @@ class CatalogSearch extends React.Component<
                       <MenuItem value="---">---</MenuItem>
                       <MenuItem value="over_100">Over 100%</MenuItem>
                       <MenuItem value="100">100%</MenuItem>
+                      <MenuItem value="90">90%</MenuItem>
                       <MenuItem value="80">80%</MenuItem>
+                      <MenuItem value="70">70%</MenuItem>
                       <MenuItem value="60">60%</MenuItem>
+                      <MenuItem value="50">50%</MenuItem>
                       <MenuItem value="40">40%</MenuItem>
                       <MenuItem value="30">30%</MenuItem>
                       <MenuItem value="macro">Macro</MenuItem>

--- a/src/components/keyboards/editdefinition/CatalogForm.tsx
+++ b/src/components/keyboards/editdefinition/CatalogForm.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { SyntheticEvent, useState } from 'react';
 import './CatalogForm.scss';
 import {
   Box,
@@ -32,6 +32,7 @@ import {
   ALL_WIRELESS_TYPE,
   CONDITION_NOT_SELECTED,
   IKeyboardFeatures,
+  IKeyboardKeyCountType,
 } from '../../../store/state';
 import {
   CatalogFormActionsType,
@@ -66,14 +67,11 @@ export default function CatalogForm(props: CatalogFormProps) {
   };
 
   const onChangeKeyCount = (
-    event: React.ChangeEvent<{ name?: string; value: unknown }>,
-    // eslint-disable-next-line no-unused-vars
-    child: React.ReactNode
+    event: React.ChangeEvent<HTMLInputElement>,
+    checked: boolean,
+    value: IKeyboardFeatures
   ): void => {
-    props.updateFeature!(
-      event.target.value as IKeyboardFeatures,
-      ALL_KEY_COUNT_TYPE
-    );
+    props.updateFeature!(checked ? value : CONDITION_NOT_SELECTED, [value]);
   };
 
   const onChangeKeyboardType = (
@@ -361,19 +359,46 @@ export default function CatalogForm(props: CatalogFormProps) {
               <div className="edit-definition-catalog-form-row">
                 <FormControl>
                   <FormLabel component="legend">Number of Keys</FormLabel>
-                  <Select
-                    value={getFeatureValue(ALL_KEY_COUNT_TYPE)}
-                    onChange={onChangeKeyCount}
-                  >
-                    <MenuItem value="---">---</MenuItem>
-                    <MenuItem value="over_100">Over 100%</MenuItem>
-                    <MenuItem value="100">100%</MenuItem>
-                    <MenuItem value="80">80%</MenuItem>
-                    <MenuItem value="60">60%</MenuItem>
-                    <MenuItem value="40">40%</MenuItem>
-                    <MenuItem value="30">30%</MenuItem>
-                    <MenuItem value="macro">Macro</MenuItem>
-                  </Select>
+                  <FormGroup row>
+                    {[
+                      ['over_100', 'Over 100%'],
+                      ['100', '100%'],
+                      ['90', '90%'],
+                      ['80', '80%'],
+                      ['70', '70%'],
+                      ['60', '60%'],
+                      ['50', '50%'],
+                      ['40', '40%'],
+                      ['30', '30%'],
+                      ['macro', 'Macro'],
+                    ].map((data) => {
+                      const [value, label] = data;
+                      return (
+                        <FormControlLabel
+                          key={value}
+                          control={
+                            <Checkbox
+                              value={value}
+                              checked={hasFeatureValue(
+                                value as IKeyboardFeatures
+                              )}
+                              onChange={(
+                                event: React.ChangeEvent<HTMLInputElement>,
+                                checked: boolean
+                              ) => {
+                                onChangeKeyCount(
+                                  event,
+                                  checked,
+                                  value as IKeyboardFeatures
+                                );
+                              }}
+                            />
+                          }
+                          label={label}
+                        />
+                      );
+                    })}
+                  </FormGroup>
                 </FormControl>
               </div>
               <div className="edit-definition-catalog-form-row">

--- a/src/components/keyboards/editdefinition/CatalogForm.tsx
+++ b/src/components/keyboards/editdefinition/CatalogForm.tsx
@@ -1,4 +1,4 @@
-import React, { SyntheticEvent, useState } from 'react';
+import React, { useState } from 'react';
 import './CatalogForm.scss';
 import {
   Box,
@@ -24,7 +24,6 @@ import {
 } from '@material-ui/core';
 import {
   ALL_HOTSWAP_TYPE,
-  ALL_KEY_COUNT_TYPE,
   ALL_OLED_TYPE,
   ALL_SPEAKER_TYPE,
   ALL_SPLIT_TYPE,
@@ -32,7 +31,6 @@ import {
   ALL_WIRELESS_TYPE,
   CONDITION_NOT_SELECTED,
   IKeyboardFeatures,
-  IKeyboardKeyCountType,
 } from '../../../store/state';
 import {
   CatalogFormActionsType,

--- a/src/store/state.ts
+++ b/src/store/state.ts
@@ -76,8 +76,11 @@ export const FirmwareCodePlace: { [p: string]: IFirmwareCodePlace } = {
 export const ALL_KEY_COUNT_TYPE = [
   'over_100',
   '100',
+  '90',
   '80',
+  '70',
   '60',
+  '50',
   '40',
   '30',
   'macro',


### PR DESCRIPTION
As-is: Over 100%, 100%, 80%, 60%, 40%, 30%, Macro (single selection)
To-be: Over 100%, 100%, 90%, 80%, 70%, 60%, 50%, 40%, 30%, Macro (multiple selections) 