### PR TITLE
Revert "Filter the results of keyboard definitions with PRODUCT string"

### DIFF
--- a/src/services/provider/Firebase.ts
+++ b/src/services/provider/Firebase.ts
@@ -177,12 +177,11 @@ export class FirebaseProvider implements IStorage, IAuth {
         .where('status', '==', 'approved')
         .get();
       let docs = querySnapshotByVidAndPid.docs;
-      // Fix #587 https://github.com/remap-keys/remap/issues/587
-      // Irrespective of the number of the results, filter the results
-      // with the Product name.
-      docs = docs.filter((doc) =>
-        productName.endsWith(doc.data().product_name)
-      );
+      if (docs.length > 1) {
+        docs = docs.filter((doc) =>
+          productName.endsWith(doc.data().product_name)
+        );
+      }
       if (docs.length === 0) {
         console.warn(
           `Keyboard definition not found: ${vendorId}:${productId}:${productName}`


### PR DESCRIPTION
Reverts remap-keys/remap#600

We should not apply the change #600, because of detecting a keyboard with only VID and PID. Read #587.