### PR TITLE
Can go back to the previous page by pressing the browser back button in each keyboard catalog page.

### DIFF
--- a/src/components/catalog/content/Content.tsx
+++ b/src/components/catalog/content/Content.tsx
@@ -10,6 +10,7 @@ import { CatalogKeyboardHeader } from '../keyboard/CatalogKeyboardHeader';
 import { IKeyboardDefinitionDocument } from '../../../services/storage/Storage';
 import { sendEventToGoogleAnalytics } from '../../../utils/GoogleAnalytics';
 import TweetButton from '../../common/twitter/TweetButton';
+import { useHistory } from 'react-router-dom';
 
 type ContentState = {};
 type OwnProps = {};
@@ -78,20 +79,17 @@ const CategoryKeyboardContent: React.FC<CategoryKeyboardContentProps> = ({
   goToIntroduction,
   goToKeymap,
 }) => {
+  const history = useHistory();
   const onChangeTab = (event: React.ChangeEvent<{}>, value: number) => {
     if (value === 0) {
       sendEventToGoogleAnalytics('catalog/introduction');
       // eslint-disable-next-line no-undef
-      history.pushState(null, 'Remap', `/catalog/${definitionDocument.id}`);
+      history.push(`/catalog/${definitionDocument.id}`);
       goToIntroduction();
     } else if (value === 1) {
       sendEventToGoogleAnalytics('catalog/keymap');
       // eslint-disable-next-line no-undef
-      history.pushState(
-        null,
-        'Remap',
-        `/catalog/${definitionDocument.id}/keymap`
-      );
+      history.push(`/catalog/${definitionDocument.id}/keymap`);
       goToKeymap();
     }
   };

--- a/src/components/catalog/keyboard/CatalogKeyboard.container.ts
+++ b/src/components/catalog/keyboard/CatalogKeyboard.container.ts
@@ -2,6 +2,12 @@ import { connect } from 'react-redux';
 import { RootState } from '../../../store/state';
 import CatalogKeyboard from './CatalogKeyboard';
 import { IMetaData, MetaActions } from '../../../actions/meta.action';
+import { RouteComponentProps, withRouter } from 'react-router-dom';
+import {
+  catalogActionsThunk,
+  CatalogAppActions,
+  CatalogKeyboardActions,
+} from '../../../actions/catalog.action';
 
 // eslint-disable-next-line no-unused-vars
 const mapStateToProps = (state: RootState) => {
@@ -10,7 +16,8 @@ const mapStateToProps = (state: RootState) => {
     definitionDocument: state.entities.keyboardDefinitionDocument,
   };
 };
-export type CatalogKeyboardStateType = ReturnType<typeof mapStateToProps>;
+export type CatalogKeyboardStateType = ReturnType<typeof mapStateToProps> &
+  RouteComponentProps;
 
 // eslint-disable-next-line no-unused-vars
 const mapDispatchToProps = (_dispatch: any) => {
@@ -21,8 +28,20 @@ const mapDispatchToProps = (_dispatch: any) => {
     initializeMeta: () => {
       _dispatch(MetaActions.initialize());
     },
+    goToIntroduction: () => {
+      _dispatch(CatalogAppActions.updatePhase('introduction'));
+    },
+    goToKeymap: () => {
+      _dispatch(CatalogKeyboardActions.clearKeymap());
+      _dispatch(CatalogAppActions.updatePhase('keymap'));
+    },
+    applySharedKeymap: (definitionId: string, keymapId: string) => {
+      _dispatch(catalogActionsThunk.applySharedKeymap(definitionId, keymapId));
+    },
   };
 };
 export type CatalogKeyboardActionsType = ReturnType<typeof mapDispatchToProps>;
 
-export default connect(mapStateToProps, mapDispatchToProps)(CatalogKeyboard);
+export default withRouter(
+  connect(mapStateToProps, mapDispatchToProps)(CatalogKeyboard)
+);

--- a/src/components/catalog/keyboard/CatalogKeyboard.tsx
+++ b/src/components/catalog/keyboard/CatalogKeyboard.tsx
@@ -44,7 +44,6 @@ export default class CatalogKeyboard extends React.Component<
     }
     this.unregisterHistoryCallback = this.props.history!.listen(
       (location, action) => {
-        // console.log(`location: ${location.search} action: ${action}`);
         if (action === 'POP') {
           const introductionMatch = matchPath(location.pathname, {
             path: '/catalog/:definitionId',

--- a/src/components/catalog/keyboard/CatalogKeyboard.tsx
+++ b/src/components/catalog/keyboard/CatalogKeyboard.tsx
@@ -6,6 +6,8 @@ import {
 } from './CatalogKeyboard.container';
 import CatalogIntroduction from './CatalogIntroduction.container';
 import CatalogKeymap from './CatalogKeymap.container';
+import { matchPath } from 'react-router-dom';
+import * as qs from 'qs';
 
 type CatalogKeyboardState = {};
 type OwnProps = {};
@@ -17,6 +19,8 @@ export default class CatalogKeyboard extends React.Component<
   CatalogKeyboardProps,
   CatalogKeyboardState
 > {
+  private unregisterHistoryCallback: any;
+
   constructor(props: CatalogKeyboardProps | Readonly<CatalogKeyboardProps>) {
     super(props);
   }
@@ -38,6 +42,48 @@ export default class CatalogKeyboard extends React.Component<
     } else {
       this.props.initializeMeta!();
     }
+    this.unregisterHistoryCallback = this.props.history!.listen(
+      (location, action) => {
+        // console.log(`location: ${location.search} action: ${action}`);
+        if (action === 'POP') {
+          const introductionMatch = matchPath(location.pathname, {
+            path: '/catalog/:definitionId',
+            exact: true,
+            strict: true,
+          });
+          if (introductionMatch) {
+            this.props.goToIntroduction!();
+            return;
+          }
+          const keymapMatch = matchPath<{ definitionId: string }>(
+            location.pathname,
+            {
+              path: '/catalog/:definitionId/keymap',
+              exact: true,
+              strict: true,
+            }
+          );
+          if (keymapMatch) {
+            this.props.goToKeymap!();
+            if (location.search) {
+              const queryParams = qs.parse(location.search, {
+                ignoreQueryPrefix: true,
+              });
+              if (queryParams.id) {
+                this.props.applySharedKeymap!(
+                  keymapMatch.params.definitionId,
+                  queryParams.id as string
+                );
+              }
+            }
+          }
+        }
+      }
+    );
+  }
+
+  componentWillUnmount() {
+    this.unregisterHistoryCallback && this.unregisterHistoryCallback();
   }
 
   render() {

--- a/src/components/catalog/keyboard/CatalogKeymap.container.ts
+++ b/src/components/catalog/keyboard/CatalogKeymap.container.ts
@@ -9,6 +9,7 @@ import {
 import { storageActionsThunk } from '../../../actions/storage.action';
 import { AbstractKeymapData } from '../../../services/storage/Storage';
 import { NotificationActions } from '../../../actions/actions';
+import { RouteComponentProps, withRouter } from 'react-router-dom';
 
 // eslint-disable-next-line no-unused-vars
 const mapStateToProps = (state: RootState) => {
@@ -21,7 +22,8 @@ const mapStateToProps = (state: RootState) => {
     langLabel: state.catalog.keyboard.langLabel,
   };
 };
-export type CatalogKeymapStateType = ReturnType<typeof mapStateToProps>;
+export type CatalogKeymapStateType = ReturnType<typeof mapStateToProps> &
+  RouteComponentProps;
 
 // eslint-disable-next-line no-unused-vars
 const mapDispatchToProps = (_dispatch: any) => {
@@ -45,4 +47,6 @@ const mapDispatchToProps = (_dispatch: any) => {
 };
 export type CatalogKeymapActionsType = ReturnType<typeof mapDispatchToProps>;
 
-export default connect(mapStateToProps, mapDispatchToProps)(CatalogKeymap);
+export default withRouter(
+  connect(mapStateToProps, mapDispatchToProps)(CatalogKeymap)
+);

--- a/src/components/catalog/keyboard/Catalogkeymap.tsx
+++ b/src/components/catalog/keyboard/Catalogkeymap.tsx
@@ -62,7 +62,7 @@ export default class CatalogKeymap extends React.Component<
   // eslint-disable-next-line no-unused-vars
   onClickBackButton(event: React.MouseEvent<{}>) {
     // eslint-disable-next-line no-undef
-    history.pushState(null, 'Remap', '/catalog');
+    this.props.history!.push('/catalog');
     this.props.goToSearch!();
   }
 
@@ -70,9 +70,7 @@ export default class CatalogKeymap extends React.Component<
     sendEventToGoogleAnalytics('catalog/apply_keymap');
     this.props.applySharedKeymapData!(savedKeymapData);
     // eslint-disable-next-line no-undef
-    history.pushState(
-      null,
-      'Remap',
+    this.props.history!.push(
       `/catalog/${this.props.definitionDocument!.id}/keymap?id=${
         savedKeymapData.id
       }`


### PR DESCRIPTION
Fix #630 

In this pull request, I register the event listener to handle the event fired by pressing the browser's back button. The event listener checks the action type. If the action type is "POP", change the state to render each screen according to the passed `location` information. The location object has a path name and query parameters to go back to the previous page. The previous state can be determined by checking the path with `matchPath` function provided by the React Router library.

Also, to handle histories In the React Router, use the `history.push` function provided by the `RouteComponentProps`.