### PR TITLE
Fix the issue that assigning a value to the readonly property.

### DIFF
--- a/src/models/KeyModel.ts
+++ b/src/models/KeyModel.ts
@@ -55,7 +55,7 @@ export default class KeyModel {
     this.pos = locs[0]; // 0 < locs[0].length ? locs[0] : locs[3];
     if (!this.includePosition(this.pos)) {
       // If there is no position label, this Key should be "Decal".
-      this.keyOp = Object.assign(this.keyOp || {}, { d: true });
+      this.keyOp = { ...(this.keyOp || {}), ...{ d: true } };
     }
     this.optionLabel =
       4 <= locs.length ? locs[3] : `${OPTION_DEFAULT},${OPTION_DEFAULT}`;


### PR DESCRIPTION
Fix #589 

The `keyOp` property is a readonly property, but the `Object.assign` function tries replacing the value and it is filed. As the result, the keyboard layout is not shown.

Instead of using the `Object.assign`, use the spread expression to avoid the assigning the value to the readonly property.