### PR TITLE
arrange the css for smartphone

### DIFF
--- a/src/_variables.scss
+++ b/src/_variables.scss
@@ -37,7 +37,7 @@ $space-xs: 2px;
 
 // media query
 $breakpoints: (
-  'sm': 'screen and (max-width: 414px)',
+  'sm': 'screen and (max-width: 599px)',
   'md': 'screen and (max-width: 768px)',
   'lg': 'screen and (max-width: 1000px)',
   'xl': 'screen and (min-width: 1001px)',

--- a/src/components/catalog/keyboard/CatalogIntroduction.scss
+++ b/src/components/catalog/keyboard/CatalogIntroduction.scss
@@ -22,6 +22,12 @@
     padding-top: 8px;
   }
 
+  @include mq(sm) {
+    &-container {
+      padding-top: 0;
+    }
+  }
+
   &-content {
     width: 100%;
   }

--- a/src/components/catalog/keyboard/CatalogKeyboard.scss
+++ b/src/components/catalog/keyboard/CatalogKeyboard.scss
@@ -42,6 +42,12 @@
     }
   }
 
+  @include mq(sm) {
+    &-header {
+      padding: 8px;
+    }
+  }
+
   &-column {
     width: 100%;
   }

--- a/src/components/catalog/keyboard/CatalogKeyboardHeader.scss
+++ b/src/components/catalog/keyboard/CatalogKeyboardHeader.scss
@@ -10,6 +10,7 @@
   flex-direction: row;
   align-items: center;
   justify-content: space-between;
+  flex-wrap: wrap;
 
   &-title {
     display: flex;
@@ -29,12 +30,22 @@
       font-size: 32px;
       font-weight: bold;
     }
+    @include mq(lg) {
+      & h1 {
+        font-size: 24px;
+        font-weight: bold;
+      }
+      & h6 {
+        font-size: 0.8rem;
+      }
+    }
   }
 
   &-links {
     display: flex;
     flex-direction: row;
     align-items: center;
+    margin-left: auto;
 
     &-github {
       margin-left: 16px;
@@ -47,5 +58,35 @@
     &-stores {
       margin-left: 16px;
     }
+    @include mq(lg) {
+      &-github {
+        margin-left: 8px;
+        div {
+          width: 32px;
+          height: 32px;
+        }
+      }
+
+      &-home {
+        width: 32px;
+        height: 32px;
+        margin-left: 8px;
+      }
+
+      &-stores {
+        margin-left: 8px;
+        button {
+          width: 32px;
+          height: 32px;
+          padding: 0;
+        }
+      }
+    }
+  }
+}
+
+@include mq(sm) {
+  .catalog-keyboard-header {
+    margin-bottom: 8px;
   }
 }


### PR DESCRIPTION
The results of this commit are as follows:

<img width="382" alt="スクリーンショット 2021-09-15 12 37 00" src="https://user-images.githubusercontent.com/316463/133371211-e75806e5-73c3-4830-bfcd-b9a4425c6c3c.png">


<img width="385" alt="スクリーンショット 2021-09-15 12 36 42" src="https://user-images.githubusercontent.com/316463/133371202-c004a962-6ccf-4b07-ae03-4a20c447f9f2.png">
