### PR TITLE
Fix the issue #548.

### DIFF
--- a/src/components/configure/customkey/CustomKey.tsx
+++ b/src/components/configure/customkey/CustomKey.tsx
@@ -344,7 +344,7 @@ export default class CustomKey extends React.Component<OwnProps, OwnState> {
               holdKey={this.state.holdKey}
               tapKey={this.state.tapKey}
               layerCount={this.props.layerCount}
-              labelLang={'en-us'}
+              labelLang={this.props.labelLang}
               onChange={(hold, tap) => {
                 this.onChangeHoldTap(hold, tap);
               }}

--- a/src/services/hid/KeycodeInfoList.ts
+++ b/src/services/hid/KeycodeInfoList.ts
@@ -1641,7 +1641,7 @@ export const keyInfoList: KeyInfo[] = [
         long: 'KC_LANG5',
         short: 'KC_LANG5',
       },
-      label: 'JIS Zenkaku/Hankaku',
+      label: 'Lang 5',
     },
   },
   {

--- a/src/services/hid/KeycodeInfoList.ts
+++ b/src/services/hid/KeycodeInfoList.ts
@@ -1634,7 +1634,7 @@ export const keyInfoList: KeyInfo[] = [
     },
   },
   {
-    desc: '',
+    desc: 'Language 5',
     keycodeInfo: {
       code: 148,
       name: {


### PR DESCRIPTION
Fix #548.

This pull request has two modifications:

(1) Currently, the `JIS Zenkaku/Hankaku` is assigned to the `Lang 5`. However, actually the `半角/全角` key code is 0x35 (this is `KC_GRAV`). Therefore, I think that we should remove the `JIS Zenkaku/Hankaku` label from the `Lang 5` key.

<img width="1147" alt="スクリーンショット 2021-08-09 7 00 38" src="https://user-images.githubusercontent.com/261787/128647124-364b17f0-0334-4488-ab19-c9503673059b.png">

(2) The keyboard language setting is not passed to the `TabHoldTapKey` component (instead, `en-us` is passed), therefore the `半角/全角` key label is not shown on the HOLD/TAP tab panel when the `Japanese` is selected.  The `props.labelLang` value should be passed to the `TabHoldTapKey` component.

<img width="1165" alt="スクリーンショット 2021-08-09 6 58 16" src="https://user-images.githubusercontent.com/261787/128647203-086bc6f7-0192-4c53-bcb7-6a5304cbd460.png">
