### PR TITLE
Put the hyper link to open each catalog page on a new tag.

### DIFF
--- a/src/components/catalog/search/CatalogSearch.scss
+++ b/src/components/catalog/search/CatalogSearch.scss
@@ -44,6 +44,11 @@
   display: flex;
   flex-direction: column;
   margin: 16px;
+
+  & a {
+    color: black;
+    text-decoration: none;
+  }
 }
 
 .catalog-search-result-pagination {

--- a/src/components/catalog/search/CatalogSearch.tsx
+++ b/src/components/catalog/search/CatalogSearch.tsx
@@ -448,11 +448,11 @@ type KeyboardCardProps = {
 function KeyboardCard(props: KeyboardCardProps) {
   const onClickCard = () => {
     sendEventToGoogleAnalytics('catalog/open_from_search');
-    location.href = `/catalog/${props.definition.id}`;
+    return true;
   };
 
   return (
-    <Card className="catalog-search-result-card" onClick={onClickCard}>
+    <Card className="catalog-search-result-card">
       {props.definition.imageUrl ? (
         <CardMedia
           image={props.definition.imageUrl}
@@ -460,31 +460,37 @@ function KeyboardCard(props: KeyboardCardProps) {
         />
       ) : null}
       <CardContent className="catalog-search-result-card-container">
-        <div className="catalog-search-result-card-content">
-          <div className="catalog-search-result-card-header">
-            <div className="catalog-search-result-card-header-name-container">
-              <h2 className="catalog-search-result-card-name">
-                {props.definition.name}
-              </h2>
-              <div className="catalog-search-result-card-header-name-row">
-                <Typography variant="caption">
-                  VID: {hexadecimal(props.definition.vendorId, 4)} / PID:{' '}
-                  {hexadecimal(props.definition.productId, 4)}
-                </Typography>
-                <Typography variant="caption">
-                  Designed by {getGitHubUserDisplayName(props.definition)}
-                </Typography>
+        <a
+          href={`/catalog/${props.definition.id}`}
+          onClick={onClickCard}
+          rel="noreferrer"
+        >
+          <div className="catalog-search-result-card-content">
+            <div className="catalog-search-result-card-header">
+              <div className="catalog-search-result-card-header-name-container">
+                <h2 className="catalog-search-result-card-name">
+                  {props.definition.name}
+                </h2>
+                <div className="catalog-search-result-card-header-name-row">
+                  <Typography variant="caption">
+                    VID: {hexadecimal(props.definition.vendorId, 4)} / PID:{' '}
+                    {hexadecimal(props.definition.productId, 4)}
+                  </Typography>
+                  <Typography variant="caption">
+                    Designed by {getGitHubUserDisplayName(props.definition)}
+                  </Typography>
+                </div>
               </div>
             </div>
+            <div className="catalog-search-result-card-features">
+              <FeatureList
+                definitionId={props.definition.id}
+                features={props.definition.features}
+                size="small"
+              />
+            </div>
           </div>
-          <div className="catalog-search-result-card-features">
-            <FeatureList
-              definitionId={props.definition.id}
-              features={props.definition.features}
-              size="small"
-            />
-          </div>
-        </div>
+        </a>
       </CardContent>
     </Card>
   );


### PR DESCRIPTION
Fix #567

<img width="1329" alt="スクリーンショット 2021-08-21 7 40 35" src="https://user-images.githubusercontent.com/261787/130300067-e314dceb-c1ef-4a03-b868-2db89665e520.png">

Users can open each keyboard catalog page on an opened new tab by the hyper link added by this pull request.