### PR TITLE
Refresh the keymaps according to updated keyboard definition information

### DIFF
--- a/src/actions/hid.action.ts
+++ b/src/actions/hid.action.ts
@@ -474,6 +474,23 @@ export const hidActionsThunk = {
     }
   },
 
+  refreshKeymaps: (): ThunkPromiseAction<void> => async (
+    dispatch: ThunkDispatch<RootState, undefined, ActionTypes>,
+    getState: () => RootState
+  ) => {
+    const { app, entities } = getState();
+    const keyboard: IKeyboard = entities.keyboard!;
+    const keymaps: IKeymaps[] = await loadKeymap(
+      dispatch,
+      keyboard,
+      entities.device.layerCount,
+      entities.keyboardDefinition!.matrix.rows,
+      entities.keyboardDefinition!.matrix.cols,
+      app.labelLang
+    );
+    dispatch(HidActions.updateKeymaps(keymaps));
+  },
+
   resetKeymap: (): ThunkPromiseAction<void> => async (
     dispatch: ThunkDispatch<RootState, undefined, ActionTypes>,
     getState: () => RootState

--- a/src/actions/storage.action.ts
+++ b/src/actions/storage.action.ts
@@ -141,6 +141,7 @@ export const storageActionsThunk = {
       )
     );
     dispatch(StorageActions.updateKeyboardDefinition(keyboardDefinition));
+    await dispatch(hidActionsThunk.refreshKeymaps());
     dispatch(AppActions.remapsInit(entities.device.layerCount));
     dispatch(KeydiffActions.clearKeydiff());
     dispatch(KeycodeKeyActions.clear());


### PR DESCRIPTION
Fix #603 

The previous implementation #613 was reverted at #614 because all keyboards cannot be opened. The reason is that the refresh logic was refactored and each call was some issues. In this time, I don't refactor exist logic. And, I add a new refresh logic and call it at only updating a keyboard definition from local.