### PR TITLE
enabled to search keycodes

### DIFF
--- a/src/components/configure/keycodekey/KeycodeKey.tsx
+++ b/src/components/configure/keycodekey/KeycodeKey.tsx
@@ -5,7 +5,7 @@ import {
   KeycodeKeyStateType,
 } from './KeycodeKey.container';
 import './KeycodeKey.scss';
-import { genKey, Key } from './KeyGen';
+import { Key } from './KeyGen';
 
 export type AnyKey = {
   label: string;
@@ -69,9 +69,13 @@ export default class KeycodeKey extends React.Component<
   }
   render() {
     const draggable = this.props.draggable;
-    const km = this.props.value.keymap;
+    //const km = this.props.value.keymap;
 
-    const key: Key = genKey(km, this.props.labelLang!);
+    //console.log(this.props.labelLang);
+    //console.log(km);
+    //const key: Key = genKey(km, this.props.labelLang!);
+    const key: Key = this.props.value;
+    //console.log(key);
     const label = key.label;
     const modifierLabel = key.meta;
     const modifierRightLabel = key.metaRight;

--- a/src/components/configure/keycodekey/KeycodeKey.tsx
+++ b/src/components/configure/keycodekey/KeycodeKey.tsx
@@ -69,13 +69,7 @@ export default class KeycodeKey extends React.Component<
   }
   render() {
     const draggable = this.props.draggable;
-    //const km = this.props.value.keymap;
-
-    //console.log(this.props.labelLang);
-    //console.log(km);
-    //const key: Key = genKey(km, this.props.labelLang!);
     const key: Key = this.props.value;
-    //console.log(key);
     const label = key.label;
     const modifierLabel = key.meta;
     const modifierRightLabel = key.metaRight;

--- a/src/components/configure/keycodes/Keycodes.scss
+++ b/src/components/configure/keycodes/Keycodes.scss
@@ -35,6 +35,12 @@
         transition: background-color 0.5s;
       }
     }
+    .keycodes-search {
+      margin-top: -14px;
+      svg {
+        color: rgba(0, 0, 0, 0.7);
+      }
+    }
   }
   .keylayout-switch {
     display: flex;

--- a/src/components/configure/keycodes/Keycodes.tsx
+++ b/src/components/configure/keycodes/Keycodes.tsx
@@ -47,32 +47,34 @@ export default class Keycodes extends React.Component<KeycodesProps, OwnState> {
   /**
    * Filter keys matching with the label and meta case-insensitive.
    * Sort them with prefix matching.
-   * @param searchKey
-   * @returns
+   * The label keys are listed higher than the meta keys.
    */
   private filterKeys(searchKey: string): Key[] {
     const search = searchKey.toLowerCase();
     let allKeys: Key[] = Object.values(this.state.categoryKeys).flat();
 
     // match with label & meta
-    const filteredKeys = allKeys.filter(
-      (key) =>
-        0 <= key.label.toLowerCase().indexOf(search) ||
-        0 <= key.meta.toLowerCase().indexOf(search)
+    const labelKeys = allKeys.filter(
+      (key) => 0 <= key.label.toLowerCase().indexOf(search)
+    );
+    const metaKeys = allKeys.filter(
+      (key) => 0 <= key.meta.toLowerCase().indexOf(search)
     );
 
-    // prioritize
-    const sortedKeys = filteredKeys.sort((k0, k1) => {
-      const indexLabel0 = k0.label.toLowerCase().indexOf(search);
-      const indexMeta0 = k0.meta.toLowerCase().indexOf(search) + 100; //deprioritize meta text
-      const indexLabel1 = k1.label.toLowerCase().indexOf(search);
-      const indexMeta1 = k1.meta.toLowerCase().indexOf(search) + 100; // deprioritize meta text
-      const index0 = Math.max(indexLabel0, indexMeta0);
-      const index1 = Math.max(indexLabel1, indexMeta1);
-      return index0 - index1;
-    });
+    const labelSortedKeys = labelKeys.sort(
+      (k0, k1) =>
+        k0.label.toLowerCase().indexOf(search) -
+        k1.label.toLowerCase().indexOf(search)
+    );
 
-    return sortedKeys;
+    const metaSortedKeys = metaKeys.sort(
+      (k0, k1) =>
+        k0.meta.toLowerCase().indexOf(search) -
+        k1.meta.toLowerCase().indexOf(search)
+    );
+
+    // label is more important than meta
+    return labelSortedKeys.concat(metaSortedKeys);
   }
 
   private removeBmpCategory(categoryKeys: { [category: string]: Key[] }) {


### PR DESCRIPTION
For this commit, a user can find keycodes easily by inputting search text.
The search target is both keycode's label and its meta label regardless of categories.
<img width="1307" alt="スクリーンショット 2021-08-19 17 43 43" src="https://user-images.githubusercontent.com/316463/130038357-c0fa2d26-683a-480e-9302-ca9da2711ec7.png">

Sort priority is the position of the matching keyword.
For example, in the case of the keyword is "mo", "Mouse" is showed forward rather than "RGB Mode".
The matching position of the keyword "Mouse" is 0, on the other hand, the matching position of "RGB Mode" is 4.