### PR TITLE
auto focus and select when open the custom key popover

### DIFF
--- a/src/components/configure/customkey/AutocompleteKeys.tsx
+++ b/src/components/configure/customkey/AutocompleteKeys.tsx
@@ -30,6 +30,7 @@ const filterOptions = (
 };
 
 type OwnProps = {
+  autoFocus: boolean;
   keycodeOptions: IKeymap[];
   keycodeInfo: IKeymap | null;
   label: string;
@@ -107,6 +108,10 @@ export default class AutocompleteKeys extends React.Component<
             {...params}
             label={this.props.label}
             variant="outlined"
+            autoFocus={this.props.autoFocus}
+            onFocus={(evt) => {
+              setTimeout(() => evt.target.select(), 300); // need to have short duration to work "select" in case of an Autocomplete component.
+            }}
             inputProps={{
               ...params.inputProps,
             }}

--- a/src/components/configure/customkey/CustomKey.tsx
+++ b/src/components/configure/customkey/CustomKey.tsx
@@ -83,7 +83,6 @@ export default class CustomKey extends React.Component<OwnProps, OwnState> {
   }
 
   private onEnter() {
-    console.log('enter');
     //TODO: initialize input status
     const keymap: IKeymap = this.props.value.keymap;
     const code = keymap.code;

--- a/src/components/configure/customkey/CustomKey.tsx
+++ b/src/components/configure/customkey/CustomKey.tsx
@@ -33,6 +33,10 @@ export type PopoverPosition = {
   side: 'left' | 'above' | 'below' | 'right';
 };
 
+const TAB_INDEX_KEY = 0;
+const TAB_INDEX_HOLDTAP = 1;
+const TAB_INDEX_CUSTOM = 2;
+
 type OwnProps = {
   id: string;
   value: Key;
@@ -79,6 +83,7 @@ export default class CustomKey extends React.Component<OwnProps, OwnState> {
   }
 
   private onEnter() {
+    console.log('enter');
     //TODO: initialize input status
     const keymap: IKeymap = this.props.value.keymap;
     const code = keymap.code;
@@ -323,7 +328,7 @@ export default class CustomKey extends React.Component<OwnProps, OwnState> {
               <Tab label="CUSTOM" {...a11yProps(2)} />
             </Tabs>
           </AppBar>
-          <TabPanel value={this.state.selectedTabIndex} index={0}>
+          <TabPanel value={this.state.selectedTabIndex} index={TAB_INDEX_KEY}>
             <TabKey
               value={this.state.value}
               desc={desc}
@@ -331,12 +336,16 @@ export default class CustomKey extends React.Component<OwnProps, OwnState> {
               hexCode={this.state.hexCode}
               labelLang={this.props.labelLang}
               bleMicroPro={this.props.bleMicroPro}
+              autoFocus={this.state.selectedTabIndex === TAB_INDEX_KEY}
               onChangeKey={(opt: IKeymap) => {
                 this.onChangeKey(opt);
               }}
             />
           </TabPanel>
-          <TabPanel value={this.state.selectedTabIndex} index={1}>
+          <TabPanel
+            value={this.state.selectedTabIndex}
+            index={TAB_INDEX_HOLDTAP}
+          >
             <div className="customkey-description">
               {'Please select each key code when Hold / Tap'}
             </div>
@@ -345,12 +354,16 @@ export default class CustomKey extends React.Component<OwnProps, OwnState> {
               tapKey={this.state.tapKey}
               layerCount={this.props.layerCount}
               labelLang={this.props.labelLang}
+              autoFocus={this.state.selectedTabIndex === TAB_INDEX_HOLDTAP}
               onChange={(hold, tap) => {
                 this.onChangeHoldTap(hold, tap);
               }}
             />
           </TabPanel>
-          <TabPanel value={this.state.selectedTabIndex} index={2}>
+          <TabPanel
+            value={this.state.selectedTabIndex}
+            index={TAB_INDEX_CUSTOM}
+          >
             <div className="customkey-description">
               You can assign a keycode(hex) manually.
             </div>
@@ -384,7 +397,9 @@ export default class CustomKey extends React.Component<OwnProps, OwnState> {
               onChange={(e) => {
                 this.onChangeHexCode(e.target.value);
               }}
+              onFocus={(evt) => evt.target.select()}
               value={this.state.hexCode.toUpperCase()}
+              autoFocus={this.state.selectedTabIndex === TAB_INDEX_CUSTOM}
             />
 
             <div className="customkey-bcode">

--- a/src/components/configure/customkey/TabHoldTapKey.tsx
+++ b/src/components/configure/customkey/TabHoldTapKey.tsx
@@ -19,6 +19,7 @@ type OwnProps = {
   tapKey: IKeymap | null;
   layerCount: number;
   labelLang: KeyboardLabelLang;
+  autoFocus: boolean;
   // eslint-disable-next-line no-unused-vars
   onChange: (hold: IKeymap | null, tap: IKeymap | null) => void;
 };
@@ -130,6 +131,7 @@ export default class TabHoldTapKey extends React.Component<OwnProps, OwnState> {
           showKinds={false}
           keycodeOptions={this._holdKeyOptions}
           keycodeInfo={this.props.holdKey}
+          autoFocus={this.props.autoFocus}
           onChange={(opt) => {
             this.onChangeHoldKey(opt);
           }}
@@ -141,6 +143,7 @@ export default class TabHoldTapKey extends React.Component<OwnProps, OwnState> {
           label="Tap"
           keycodeOptions={this.tapKeycodeOptions}
           keycodeInfo={this.props.tapKey}
+          autoFocus={false}
           onChange={(opt) => {
             this.onChangeTapKey(opt);
           }}

--- a/src/components/configure/customkey/TabKey.tsx
+++ b/src/components/configure/customkey/TabKey.tsx
@@ -18,6 +18,7 @@ import { KeyCategory } from '../../../services/hid/KeyCategoryList';
 import { KeyboardLabelLang } from '../../../services/labellang/KeyLabelLangs';
 
 type OwnProps = {
+  autoFocus: boolean;
   value: IKeymap | null; // Keys
   desc: string;
   layerCount: number;
@@ -176,6 +177,7 @@ export default class TabKey extends React.Component<OwnProps, OwnState> {
           label="Keycode"
           keycodeOptions={this.basicKeymapsWithBmp}
           keycodeInfo={this.props.value}
+          autoFocus={this.props.autoFocus}
           onChange={(opt) => {
             this.onChangeKeycode(opt);
           }}


### PR DESCRIPTION
Set focus automatically and select all text when open the custom key popover.

<img width="448" alt="スクリーンショット 2021-08-19 13 41 57" src="https://user-images.githubusercontent.com/316463/130008912-ffeecfb5-2247-456a-b22a-bd79a140da93.png">
