### PR TITLE
relocate tabs in header to the content on the catalog page

### DIFF
--- a/src/components/catalog/content/Content.container.ts
+++ b/src/components/catalog/content/Content.container.ts
@@ -1,9 +1,14 @@
 import { connect } from 'react-redux';
+import {
+  CatalogAppActions,
+  CatalogKeyboardActions,
+} from '../../../actions/catalog.action';
 import { RootState } from '../../../store/state';
 import Content from './Content';
 
 const mapStateToProps = (state: RootState) => {
   return {
+    definitionDocument: state.entities.keyboardDefinitionDocument,
     phase: state.catalog.app.phase,
   };
 };
@@ -11,7 +16,15 @@ export type ContentStateType = ReturnType<typeof mapStateToProps>;
 
 /* eslint-disable-next-line no-unused-vars */
 const mapDispatchToProps = (_dispatch: any) => {
-  return {};
+  return {
+    goToKeymap: () => {
+      _dispatch(CatalogKeyboardActions.clearKeymap());
+      _dispatch(CatalogAppActions.updatePhase('keymap'));
+    },
+    goToIntroduction: () => {
+      _dispatch(CatalogAppActions.updatePhase('introduction'));
+    },
+  };
 };
 export type ContentActionsType = ReturnType<typeof mapDispatchToProps>;
 

--- a/src/components/catalog/content/Content.scss
+++ b/src/components/catalog/content/Content.scss
@@ -4,7 +4,22 @@
   position: relative;
   flex-direction: column;
   align-items: center;
-  height: 100vh;
+  height: 100%;
+  width: 100%;
+  min-height: 100vh;
+  max-width: 960px;
+  margin: 0 auto;
+  padding-top: 64px;
+
+  &-nav {
+    width: 100%;
+    display: flex;
+    flex-direction: row;
+    justify-content: flex-start;
+    .MuiTabs-root {
+      background-color: white;
+    }
+  }
 
   .catalog-processing-wrapper {
     position: relative;
@@ -17,4 +32,19 @@
     flex: 1 1;
     width: 100%;
   }
+}
+
+@include mq(sm) {
+  .catalog-content {
+    padding-top: calc(var(--key-height));
+  }
+}
+
+.catalog-share-buttons {
+  margin-right: 16px;
+  display: flex;
+  flex-direction: row;
+  justify-content: flex-end;
+  margin-left: auto;
+  align-items: center;
 }

--- a/src/components/catalog/content/Content.tsx
+++ b/src/components/catalog/content/Content.tsx
@@ -1,11 +1,15 @@
 import React from 'react';
 import { ContentActionsType, ContentStateType } from './Content.container';
 import './Content.scss';
-import { CircularProgress } from '@material-ui/core';
+import { CircularProgress, Tab, Tabs } from '@material-ui/core';
 import Footer from '../../common/footer/Footer.container';
 import { ICatalogPhase } from '../../../store/state';
 import CatalogSearch from '../search/CatalogSearch.container';
 import CatalogKeyboard from '../keyboard/CatalogKeyboard.container';
+import { CatalogKeyboardHeader } from '../keyboard/CatalogKeyboardHeader';
+import { IKeyboardDefinitionDocument } from '../../../services/storage/Storage';
+import { sendEventToGoogleAnalytics } from '../../../utils/GoogleAnalytics';
+import TweetButton from '../../common/twitter/TweetButton';
 
 type ContentState = {};
 type OwnProps = {};
@@ -22,30 +26,26 @@ export default class Content extends React.Component<
   }
 
   render() {
-    return (
-      <div className="catalog-content">
-        <Contents phase={this.props.phase!} />
-        <Footer />
-      </div>
-    );
-  }
-}
-
-type ContentsProps = {
-  phase: ICatalogPhase;
-};
-function Contents(props: ContentsProps) {
-  switch (props.phase) {
-    case 'init':
-    case 'processing':
-      return <PhaseProcessing />;
-    case 'list':
-      return <CatalogSearch />;
-    case 'introduction':
-    case 'keymap':
-      return <CatalogKeyboard />;
-    default:
-      throw new Error(`Unknown state.catalog.app.phase value: ${props.phase}`);
+    const phase = this.props.phase!;
+    switch (phase) {
+      case 'init':
+      case 'processing':
+        return <PhaseProcessing />;
+      case 'list':
+        return <CatalogSearch />;
+      case 'introduction':
+      case 'keymap':
+        return (
+          <CategoryKeyboardContent
+            phase={phase}
+            definitionDocument={this.props.definitionDocument!}
+            goToIntroduction={this.props.goToIntroduction!.bind(this)}
+            goToKeymap={this.props.goToKeymap!.bind(this)}
+          />
+        );
+      default:
+        throw new Error(`Unknown state.catalog.app.phase value: ${phase}`);
+    }
   }
 }
 
@@ -59,3 +59,60 @@ function PhaseProcessing() {
     </div>
   );
 }
+
+type CategoryKeyboardContentProps = {
+  phase: ICatalogPhase;
+  definitionDocument: IKeyboardDefinitionDocument;
+  goToIntroduction: () => void;
+  goToKeymap: () => void;
+};
+
+const CategoryKeyboardContent: React.FC<CategoryKeyboardContentProps> = ({
+  phase,
+  definitionDocument,
+  goToIntroduction,
+  goToKeymap,
+}) => {
+  const onChangeTab = (event: React.ChangeEvent<{}>, value: number) => {
+    if (value === 0) {
+      sendEventToGoogleAnalytics('catalog/introduction');
+      // eslint-disable-next-line no-undef
+      history.pushState(null, 'Remap', `/catalog/${definitionDocument.id}`);
+      goToIntroduction();
+    } else if (value === 1) {
+      sendEventToGoogleAnalytics('catalog/keymap');
+      // eslint-disable-next-line no-undef
+      history.pushState(
+        null,
+        'Remap',
+        `/catalog/${definitionDocument.id}/keymap`
+      );
+      goToKeymap();
+    }
+  };
+  if ((['introduction', 'keymap'] as ICatalogPhase[]).includes(phase)) {
+    const value = phase === 'keymap' ? 1 : 0;
+    // eslint-disable-next-line no-undef
+    const url = `https://remap-keys.app/catalog/${definitionDocument!.id}`;
+    return (
+      <>
+        <div className="catalog-content">
+          <CatalogKeyboardHeader definitionDocument={definitionDocument!} />
+          <div className="catalog-content-nav">
+            <Tabs value={value} indicatorColor="primary" onChange={onChangeTab}>
+              <Tab label="Overview" />
+              <Tab label="Keymap" />
+            </Tabs>
+            <div className="catalog-share-buttons">
+              <TweetButton url={url} />
+            </div>
+          </div>
+          <CatalogKeyboard />
+        </div>
+        <Footer />
+      </>
+    );
+  } else {
+    return null;
+  }
+};

--- a/src/components/catalog/content/Content.tsx
+++ b/src/components/catalog/content/Content.tsx
@@ -32,7 +32,12 @@ export default class Content extends React.Component<
       case 'processing':
         return <PhaseProcessing />;
       case 'list':
-        return <CatalogSearch />;
+        return (
+          <>
+            <CatalogSearch />
+            <Footer />
+          </>
+        );
       case 'introduction':
       case 'keymap':
         return (

--- a/src/components/catalog/header/Header.container.ts
+++ b/src/components/catalog/header/Header.container.ts
@@ -1,11 +1,7 @@
 import { connect } from 'react-redux';
 import { RootState } from '../../../store/state';
 import Header from './Header';
-import {
-  catalogActionsThunk,
-  CatalogAppActions,
-  CatalogKeyboardActions,
-} from '../../../actions/catalog.action';
+import { catalogActionsThunk } from '../../../actions/catalog.action';
 import { AppActionsThunk } from '../../../actions/actions';
 import { storageActionsThunk } from '../../../actions/storage.action';
 import { MetaActions } from '../../../actions/meta.action';
@@ -16,7 +12,6 @@ const mapStateToProps = (state: RootState) => {
     auth: state.auth.instance,
     signedIn: state.app.signedIn,
     phase: state.catalog.app.phase,
-    definitionDocument: state.entities.keyboardDefinitionDocument,
   };
 };
 export type HeaderStateType = ReturnType<typeof mapStateToProps>;
@@ -36,13 +31,6 @@ const mapDispatchToProps = (_dispatch: any) => {
     goToSearch: () => {
       _dispatch(storageActionsThunk.searchKeyboardsForCatalog());
       _dispatch(MetaActions.initialize());
-    },
-    goToKeymap: () => {
-      _dispatch(CatalogKeyboardActions.clearKeymap());
-      _dispatch(CatalogAppActions.updatePhase('keymap'));
-    },
-    goToIntroduction: () => {
-      _dispatch(CatalogAppActions.updatePhase('introduction'));
     },
   };
 };

--- a/src/components/catalog/header/Header.scss
+++ b/src/components/catalog/header/Header.scss
@@ -25,7 +25,7 @@
   }
 
   &-logo {
-    //margin-left: 8px;
+    margin-top: 8px;
   }
 
   &-menu-button {

--- a/src/components/catalog/header/Header.tsx
+++ b/src/components/catalog/header/Header.tsx
@@ -4,10 +4,9 @@ import './Header.scss';
 import { HeaderActionsType, HeaderStateType } from './Header.container';
 import { Logo } from '../../common/logo/Logo';
 import ProfileIcon from '../../common/auth/ProfileIcon.container';
-import { IconButton, Tab, Tabs } from '@material-ui/core';
+import { IconButton } from '@material-ui/core';
 import { ArrowBackIos } from '@material-ui/icons';
 import { ICatalogPhase } from '../../../store/state';
-import { IKeyboardDefinitionDocument } from '../../../services/storage/Storage';
 import { sendEventToGoogleAnalytics } from '../../../utils/GoogleAnalytics';
 
 type HeaderState = {};
@@ -43,19 +42,11 @@ class Header extends React.Component<HeaderProps, HeaderState> {
               </IconButton>
             </div>
           ) : null}
-          <div className="catalog-header-logo">
-            <a href="/">
-              <Logo width={100} />
-            </a>
-          </div>
         </div>
-        <div className="catalog-header-nav">
-          <CategoryKeyboardNav
-            phase={this.props.phase!}
-            definitionDocument={this.props.definitionDocument!}
-            goToIntroduction={this.props.goToIntroduction!}
-            goToKeymap={this.props.goToKeymap!}
-          />
+        <div className="catalog-header-logo">
+          <a href="/">
+            <Logo width={100} />
+          </a>
         </div>
         <div className="catalog-header-menu-button">
           <ProfileIcon
@@ -70,44 +61,3 @@ class Header extends React.Component<HeaderProps, HeaderState> {
 }
 
 export default Header;
-
-type CategoryKeyboardNavProps = {
-  phase: ICatalogPhase;
-  definitionDocument: IKeyboardDefinitionDocument;
-  goToIntroduction: () => void;
-  goToKeymap: () => void;
-};
-
-const CategoryKeyboardNav: React.FC<CategoryKeyboardNavProps> = ({
-  phase,
-  definitionDocument,
-  goToIntroduction,
-  goToKeymap,
-}) => {
-  const onChangeTab = (event: React.ChangeEvent<{}>, value: number) => {
-    if (value === 0) {
-      sendEventToGoogleAnalytics('catalog/introduction');
-      history.pushState(null, 'Remap', `/catalog/${definitionDocument.id}`);
-      goToIntroduction();
-    } else if (value === 1) {
-      sendEventToGoogleAnalytics('catalog/keymap');
-      history.pushState(
-        null,
-        'Remap',
-        `/catalog/${definitionDocument.id}/keymap`
-      );
-      goToKeymap();
-    }
-  };
-  if ((['introduction', 'keymap'] as ICatalogPhase[]).includes(phase)) {
-    const value = phase === 'keymap' ? 1 : 0;
-    return (
-      <Tabs value={value} indicatorColor="primary" onChange={onChangeTab}>
-        <Tab label={definitionDocument.name} />
-        <Tab label="Keymap" />
-      </Tabs>
-    );
-  } else {
-    return null;
-  }
-};

--- a/src/components/catalog/keyboard/CatalogIntroduction.scss
+++ b/src/components/catalog/keyboard/CatalogIntroduction.scss
@@ -2,10 +2,9 @@
 
 .catalog-introduction {
   &-wrapper {
-    position: fixed;
+    position: relative;
     width: 100%;
     max-width: 960px;
-    margin-top: calc(var(--key-height));
     z-index: 1;
     display: flex;
     flex-direction: column;
@@ -14,12 +13,10 @@
 
   &-container {
     width: 100%;
-    height: calc(100vh - var(--key-height) - 26px);
-    overflow-y: auto;
     display: flex;
     flex-direction: column;
     align-items: center;
-    padding-top: 8px;
+    margin-bottom: 32px;
   }
 
   @include mq(sm) {
@@ -81,7 +78,7 @@
       background-color: $color-gray-300;
     }
   }
-  @include mq(lg) {
+  @include mq(sm) {
     &-image {
       padding: 0;
       &-nothing {
@@ -92,7 +89,7 @@
   }
 
   &-section {
-    margin: 8px 8px 24px 8px;
+    margin: 8px 16px 24px 8px;
 
     & h2 {
       font-size: 22px;
@@ -118,13 +115,6 @@
   &-store {
     display: inline-block;
     margin-right: 16px !important;
-  }
-
-  &-share-buttons {
-    margin-right: 16px;
-    display: flex;
-    flex-direction: row;
-    justify-content: flex-end;
   }
 
   &-description-tab {

--- a/src/components/catalog/keyboard/CatalogIntroduction.tsx
+++ b/src/components/catalog/keyboard/CatalogIntroduction.tsx
@@ -8,8 +8,6 @@ import { Grid, Link, Paper, Tab, Tabs, Typography } from '@material-ui/core';
 import PhotoLibraryIcon from '@material-ui/icons/PhotoLibrary';
 import 'react-image-gallery/styles/css/image-gallery.css';
 import ImageGallery from 'react-image-gallery';
-import { CatalogKeyboardHeader } from './CatalogKeyboardHeader';
-import TweetButton from '../../common/twitter/TweetButton';
 import {
   IAdditionalDescription,
   IKeyboardDefinitionDocument,
@@ -66,9 +64,6 @@ export default class CatalogIntroduction extends React.Component<
     return (
       <div className="catalog-introduction-wrapper">
         <div className="catalog-introduction-container">
-          <CatalogKeyboardHeader
-            definitionDocument={this.props.definitionDocument!}
-          />
           <Paper elevation={0} className="catalog-introduction-content">
             <Grid container>
               <Grid item sm={6} className="catalog-introduction-column">
@@ -109,15 +104,6 @@ export default class CatalogIntroduction extends React.Component<
                   ) : (
                     <div>Not specified by the owner of this keyboard.</div>
                   )}
-                </section>
-                <section className="catalog-introduction-section">
-                  <div className="catalog-introduction-share-buttons">
-                    <TweetButton
-                      url={`https://remap-keys.app/catalog/${
-                        this.props.definitionDocument!.id
-                      }`}
-                    />
-                  </div>
                 </section>
                 {this.props.sameAuthorKeyboardDocuments!.length > 1 ? (
                   <section className="catalog-introduction-section">

--- a/src/components/catalog/keyboard/CatalogKeyboardHeader.scss
+++ b/src/components/catalog/keyboard/CatalogKeyboardHeader.scss
@@ -5,6 +5,7 @@
   color: white;
   width: 100%;
   max-width: 960px;
+  margin-top: 8px;
   margin-bottom: 16px;
   display: flex;
   flex-direction: row;
@@ -27,8 +28,11 @@
     }
 
     & h1 {
-      font-size: 32px;
+      font-size: 28px;
       font-weight: bold;
+    }
+    & h6 {
+      font-size: 0.9rem;
     }
     @include mq(lg) {
       & h1 {
@@ -87,6 +91,7 @@
 
 @include mq(sm) {
   .catalog-keyboard-header {
+    margin-top: 0;
     margin-bottom: 8px;
   }
 }

--- a/src/components/catalog/keyboard/CatalogKeymap.scss
+++ b/src/components/catalog/keyboard/CatalogKeymap.scss
@@ -115,7 +115,7 @@
       display: flex;
       flex-direction: row;
       justify-content: flex-end;
-      z-index: 1;
+      z-index: 3;
       div {
         margin-right: 8px;
       }

--- a/src/components/catalog/keyboard/CatalogKeymap.scss
+++ b/src/components/catalog/keyboard/CatalogKeymap.scss
@@ -1,24 +1,25 @@
 @import '../../../variables';
 
 .catalog-keymap {
-  &-container-wrapper {
-    position: fixed;
-    width: 100%;
-    margin-top: calc(var(--key-height));
-    z-index: 1;
-    display: flex;
-    flex-direction: column;
-    align-items: center;
-  }
-
   &-container {
     width: 100%;
-    height: calc(100vh - var(--key-height) - 26px);
     overflow-y: auto;
+    overflow-x: clip;
     display: flex;
     flex-direction: column;
     align-items: center;
     padding-top: 8px;
+
+    &-wrapper {
+      position: relative;
+      width: 100%;
+      z-index: 1;
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      background: white;
+      margin-bottom: 32px;
+    }
   }
 
   &-header {
@@ -83,30 +84,40 @@
       flex-direction: row;
       justify-content: center;
       align-items: center;
+      flex-wrap: wrap;
       padding: $space-l $space-l 0 $space-l;
     }
 
     &-side {
       display: flex;
-      width: 70px;
+      width: 100px;
     }
 
     &-side-left {
       display: flex;
       margin-right: auto;
+      justify-content: flex-start;
     }
 
     &-side-right {
       display: flex;
       margin-left: auto;
+      justify-content: flex-end;
     }
 
     &-lang {
-      margin-left: 16px;
       white-space: nowrap;
     }
 
     &-pdf {
+    }
+    &-menu {
+      display: flex;
+      flex-direction: row;
+      justify-content: flex-end;
+      div {
+        margin-right: 8px;
+      }
     }
   }
 

--- a/src/components/catalog/keyboard/CatalogKeymap.scss
+++ b/src/components/catalog/keyboard/CatalogKeymap.scss
@@ -115,6 +115,7 @@
       display: flex;
       flex-direction: row;
       justify-content: flex-end;
+      z-index: 1;
       div {
         margin-right: 8px;
       }

--- a/src/components/catalog/keyboard/Catalogkeymap.tsx
+++ b/src/components/catalog/keyboard/Catalogkeymap.tsx
@@ -151,13 +151,17 @@ export default class CatalogKeymap extends React.Component<
       keycaps.push({ model, keymap, remap });
     });
 
-    // eslint-disable-next-line no-undef
-    const windowWidth = this.state.windowWidth || window.innerWidth;
+    const CONTENT_MAX_WIDTH = 960;
+    const contentWidth = Math.min(
+      // eslint-disable-next-line no-undef
+      this.state.windowWidth || window.innerWidth,
+      CONTENT_MAX_WIDTH
+    );
     const keyboardRootWidth = width + 40;
     const keyboardRootHeight = height + 40;
     const scale =
-      windowWidth < keyboardRootWidth
-        ? (windowWidth - 20) / keyboardRootWidth
+      contentWidth < keyboardRootWidth
+        ? (contentWidth - 20) / keyboardRootWidth
         : 1; // considering the padding: 20px
     const marginScaledHeight =
       scale < 1 ? (keyboardRootHeight * (1 - scale)) / 2 : 0;
@@ -194,7 +198,7 @@ export default class CatalogKeymap extends React.Component<
             )}
             <div
               className="catalog-keymap-keyboards"
-              style={{ margin: '0 auto', maxWidth: windowWidth }}
+              style={{ margin: '0 auto', maxWidth: contentWidth }}
             >
               <div
                 className="catalog-keymap-keyboard-root"
@@ -236,7 +240,7 @@ export default class CatalogKeymap extends React.Component<
             </div>
             <div
               className="catalog-keymap-option-container"
-              style={{ marginTop: -marginScaledHeight, maxWidth: windowWidth }}
+              style={{ marginTop: -marginScaledHeight, maxWidth: contentWidth }}
             >
               {this.props.keymaps!.length > 0 ? (
                 <Layer

--- a/src/components/catalog/keyboard/Catalogkeymap.tsx
+++ b/src/components/catalog/keyboard/Catalogkeymap.tsx
@@ -18,7 +18,6 @@ import {
 } from '@material-ui/core';
 import { AbstractKeymapData } from '../../../services/storage/Storage';
 import { KeyLabelLangs } from '../../../services/labellang/KeyLabelLangs';
-import { CatalogKeyboardHeader } from './CatalogKeyboardHeader';
 import LayoutOptionComponentList from '../../configure/layoutoption/LayoutOptionComponentList.container';
 import CatalogKeymapList from './CatalogKeymapList.container';
 import PictureAsPdfRoundedIcon from '@material-ui/icons/PictureAsPdfRounded';
@@ -27,7 +26,9 @@ import { KeymapPdfGenerator } from '../../../services/pdf/KeymapPdfGenerator';
 import { sendEventToGoogleAnalytics } from '../../../utils/GoogleAnalytics';
 import LayerPagination from '../../common/layer/LayerPagination';
 
-type CatalogKeymapState = {};
+type CatalogKeymapState = {
+  windowWidth: number;
+};
 type OwnProps = {};
 type CatalogKeymapProps = OwnProps &
   Partial<CatalogKeymapActionsType> &
@@ -45,6 +46,17 @@ export default class CatalogKeymap extends React.Component<
 > {
   constructor(props: CatalogKeymapProps | Readonly<CatalogKeymapProps>) {
     super(props);
+    this.state = { windowWidth: 0 };
+  }
+
+  componentDidMount() {
+    // eslint-disable-next-line no-undef
+    window.addEventListener('resize', this.onResize.bind(this));
+  }
+
+  componentWillUnmount() {
+    // eslint-disable-next-line no-undef
+    window.removeEventListener('resize', this.onResize.bind(this));
   }
 
   // eslint-disable-next-line no-unused-vars
@@ -97,6 +109,14 @@ export default class CatalogKeymap extends React.Component<
     });
   }
 
+  onResize() {
+    // eslint-disable-next-line no-undef
+    const newWidth = window.innerWidth;
+    if (this.state.windowWidth != newWidth) {
+      this.setState({ windowWidth: newWidth });
+    }
+  }
+
   render() {
     const kbd = new KeyboardModel(
       this.props.keyboardDefinition!.layouts.keymap
@@ -130,26 +150,63 @@ export default class CatalogKeymap extends React.Component<
       const remap = null;
       keycaps.push({ model, keymap, remap });
     });
+
+    // eslint-disable-next-line no-undef
+    const windowWidth = this.state.windowWidth || window.innerWidth;
+    const keyboardRootWidth = width + 40;
+    const keyboardRootHeight = height + 40;
+    const scale =
+      windowWidth < keyboardRootWidth
+        ? (windowWidth - 20) / keyboardRootWidth
+        : 1; // considering the padding: 20px
+    const marginScaledHeight =
+      scale < 1 ? (keyboardRootHeight * (1 - scale)) / 2 : 0;
     return (
       <div className="catalog-keymap-container-wrapper">
         <div className="catalog-keymap-container">
-          <CatalogKeyboardHeader
-            definitionDocument={this.props.definitionDocument!}
-          />
           <div className="catalog-keymap-wrapper">
+            {this.props.keymaps!.length > 0 && (
+              <div className="catalog-keymap-option-menu">
+                <div className="catalog-keymap-option-pdf">
+                  <Tooltip
+                    arrow={true}
+                    placement="top"
+                    title="Get keymap cheat sheet (PDF)"
+                  >
+                    <IconButton
+                      size="small"
+                      onClick={this.onClickGetCheatsheet.bind(this)}
+                    >
+                      <PictureAsPdfRoundedIcon />
+                    </IconButton>
+                  </Tooltip>
+                </div>
+                <div className="catalog-keymap-option-lang">
+                  <Typography variant="subtitle1">
+                    {
+                      KeyLabelLangs.KeyLabelLangMenus.find(
+                        (m) => m.labelLang === this.props.langLabel
+                      )!.menuLabel
+                    }
+                  </Typography>
+                </div>
+              </div>
+            )}
             <div
               className="catalog-keymap-keyboards"
-              style={{ margin: '0 auto' }}
+              style={{ margin: '0 auto', maxWidth: windowWidth }}
             >
               <div
                 className="catalog-keymap-keyboard-root"
                 style={{
-                  width: width + 40,
-                  height: height + 40,
+                  width: keyboardRootWidth,
+                  height: keyboardRootHeight,
                   padding: 20,
                   borderWidth: 1,
                   borderColor: 'gray',
                   borderStyle: 'solid',
+                  transform: `scale(${scale})`,
+                  marginTop: -(marginScaledHeight - 8),
                 }}
               >
                 <div
@@ -177,41 +234,16 @@ export default class CatalogKeymap extends React.Component<
                 </div>
               </div>
             </div>
-            <div className="catalog-keymap-option-container">
+            <div
+              className="catalog-keymap-option-container"
+              style={{ marginTop: -marginScaledHeight, maxWidth: windowWidth }}
+            >
               {this.props.keymaps!.length > 0 ? (
-                <>
-                  <div className="catalog-keymap-option-side catalog-keymap-option-side-left"></div>
-                  <Layer
-                    layerCount={this.props.keymaps!.length}
-                    selectedLayer={this.props.selectedLayer!}
-                    onClickLayer={this.props.updateSelectedLayer!}
-                  />
-                  <div className="catalog-keymap-option-side catalog-keymap-option-side-right">
-                    <div className="catalog-keymap-option-pdf">
-                      <Tooltip
-                        arrow={true}
-                        placement="top"
-                        title="Get keymap cheat sheet (PDF)"
-                      >
-                        <IconButton
-                          size="small"
-                          onClick={this.onClickGetCheatsheet.bind(this)}
-                        >
-                          <PictureAsPdfRoundedIcon />
-                        </IconButton>
-                      </Tooltip>
-                    </div>
-                    <div className="catalog-keymap-option-lang">
-                      <Typography variant="subtitle1">
-                        {
-                          KeyLabelLangs.KeyLabelLangMenus.find(
-                            (m) => m.labelLang === this.props.langLabel
-                          )!.menuLabel
-                        }
-                      </Typography>
-                    </div>
-                  </div>
-                </>
+                <Layer
+                  layerCount={this.props.keymaps!.length}
+                  selectedLayer={this.props.selectedLayer!}
+                  onClickLayer={this.props.updateSelectedLayer!}
+                />
               ) : null}
             </div>
           </div>

--- a/src/components/catalog/search/CatalogSearch.scss
+++ b/src/components/catalog/search/CatalogSearch.scss
@@ -1,19 +1,21 @@
 @import '../../../variables';
 
 .catalog-search-wrapper {
-  position: fixed;
+  position: relative;
   width: 100%;
   max-width: 960px;
-  margin-top: calc(var(--key-height));
   z-index: 1;
   display: flex;
   flex-direction: column;
   align-items: center;
+  margin-left: auto;
+  margin-right: auto;
 }
 
 .catalog-search-container {
   width: 100%;
-  height: calc(100vh - var(--key-height) - 26px);
+  margin-top: calc(var(--key-height));
+  height: calc(100vh - var(--key-height));
   overflow-y: auto;
   display: flex;
   flex-direction: column;
@@ -44,6 +46,7 @@
   display: flex;
   flex-direction: column;
   margin: 16px;
+  margin-bottom: 48px;
 
   & a {
     color: black;


### PR DESCRIPTION
I've just re-located the tabs in the header of the catalog page into the content.
It looks like below:

<img width="1147" alt="スクリーンショット 2021-09-15 19 24 07" src="https://user-images.githubusercontent.com/316463/133417024-86008ab5-e23e-429d-b15b-4869ebf87187.png">

<img width="388" alt="スクリーンショット 2021-09-15 19 24 13" src="https://user-images.githubusercontent.com/316463/133417043-9284db7a-508b-4f16-8f6c-2341ad52f102.png">

<img width="383" alt="スクリーンショット 2021-09-15 19 26 45" src="https://user-images.githubusercontent.com/316463/133417135-d301816c-3465-4136-8d9a-7780c6bd543a.png">
