### PR TITLE
Update a keyboard name at updating the definition JSON file.

### DIFF
--- a/src/actions/storage.action.ts
+++ b/src/actions/storage.action.ts
@@ -575,6 +575,8 @@ export const storageActionsThunk = {
   ) => {
     const { storage, keyboards, entities } = getState();
     const definitionDoc = entities.keyboardDefinitionDocument;
+    // This `keyboardDefinition` value has already been updated by a new
+    // JSON file the user uploaded from local.
     const keyboardDefinition = keyboards.editdefinition.keyboardDefinition;
     const jsonStr = keyboards.editdefinition.jsonString;
     const result = await storage.instance!.updateKeyboardDefinitionJson(

--- a/src/actions/storage.action.ts
+++ b/src/actions/storage.action.ts
@@ -575,9 +575,11 @@ export const storageActionsThunk = {
   ) => {
     const { storage, keyboards, entities } = getState();
     const definitionDoc = entities.keyboardDefinitionDocument;
+    const keyboardDefinition = keyboards.editdefinition.keyboardDefinition;
     const jsonStr = keyboards.editdefinition.jsonString;
     const result = await storage.instance!.updateKeyboardDefinitionJson(
       definitionDoc!.id,
+      keyboardDefinition!.name,
       jsonStr
     );
     if (result.success) {

--- a/src/services/provider/Firebase.ts
+++ b/src/services/provider/Firebase.ts
@@ -210,6 +210,7 @@ export class FirebaseProvider implements IStorage, IAuth {
 
   async updateKeyboardDefinitionJson(
     definitionId: string,
+    name: string,
     jsonStr: string
   ): Promise<IResult> {
     try {
@@ -221,6 +222,7 @@ export class FirebaseProvider implements IStorage, IAuth {
         .doc(definitionId)
         .update({
           json: jsonStr,
+          name,
           updated_at: now,
         });
       return {

--- a/src/services/storage/Storage.ts
+++ b/src/services/storage/Storage.ts
@@ -215,6 +215,7 @@ export interface IStorage {
   ): Promise<IResult>;
   updateKeyboardDefinitionJson(
     definitionId: string,
+    name: string,
     jsonStr: string
   ): Promise<IResult>;
   deleteKeyboardDefinitionDocument(definitionId: string): Promise<IResult>;


### PR DESCRIPTION
Fix #559 

This pull request provides one improvement so that a keyboard name is updated with a new name written in a new JSON file.