### PR TITLE
Change layer selection UI

### DIFF
--- a/src/components/catalog/keyboard/CatalogKeymap.scss
+++ b/src/components/catalog/keyboard/CatalogKeymap.scss
@@ -84,11 +84,6 @@
       justify-content: center;
       align-items: center;
       padding: $space-l $space-l 0 $space-l;
-
-      .catalog-keymap-layer-wrapper {
-        flex-direction: row;
-        min-height: 0;
-      }
     }
 
     &-side {
@@ -114,18 +109,12 @@
     }
   }
 
-  &-layer {
-    &-wrapper {
-      display: flex;
-      flex-direction: column;
-      justify-content: center;
-      align-items: flex-start;
-      min-height: 88px;
-    }
-
-    &-unselected {
-      border: 0 !important;
-    }
+  &-layer-wrapper {
+    display: flex;
+    flex-direction: row;
+    justify-content: center;
+    align-items: flex-start;
+    min-width: 88px;
   }
 
   &-content {

--- a/src/components/catalog/keyboard/CatalogKeymap.scss
+++ b/src/components/catalog/keyboard/CatalogKeymap.scss
@@ -103,6 +103,7 @@
 
     &-lang {
       margin-left: 16px;
+      white-space: nowrap;
     }
 
     &-pdf {

--- a/src/components/catalog/keyboard/Catalogkeymap.tsx
+++ b/src/components/catalog/keyboard/Catalogkeymap.tsx
@@ -10,7 +10,6 @@ import { IKeymap } from '../../../services/hid/Hid';
 import { MOD_LEFT } from '../../../services/hid/Composition';
 import Keycap from '../../configure/keycap/Keycap.container';
 import {
-  Chip,
   Grid,
   IconButton,
   Paper,
@@ -248,6 +247,7 @@ type LayerProps = {
 
 function Layer(props: LayerProps) {
   const layers = [...Array(props.layerCount)].map((_, i) => i);
+  // eslint-disable-next-line no-unused-vars
   const invisiblePages = layers.map((layer) => true);
   return (
     <div className="catalog-keymap-layer-wrapper">

--- a/src/components/catalog/keyboard/Catalogkeymap.tsx
+++ b/src/components/catalog/keyboard/Catalogkeymap.tsx
@@ -26,6 +26,7 @@ import PictureAsPdfRoundedIcon from '@material-ui/icons/PictureAsPdfRounded';
 import { genKey, Key } from '../../configure/keycodekey/KeyGen';
 import { KeymapPdfGenerator } from '../../../services/pdf/KeymapPdfGenerator';
 import { sendEventToGoogleAnalytics } from '../../../utils/GoogleAnalytics';
+import LayerPagination from '../../common/layer/LayerPagination';
 
 type CatalogKeymapState = {};
 type OwnProps = {};
@@ -247,28 +248,18 @@ type LayerProps = {
 
 function Layer(props: LayerProps) {
   const layers = [...Array(props.layerCount)].map((_, i) => i);
+  const invisiblePages = layers.map((layer) => true);
   return (
     <div className="catalog-keymap-layer-wrapper">
-      {layers.map((layer) => {
-        return (
-          <Chip
-            key={layer}
-            variant="outlined"
-            size="medium"
-            label={layer}
-            color={props.selectedLayer === layer ? 'primary' : undefined}
-            clickable={props.selectedLayer !== layer}
-            onClick={() => {
-              props.onClickLayer(layer);
-            }}
-            className={
-              props.selectedLayer !== layer
-                ? 'catalog-keymap-layer-unselected'
-                : 'catalog-keymap-layer-selected'
-            }
-          />
-        );
-      })}
+      <LayerPagination
+        orientation="horizontal"
+        count={props.layerCount}
+        page={props.selectedLayer + 1}
+        invisiblePages={invisiblePages}
+        onClickPage={(page) => {
+          props.onClickLayer(page - 1);
+        }}
+      />
     </div>
   );
 }

--- a/src/components/common/layer/LayerPagination.tsx
+++ b/src/components/common/layer/LayerPagination.tsx
@@ -8,18 +8,30 @@ import {
 import { usePagination } from '@material-ui/lab';
 import {
   KeyboardArrowDown,
+  KeyboardArrowLeft,
+  KeyboardArrowRight,
   KeyboardArrowUp,
+  MoreHoriz,
   MoreVert,
 } from '@material-ui/icons';
 import React from 'react';
 
 const useLayerPaginationStyles = makeStyles({
-  ul: {
+  ulVertical: {
     listStyle: 'none',
     padding: 0,
     margin: 0,
     display: 'flex',
     flexDirection: 'column',
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  ulHorizontal: {
+    listStyle: 'none',
+    padding: 0,
+    margin: 0,
+    display: 'flex',
+    flexDirection: 'row',
     alignItems: 'center',
     justifyContent: 'center',
   },
@@ -31,12 +43,15 @@ const useLayerPaginationStyles = makeStyles({
   },
 });
 
+type LayerPaginationOrientation = 'horizontal' | 'vertical';
+
 type LayerPaginationProps = {
   count: number;
   invisiblePages: boolean[];
   page: number;
   // eslint-disable-next-line no-unused-vars
   onClickPage: (page: number) => void;
+  orientation: LayerPaginationOrientation;
 };
 
 export default function LayerPagination(props: LayerPaginationProps) {
@@ -58,7 +73,13 @@ export default function LayerPagination(props: LayerPaginationProps) {
   });
   return (
     <nav>
-      <ul className={classes.ul}>
+      <ul
+        className={
+          props.orientation === 'vertical'
+            ? classes.ulVertical
+            : classes.ulHorizontal
+        }
+      >
         {items.map(({ page, type, selected, ...item }, index) => {
           let children = null;
           if (type === 'page') {
@@ -88,7 +109,11 @@ export default function LayerPagination(props: LayerPaginationProps) {
                 onClick={item.onClick}
                 disabled={item.disabled}
               >
-                <KeyboardArrowDown />
+                {props.orientation === 'vertical' ? (
+                  <KeyboardArrowDown />
+                ) : (
+                  <KeyboardArrowRight />
+                )}
               </IconButton>
             );
           } else if (type === 'previous') {
@@ -98,11 +123,16 @@ export default function LayerPagination(props: LayerPaginationProps) {
                 onClick={item.onClick}
                 disabled={item.disabled}
               >
-                <KeyboardArrowUp />
+                {props.orientation === 'vertical' ? (
+                  <KeyboardArrowUp />
+                ) : (
+                  <KeyboardArrowLeft />
+                )}
               </IconButton>
             );
           } else if (type === 'start-ellipsis' || type === 'end-ellipsis') {
-            children = <MoreVert />;
+            children =
+              props.orientation === 'vertical' ? <MoreVert /> : <MoreHoriz />;
           }
           return (
             <li key={index} className={classes.li}>

--- a/src/components/common/layer/LayerPagination.tsx
+++ b/src/components/common/layer/LayerPagination.tsx
@@ -1,0 +1,116 @@
+import {
+  Badge,
+  Chip,
+  IconButton,
+  makeStyles,
+  withStyles,
+} from '@material-ui/core';
+import { usePagination } from '@material-ui/lab';
+import {
+  KeyboardArrowDown,
+  KeyboardArrowUp,
+  MoreVert,
+} from '@material-ui/icons';
+import React from 'react';
+
+const useLayerPaginationStyles = makeStyles({
+  ul: {
+    listStyle: 'none',
+    padding: 0,
+    margin: 0,
+    display: 'flex',
+    flexDirection: 'column',
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  li: {
+    display: 'flex',
+  },
+  unselected: {
+    border: 0,
+  },
+});
+
+type LayerPaginationProps = {
+  count: number;
+  invisiblePages: boolean[];
+  page: number;
+  // eslint-disable-next-line no-unused-vars
+  onClickPage: (page: number) => void;
+};
+
+export default function LayerPagination(props: LayerPaginationProps) {
+  const StyledBadge = withStyles(() => ({
+    badge: {
+      right: 11,
+      top: 9,
+      border: `2px solid white`,
+    },
+  }))(Badge);
+
+  const classes = useLayerPaginationStyles();
+  const { items } = usePagination({
+    count: props.count,
+    page: props.page,
+    onChange: (event, page) => {
+      props.onClickPage(page);
+    },
+  });
+  return (
+    <nav>
+      <ul className={classes.ul}>
+        {items.map(({ page, type, selected, ...item }, index) => {
+          let children = null;
+          if (type === 'page') {
+            children = (
+              <StyledBadge
+                color="primary"
+                variant="dot"
+                invisible={props.invisiblePages[page - 1]}
+              >
+                <Chip
+                  variant="outlined"
+                  size="medium"
+                  label={page}
+                  color={selected ? 'primary' : undefined}
+                  clickable={!selected}
+                  onClick={() => {
+                    props.onClickPage(page);
+                  }}
+                  className={selected ? '' : classes.unselected}
+                />
+              </StyledBadge>
+            );
+          } else if (type === 'next') {
+            children = (
+              <IconButton
+                size="small"
+                onClick={item.onClick}
+                disabled={item.disabled}
+              >
+                <KeyboardArrowDown />
+              </IconButton>
+            );
+          } else if (type === 'previous') {
+            children = (
+              <IconButton
+                size="small"
+                onClick={item.onClick}
+                disabled={item.disabled}
+              >
+                <KeyboardArrowUp />
+              </IconButton>
+            );
+          } else if (type === 'start-ellipsis' || type === 'end-ellipsis') {
+            children = <MoreVert />;
+          }
+          return (
+            <li key={index} className={classes.li}>
+              {children}
+            </li>
+          );
+        })}
+      </ul>
+    </nav>
+  );
+}

--- a/src/components/configure/keymap/Keymap.scss
+++ b/src/components/configure/keymap/Keymap.scss
@@ -60,36 +60,6 @@
     }
   }
 
-  //.layer-wrapper {
-  //  display: flex;
-  //  flex-direction: column;
-  //  justify-content: center;
-  //  align-items: flex-start;
-  //  min-width: 80px;
-  //  padding-left: $space-l;
-  //  .layers {
-  //    display: flex;
-  //    flex-direction: column;
-  //    align-items: center;
-  //    justify-content: center;
-  //    .layer {
-  //      display: flex;
-  //      flex-direction: column;
-  //      align-items: center;
-  //      .unselected-layer {
-  //        border-width: 0;
-  //      }
-  //    }
-  //    .option {
-  //      color: $color-gray-600;
-  //      &:hover {
-  //        cursor: pointer;
-  //        color: $primary;
-  //      }
-  //    }
-  //  }
-  //}
-
   .keyboards {
     display: flex;
     flex-direction: row;

--- a/src/components/configure/keymap/Keymap.scss
+++ b/src/components/configure/keymap/Keymap.scss
@@ -54,28 +54,41 @@
     align-items: flex-start;
     min-width: 80px;
     padding-left: $space-l;
-    .layers {
-      display: flex;
+
+    .MuiPagination-ul {
       flex-direction: column;
-      align-items: center;
-      justify-content: center;
-      .layer {
-        display: flex;
-        flex-direction: column;
-        align-items: center;
-        .unselected-layer {
-          border-width: 0;
-        }
-      }
-      .option {
-        color: $color-gray-600;
-        &:hover {
-          cursor: pointer;
-          color: $primary;
-        }
-      }
     }
   }
+
+  //.layer-wrapper {
+  //  display: flex;
+  //  flex-direction: column;
+  //  justify-content: center;
+  //  align-items: flex-start;
+  //  min-width: 80px;
+  //  padding-left: $space-l;
+  //  .layers {
+  //    display: flex;
+  //    flex-direction: column;
+  //    align-items: center;
+  //    justify-content: center;
+  //    .layer {
+  //      display: flex;
+  //      flex-direction: column;
+  //      align-items: center;
+  //      .unselected-layer {
+  //        border-width: 0;
+  //      }
+  //    }
+  //    .option {
+  //      color: $color-gray-600;
+  //      &:hover {
+  //        cursor: pointer;
+  //        color: $primary;
+  //      }
+  //    }
+  //  }
+  //}
 
   .keyboards {
     display: flex;

--- a/src/components/configure/keymap/Keymap.tsx
+++ b/src/components/configure/keymap/Keymap.tsx
@@ -301,6 +301,7 @@ function Layer(props: LayerProps) {
   return (
     <div className="layer-wrapper">
       <LayerPagination
+        orientation="vertical"
         count={props.layerCount}
         page={props.selectedLayer + 1}
         invisiblePages={invisiblePages}

--- a/src/components/configure/keymap/Keymap.tsx
+++ b/src/components/configure/keymap/Keymap.tsx
@@ -1,14 +1,7 @@
 /* eslint-disable no-undef */
 import React from 'react';
 import './Keymap.scss';
-import {
-  Badge,
-  Chip,
-  IconButton,
-  MenuItem,
-  Select,
-  withStyles,
-} from '@material-ui/core';
+import { IconButton, MenuItem, Select } from '@material-ui/core';
 import CloseRoundedIcon from '@material-ui/icons/CloseRounded';
 import Keydiff from '../keydiff/Keydiff.container';
 import { KeymapActionsType, KeymapStateType } from './Keymap.container';
@@ -29,6 +22,7 @@ import {
   KeyLabelLangs,
 } from '../../../services/labellang/KeyLabelLangs';
 import KeymapToolbar from '../keymapToolbar/KeymapToolbar.container';
+import LayerPagination from '../../common/layer/LayerPagination';
 
 export type LayoutOption = {
   option: number;
@@ -297,50 +291,23 @@ type LayerProps = {
 };
 
 function Layer(props: LayerProps) {
-  const StyledBadge = withStyles(() => ({
-    badge: {
-      right: 11,
-      top: 9,
-      border: `2px solid white`,
-    },
-  }))(Badge);
   const layers = [...Array(props.layerCount)].map((_, i) => i);
+  const invisiblePages = layers.map((layer) => {
+    return (
+      props.remaps![layer] == undefined ||
+      0 == Object.values(props.remaps![layer]).length
+    );
+  });
   return (
     <div className="layer-wrapper">
-      <div className="layers">
-        <div className="layer">
-          {layers!.map((layer) => {
-            const invisible =
-              props.remaps![layer] == undefined ||
-              0 == Object.values(props.remaps![layer]).length;
-            return (
-              <StyledBadge
-                key={layer}
-                color="primary"
-                variant="dot"
-                invisible={invisible}
-              >
-                <Chip
-                  key={layer}
-                  variant="outlined"
-                  size="medium"
-                  label={layer}
-                  color={props.selectedLayer == layer ? 'primary' : undefined}
-                  clickable={props.selectedLayer != layer}
-                  onClick={() => {
-                    props.onClickLayer(layer);
-                  }}
-                  className={
-                    props.selectedLayer != layer
-                      ? 'unselected-layer'
-                      : 'selected-layer'
-                  }
-                />
-              </StyledBadge>
-            );
-          })}
-        </div>
-      </div>
+      <LayerPagination
+        count={props.layerCount}
+        page={props.selectedLayer + 1}
+        invisiblePages={invisiblePages}
+        onClickPage={(page) => {
+          props.onClickLayer(page - 1);
+        }}
+      />
     </div>
   );
 }


### PR DESCRIPTION
Fix #553

Currently, all layer numbers are displayed. Of course, as like the reported issue, the displaying method has a problem when the number of layers are many a bit. I want to change the method with the Pagination component.

![Screenshot_20210812_143744](https://user-images.githubusercontent.com/261787/129143777-c35186ad-447c-496d-a612-ecbf3b931b15.png)

The keyboard catalog page also has same issue. I fix it with the same approach above.

![Screenshot_20210812_143821](https://user-images.githubusercontent.com/261787/129143853-fcb4294c-b856-4f74-a4dd-e7b89a01d9a4.png)
