### PR TITLE
Add a new path `/_catalog` to support OGP tags for each keyboard catalog pages

### DIFF
--- a/firebase.json
+++ b/firebase.json
@@ -9,6 +9,10 @@
         "function": "sitemap"
       },
       {
+        "source": "/catalog/**",
+        "function": "catalog"
+      },
+      {
         "source": "**",
         "destination": "/index.html"
       }

--- a/public/index.html
+++ b/public/index.html
@@ -28,6 +28,20 @@
     <meta property="og:type" content="website" />
     <meta property="og:site_name" content="Remap" />
 
+    <meta property="og:title" content="Remap" />
+    <meta
+      name="description"
+      content="Remap allows you to configure key mappings and lighting of your keyboard with QMK firmware in Web Browser."
+    />
+    <meta
+      property="og:description"
+      content="Remap allows you to configure key mappings and lighting of your keyboard with QMK firmware in Web Browser."
+    />
+    <meta property="og:url" content="%PUBLIC_URL%" />
+    <meta property="og:image" content="%PUBLIC_URL%/ogp_image.png" />
+
+    <title>Remap</title>
+
     <link rel="apple-touch-icon" href="%PUBLIC_URL%/logo192.png" />
     <link rel="manifest" href="%PUBLIC_URL%/manifest.json" />
     <script type="application/ld+json">

--- a/public/index.html
+++ b/public/index.html
@@ -28,17 +28,23 @@
     <meta property="og:type" content="website" />
     <meta property="og:site_name" content="Remap" />
 
-    <meta property="og:title" content="Remap" />
+    <meta property="og:title" content="Remap" data-rh="true" />
     <meta
       name="description"
       content="Remap allows you to configure key mappings and lighting of your keyboard with QMK firmware in Web Browser."
+      data-rh="true"
     />
     <meta
       property="og:description"
       content="Remap allows you to configure key mappings and lighting of your keyboard with QMK firmware in Web Browser."
+      data-rh="true"
     />
-    <meta property="og:url" content="%PUBLIC_URL%" />
-    <meta property="og:image" content="%PUBLIC_URL%/ogp_image.png" />
+    <meta property="og:url" content="%PUBLIC_URL%" data-rh="true" />
+    <meta
+      property="og:image"
+      content="%PUBLIC_URL%/ogp_image.png"
+      data-rh="true"
+    />
 
     <title>Remap</title>
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { SnackbarProvider } from 'notistack';
 import './App.css';
-import { BrowserRouter, Switch, Route } from 'react-router-dom';
+import { BrowserRouter, Switch, Route, Redirect } from 'react-router-dom';
 import { StyledComponentProps, withStyles } from '@material-ui/core/styles';
 import Configure from './components/configure/Configure.container';
 import Hid from './services/hid/ui/Hid';
@@ -55,6 +55,26 @@ class App extends React.Component<StyledComponentProps, {}> {
             <Route path="/catalog/:definitionId">
               <Catalog catalogDetailMode="introduction" />
             </Route>
+            <Route
+              path="/_catalog/:definitionId/keymap"
+              render={(props) => {
+                const path = `/catalog/${props.match.params.definitionId}/keymap${props.location.search}`;
+                props.history.push(path);
+                return null;
+              }}
+            />
+            <Redirect
+              from="/_catalog/:definitionId"
+              to="/catalog/:definitionId"
+            />
+            <Route
+              path="/_catalog"
+              render={(props) => {
+                const path = `/catalog${props.location.search}`;
+                props.history.push(path);
+                return null;
+              }}
+            />
             <Route component={Top} />
           </Switch>
         </BrowserRouter>


### PR DESCRIPTION
Fix #524 