### PR TITLE
Improved the filter and sort algorithm of the autocomplete on the custom key popover

### DIFF
--- a/src/components/configure/customkey/AutocompleteKeys.tsx
+++ b/src/components/configure/customkey/AutocompleteKeys.tsx
@@ -16,16 +16,17 @@ const filterOptions = (
   { inputValue }: { inputValue: string }
 ) => {
   const value = inputValue.toLowerCase();
-  const matcheLabels = options.filter(
-    (option) => 0 <= option.keycodeInfo.label.toLowerCase().indexOf(value)
+  const matchedLabels = options.filter(
+    (option: IKeymap) =>
+      0 <= option.keycodeInfo.label.toLowerCase().indexOf(value)
   );
-  const matcheKinds = options.filter(
-    (option) =>
+  const matchedKinds = options.filter(
+    (option: IKeymap) =>
       0 <=
       option.kinds.join('::').replaceAll('_', '-').toLowerCase().indexOf(value)
   );
 
-  return matcheLabels.concat(matcheKinds);
+  return matchedLabels.concat(matchedKinds);
 };
 
 type OwnProps = {

--- a/src/components/configure/customkey/AutocompleteKeys.tsx
+++ b/src/components/configure/customkey/AutocompleteKeys.tsx
@@ -5,6 +5,29 @@ import { TextField } from '@material-ui/core';
 import { IKeymap } from '../../../services/hid/Hid';
 import { KeymapCategory } from '../../../services/hid/KeycodeList';
 
+/**
+ * Filter and sort strategy.
+ * CASE INSENSITIVE
+ * 1st priority: Match a key's label.
+ * 2nd priority: Match a kinds.
+ */
+const filterOptions = (
+  options: IKeymap[],
+  { inputValue }: { inputValue: string }
+) => {
+  const value = inputValue.toLowerCase();
+  const matcheLabels = options.filter(
+    (option) => 0 <= option.keycodeInfo.label.toLowerCase().indexOf(value)
+  );
+  const matcheKinds = options.filter(
+    (option) =>
+      0 <=
+      option.kinds.join('::').replaceAll('_', '-').toLowerCase().indexOf(value)
+  );
+
+  return matcheLabels.concat(matcheKinds);
+};
+
 type OwnProps = {
   keycodeOptions: IKeymap[];
   keycodeInfo: IKeymap | null;
@@ -49,6 +72,7 @@ export default class AutocompleteKeys extends React.Component<
         freeSolo
         size="small"
         options={this.props.keycodeOptions}
+        filterOptions={filterOptions}
         value={this.props.keycodeInfo}
         onChange={(event: any, newValue: string | IKeymap | null) => {
           this.updateValue(newValue as IKeymap);
@@ -58,11 +82,7 @@ export default class AutocompleteKeys extends React.Component<
           this.setInputValue(newInputValue.split('::')[0]);
         }}
         getOptionLabel={(option) => {
-          if (typeof option === 'string') {
-            return option;
-          } else {
-            return `${option.keycodeInfo!.label}::${option.kinds.join('::')}`;
-          }
+          return `${option.keycodeInfo!.label}::${option.kinds.join('::')}`;
         }}
         renderOption={(option) => (
           <div className="customkey-auto-select-item">


### PR DESCRIPTION
To solve issue #563, I set a new filter algorithm for the autocomplete on the custom key popover.
The algorithm prefers to show the key label earlier than the key categories which match the input text.

For this commit, a user will be able to search for a key label he/she wants more intuitively.
<img width="407" alt="スクリーンショット 2021-08-19 11 51 07" src="https://user-images.githubusercontent.com/316463/129999907-95db4900-e442-4a22-a8b7-ac2304c41f00.png">
