### PR TITLE
Call loadKeymaps() function after keyboard definition is changed.

### DIFF
--- a/src/actions/storage.action.ts
+++ b/src/actions/storage.action.ts
@@ -146,7 +146,6 @@ export const storageActionsThunk = {
     dispatch(KeydiffActions.clearKeydiff());
     dispatch(KeycodeKeyActions.clear());
     dispatch(KeymapActions.clearSelectedPos());
-    console.log('refreshKeyboardDefinition - finish');
   },
 
   // eslint-disable-next-line no-undef

--- a/src/actions/storage.action.ts
+++ b/src/actions/storage.action.ts
@@ -141,10 +141,12 @@ export const storageActionsThunk = {
       )
     );
     dispatch(StorageActions.updateKeyboardDefinition(keyboardDefinition));
+    dispatch(await hidActionsThunk.refreshKeymaps());
     dispatch(AppActions.remapsInit(entities.device.layerCount));
     dispatch(KeydiffActions.clearKeydiff());
     dispatch(KeycodeKeyActions.clear());
     dispatch(KeymapActions.clearSelectedPos());
+    console.log('refreshKeyboardDefinition - finish');
   },
 
   // eslint-disable-next-line no-undef


### PR DESCRIPTION
Fix #603

When loading a different keyboard definition JSON file after opening a keyboard and the file has different rows and columns values from the opened keyboard, key codes from MCU are shifted from the keyboard layout, as the result, key mappings does not shown normally. To adjust them, it is necessary to call the `loadKeymaps()` function after the keyboard definition information is changed.