### PR TITLE
Filter the results of keyboard definitions with PRODUCT string

### DIFF
--- a/src/services/provider/Firebase.ts
+++ b/src/services/provider/Firebase.ts
@@ -177,11 +177,12 @@ export class FirebaseProvider implements IStorage, IAuth {
         .where('status', '==', 'approved')
         .get();
       let docs = querySnapshotByVidAndPid.docs;
-      if (docs.length > 1) {
-        docs = docs.filter((doc) =>
-          productName.endsWith(doc.data().product_name)
-        );
-      }
+      // Fix #587 https://github.com/remap-keys/remap/issues/587
+      // Irrespective of the number of the results, filter the results
+      // with the Product name.
+      docs = docs.filter((doc) =>
+        productName.endsWith(doc.data().product_name)
+      );
       if (docs.length === 0) {
         console.warn(
           `Keyboard definition not found: ${vendorId}:${productId}:${productName}`


### PR DESCRIPTION
Fix #587 

Filter the results of keyboard definitions with PRODUCT string, irrespective of the number of the search results with VID and PID. Current Remap revision doesn't filter the results with PRODUCT string when the  number of the results is one. However, to fix the #587, it must filter the results with the PRODUCT string as well in the case that the number of the results is one.