### PR TITLE
fixed to show the right meta chars

### DIFF
--- a/src/services/labellang/KeyLabelLangs.ts
+++ b/src/services/labellang/KeyLabelLangs.ts
@@ -133,7 +133,7 @@ function genKeyLabels(keylabels: KeyLabel[]): KeyLabel[] {
   return list;
 }
 
-const KEY_LABEL_LANGS: {
+export const KEY_LABEL_LANGS: {
   labelLang: KeyboardLabelLang;
   keyLabels: KeyLabel[];
   menuLabel: string;


### PR DESCRIPTION
When generating Keys, check the meta-right char exist, every time.
It's a little heavy to calculate it but easy to edit the key top labels by editing its data.

<img width="1278" alt="スクリーンショット 2021-08-23 12 43 33" src="https://user-images.githubusercontent.com/316463/130387745-9acda683-8d34-422c-a7b1-6efdea67429c.png">
