### PR TITLE
Remove the package.alias.json symbolic link.

### DIFF
--- a/src/components/configure/Configure.container.ts
+++ b/src/components/configure/Configure.container.ts
@@ -20,6 +20,7 @@ const mapStateToProps = (state: RootState) => {
     draggingKey: state.configure.keycodeKey.draggingKey,
     testMatrix: state.configure.keymapToolbar.testMatrix,
     keyboard: state.entities.keyboard,
+    buildNumber: state.app.buildNumber,
   };
 };
 export type ConfigureStateType = ReturnType<typeof mapStateToProps>;

--- a/src/components/configure/Configure.tsx
+++ b/src/components/configure/Configure.tsx
@@ -10,11 +10,12 @@ import {
   ConfigureActionsType,
   ConfigureStateType,
 } from './Configure.container';
-import appPackage from '../../package.alias.json';
 import { NotificationItem } from '../../actions/actions';
 import { Button } from '@material-ui/core';
 import { IKeyboard } from '../../services/hid/Hid';
 import Footer from '../common/footer/Footer.container';
+
+const APPLICATION_NAME = 'Remap';
 
 type OwnProps = {};
 type ConfigureProps = OwnProps &
@@ -74,7 +75,7 @@ class Configure extends React.Component<ConfigureProps, OwnState> {
     const hasKeysToFlush = this.props.remaps!.reduce((has, v) => {
       return 0 < Object.values(v).length || has;
     }, false);
-    const title = hasKeysToFlush ? `*${appPackage.name}` : appPackage.name;
+    const title = hasKeysToFlush ? `*${APPLICATION_NAME}` : APPLICATION_NAME;
     this.props.updateTitle!(title);
   }
 
@@ -104,9 +105,10 @@ class Configure extends React.Component<ConfigureProps, OwnState> {
       });
       return;
     }
-    const version = appPackage.version;
-    const name = appPackage.name;
-    this.props.initAppPackage!(name, version);
+    this.props.initAppPackage!(
+      APPLICATION_NAME,
+      String(this.props.buildNumber!)
+    );
 
     if (this.props.auth) {
       this.props.auth.subscribeAuthStatus((user) => {

--- a/src/package.alias.json
+++ b/src/package.alias.json
@@ -1,1 +1,0 @@
-../package.json


### PR DESCRIPTION
The `package.alias.json` is a symbolic link to access to the name and the version of this application from a source code. However, current version does not use them. And, the symbolic link causes some problem on some environment including Windows.

As the result, I want to remove the `package.alias.json` symbolic link to avoid some problems.