### PR TITLE
Add z-index so that users can click layer switch on catalog keymap page.

### DIFF
--- a/src/components/catalog/keyboard/CatalogKeymap.scss
+++ b/src/components/catalog/keyboard/CatalogKeymap.scss
@@ -86,6 +86,7 @@
       align-items: center;
       flex-wrap: wrap;
       padding: $space-l $space-l 0 $space-l;
+      z-index: 2;
     }
 
     &-side {


### PR DESCRIPTION
Users can't tap the layer switch UI on Smart-phone devices. It seems that this causes by the z order of related elements:

<img width="1669" alt="スクリーンショット 2021-09-17 7 09 39" src="https://user-images.githubusercontent.com/261787/133692254-426b0f9f-5a35-4178-ba82-25b2fae8e4e4.png">

We can fix this issue by adding `z-index: 2` style definition to the container element of the layer switch UI.

<img width="1671" alt="スクリーンショット 2021-09-17 7 12 53" src="https://user-images.githubusercontent.com/261787/133692528-dcee1da5-98b7-4829-afcd-b19f39755e46.png">

