### PR TITLE
Clear information for Macro Editor at disconnecting keyboard.

### DIFF
--- a/src/components/configure/Configure.container.ts
+++ b/src/components/configure/Configure.container.ts
@@ -9,6 +9,7 @@ import {
 } from '../../actions/actions';
 import { IKeyboard } from '../../services/hid/Hid';
 import { MetaActions } from '../../actions/meta.action';
+import { MacroEditorActions } from '../../actions/macro.action';
 
 const mapStateToProps = (state: RootState) => {
   return {
@@ -60,6 +61,7 @@ const mapDispatchToProps = (_dispatch: any) => {
       }
 
       _dispatch(HidActions.disconnectKeyboard(keyboard));
+      _dispatch(MacroEditorActions.clearMacroKey());
       _dispatch(KeymapToolbarActions.updateTestMatrix(false));
     },
 


### PR DESCRIPTION
Fix #610 

Clear information for Macro Editor when a keyboard is disconnected, because the Macro Editor is displayed when other keyboard is connected due to the information for Macro Editor is remained in the state.