### PR TITLE
Set no image to the keyboard image of the same designers'

### DIFF
--- a/src/components/catalog/keyboard/CatalogIntroduction.scss
+++ b/src/components/catalog/keyboard/CatalogIntroduction.scss
@@ -146,6 +146,13 @@
       width: 100px;
       height: 75px;
       border: 1px dotted $color-gray-300;
+      display: flex;
+      flex-direction: column;
+      justify-content: center;
+      align-items: center;
+      color: $color-gray-600;
+      background-color: $color-gray-300;
+      font-size: 0.8rem;
     }
 
     &-name {

--- a/src/components/catalog/keyboard/CatalogIntroduction.tsx
+++ b/src/components/catalog/keyboard/CatalogIntroduction.tsx
@@ -131,7 +131,10 @@ export default class CatalogIntroduction extends React.Component<
                               }}
                             />
                           ) : (
-                            <div className="catalog-introduction-same-author-keyboard-no-image" />
+                            <div className="catalog-introduction-same-author-keyboard-no-image">
+                              <PhotoLibraryIcon />
+                              No Image
+                            </div>
                           )}
                           <Typography
                             variant="subtitle1"


### PR DESCRIPTION
<img width="289" alt="スクリーンショット 2021-09-16 18 52 10" src="https://user-images.githubusercontent.com/316463/133591505-42630373-6308-472c-b012-ad0878dbddb7.png">
