### PR TITLE
Feat 645 subcategories

### DIFF
--- a/src/components/configure/customkey/CustomKey.tsx
+++ b/src/components/configure/customkey/CustomKey.tsx
@@ -153,7 +153,7 @@ export default class CustomKey extends React.Component<OwnProps, OwnState> {
   private isMeaningfulChange(km: IKeymap): boolean {
     const dstMods = ModsComposition.genBinary(km.modifiers);
 
-    if (km.kinds.includes('one_shot_mod') && dstMods === 0) {
+    if (km.kinds.includes('osm') && dstMods === 0) {
       // OneShotMods without any modifiers
       return false;
     }

--- a/src/components/configure/customkey/TabKey.tsx
+++ b/src/components/configure/customkey/TabKey.tsx
@@ -165,7 +165,7 @@ export default class TabKey extends React.Component<TabKeyProps, OwnState> {
      * the key's code should be calculated.
      */
     const kinds = keymap.kinds;
-    if (kinds.includes('one_shot_mod')) {
+    if (kinds.includes('osm')) {
       keymap.code = new OneShotModComposition(direction, mods).getCode();
     } else if (kinds.includes('layer_mod')) {
       const layer = keymap.option!;

--- a/src/components/configure/keycodekey/KeycodeKey.scss
+++ b/src/components/configure/keycodekey/KeycodeKey.scss
@@ -13,6 +13,9 @@
   margin-top: 8px;
   z-index: 1;
   position: relative;
+  &:hover {
+    background-color: $primary-light !important;
+  }
 
   &.grabbable {
     cursor: grab;

--- a/src/components/configure/keycodekey/KeycodeKey.scss
+++ b/src/components/configure/keycodekey/KeycodeKey.scss
@@ -14,7 +14,7 @@
   z-index: 1;
   position: relative;
   &:hover {
-    background-color: $primary-light !important;
+    background-color: $primary-pale !important;
   }
 
   &.grabbable {

--- a/src/components/configure/keycodes/Keycodes.scss
+++ b/src/components/configure/keycodes/Keycodes.scss
@@ -9,6 +9,28 @@
   flex-wrap: wrap;
   max-width: 1280px;
   margin: 0 auto;
+
+  .sub-category {
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    align-items: center;
+    overflow-wrap: anywhere;
+    width: calc(var(--key-width) * 2);
+    height: calc(var(--key-height));
+    border: 1px solid transparent;
+    margin-right: 16px;
+    margin-top: 8px;
+    span {
+      font-size: 0.6rem;
+      font-weight: 600;
+      padding: 0 2px;
+      &:hover {
+        color: white;
+        background-color: $primary-pale;
+      }
+    }
+  }
 }
 .key-categories {
   display: flex;

--- a/src/components/configure/keycodes/Keycodes.scss
+++ b/src/components/configure/keycodes/Keycodes.scss
@@ -15,9 +15,7 @@
     flex-direction: row;
     &:hover {
       .keycodekey {
-        background-color: $primary-pale;
-        border-color: white;
-        transition: background-color 0.5s;
+        border-color: $primary-light;
       }
       .sub-category {
         span {

--- a/src/components/configure/keycodes/Keycodes.scss
+++ b/src/components/configure/keycodes/Keycodes.scss
@@ -6,29 +6,49 @@
 
 .keycodes {
   display: flex;
+  flex-direction: column;
   flex-wrap: wrap;
   max-width: 1280px;
   margin: 0 auto;
-
-  .sub-category {
+  .sub-category-group {
     display: flex;
-    flex-direction: column;
-    justify-content: center;
-    align-items: center;
-    overflow-wrap: anywhere;
-    width: calc(var(--key-width) * 2);
-    height: calc(var(--key-height));
-    border: 1px solid transparent;
-    margin-right: 16px;
-    margin-top: 8px;
-    span {
-      font-size: 0.6rem;
-      font-weight: 600;
-      padding: 0 2px;
-      &:hover {
-        color: white;
+    flex-direction: row;
+    &:hover {
+      .keycodekey {
         background-color: $primary-pale;
+        border-color: white;
+        transition: background-color 0.5s;
       }
+      .sub-category {
+        span {
+          color: $primary-light;
+        }
+      }
+    }
+    .sub-category {
+      display: flex;
+      flex-direction: column;
+      justify-content: center;
+      align-items: flex-end;
+      text-align: right;
+      overflow-wrap: anywhere;
+      width: 90px;
+      min-width: 90px;
+      height: calc(var(--key-height));
+      border: 1px solid transparent;
+      margin-right: 8px;
+      margin-top: 8px;
+      span {
+        font-size: 0.72rem;
+        font-weight: 600;
+        padding: 0 2px;
+      }
+    }
+
+    .sub-category-keys {
+      display: flex;
+      flex-direction: row;
+      flex-wrap: wrap;
     }
   }
 }

--- a/src/components/configure/keycodes/Keycodes.stories.scss
+++ b/src/components/configure/keycodes/Keycodes.stories.scss
@@ -1,0 +1,54 @@
+@import '../../../variables';
+
+:root {
+  --switch-width: 140px;
+}
+
+.keycodes-2width {
+  .sub-category {
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    align-items: center;
+    overflow-wrap: anywhere;
+    width: calc(var(--key-width) * 2);
+    height: calc(var(--key-height));
+    border: 1px solid transparent;
+    margin-right: 16px;
+    margin-top: 8px;
+    span {
+      font-size: 0.6rem;
+      font-weight: 600;
+      padding: 0 2px;
+      &:hover {
+        color: white;
+        background-color: $primary-pale;
+      }
+    }
+  }
+}
+
+.sub-category-group {
+  display: flex;
+  flex-direction: row;
+  .sub-category {
+    display: flex;
+    align-items: flex-end;
+    width: calc(var(--key-width) * 2);
+    min-width: calc(var(--key-width) * 2);
+    margin-right: 16px;
+    text-align: right;
+  }
+  .sub-category-keys {
+    display: flex;
+    flex-direction: row;
+    flex-wrap: wrap;
+  }
+}
+
+.keycodes-left-subcategory {
+  .keycodes {
+    display: flex;
+    flex-direction: column;
+  }
+}

--- a/src/components/configure/keycodes/Keycodes.stories.tsx
+++ b/src/components/configure/keycodes/Keycodes.stories.tsx
@@ -1,0 +1,186 @@
+/* eslint-disable no-undef */
+import React from 'react';
+import CssBaseline from '@material-ui/core/CssBaseline';
+import Keycodes from './Keycodes';
+import { Key } from '../keycodekey/KeyGen';
+import { Provider } from 'react-redux';
+
+import { createStore, applyMiddleware } from 'redux';
+import thunk from 'redux-thunk';
+import { composeWithDevTools } from 'redux-devtools-extension';
+import reducers from '../../../store/reducers';
+import { errorReportingLogger } from '../../../utils/ErrorReportingLogger';
+
+import './Keycodes.stories.scss';
+import { KeymapCategory } from '../../../services/hid/KeycodeList';
+import KeycodeKey from '../keycodekey/KeycodeKey.container';
+import SearchIcon from '@material-ui/icons/Search';
+import { Button, TextField, InputAdornment } from '@material-ui/core';
+
+const store = createStore(
+  reducers,
+  composeWithDevTools(
+    applyMiddleware(thunk),
+    applyMiddleware(errorReportingLogger)
+  )
+);
+
+export default {
+  title: 'Keycodes',
+  component: Keycodes,
+  decorators: [
+    (Story: any) => (
+      <React.Fragment>
+        <Provider store={store}>
+          <CssBaseline />
+          <Story />
+        </Provider>
+      </React.Fragment>
+    ),
+  ],
+};
+
+class KeycodesLeftSub extends Keycodes {
+  constructor(props: any) {
+    super(props);
+  }
+
+  render() {
+    let keys: Key[];
+    if (this.state.searchText) {
+      keys = this.filterKeys(this.state.searchText);
+    } else if (this.state.category) {
+      keys = this.state.categoryKeys[this.state.category] || [];
+    } else {
+      keys = [];
+    }
+    const macrEditMode = this.props.macroKey != null;
+    let categoryKeys: { [name: string]: JSX.Element[] } = {};
+    keys.forEach((key, index) => {
+      const isMacro = key.keymap.kinds.includes('macro');
+      const subCategoryName: KeymapCategory =
+        key.keymap.kinds[key.keymap.kinds.length - 1];
+      if (
+        !Object.prototype.hasOwnProperty.call(categoryKeys, subCategoryName)
+      ) {
+        categoryKeys[subCategoryName] = [];
+      }
+
+      categoryKeys[subCategoryName].push(
+        <KeycodeKey
+          index={index}
+          key={`${this.state.category}${index}`}
+          value={key}
+          draggable={true}
+          clickable={isMacro && !macrEditMode}
+        />
+      );
+    });
+
+    const keycodekeys: JSX.Element[] = Object.keys(categoryKeys).map(
+      (sub, index) => {
+        return (
+          <div className="sub-category-group" key={index}>
+            <div className="sub-category">
+              <span>{sub.split('_').join(' ').toUpperCase()}</span>
+            </div>
+            <div className="sub-category-keys">{categoryKeys[sub]}</div>
+          </div>
+        );
+      }
+    );
+    return (
+      <>
+        <div className="key-categories">
+          {Object.keys(this.state.categoryKeys).map((cat, index) => {
+            const len = this.state.categoryKeys[cat].length;
+            return (
+              <div
+                className={[
+                  'key-category',
+                  len === 0 && 'key-category-empty-keys',
+                ].join(' ')}
+                key={index}
+              >
+                <Button
+                  disabled={this.state.category === cat || len === 0}
+                  onClick={this.selectCategory.bind(this, cat)}
+                >
+                  {cat}
+                </Button>
+              </div>
+            );
+          })}
+          <div className="key-category">
+            <TextField
+              className="keycodes-search"
+              size="small"
+              type="search"
+              value={this.state.searchText}
+              InputProps={{
+                startAdornment: (
+                  <InputAdornment position="start">
+                    <SearchIcon />
+                  </InputAdornment>
+                ),
+              }}
+              onChange={() => {}}
+            />
+          </div>
+        </div>
+        <div
+          className="keycodes"
+          style={{
+            minWidth:
+              this.props.keyboardWidth! + 144 /* = (PADDING + KeycodeKey)*2 */,
+          }}
+        >
+          {keycodekeys}
+        </div>
+      </>
+    );
+  }
+}
+
+export const Keycodes_Subcategory = () => {
+  return (
+    <Keycodes
+      layerCount={4}
+      labelLang="en-us"
+      macroKey={null}
+      macroMaxCount={15}
+      macroMaxBufferSize={512}
+      macroBufferBytes={new Uint8Array(512)}
+    />
+  );
+};
+
+export const Keycodes_DoubleWidth = () => {
+  return (
+    <div className="keycodes-2width">
+      <Keycodes
+        layerCount={4}
+        labelLang="en-us"
+        macroKey={null}
+        macroMaxCount={15}
+        macroMaxBufferSize={512}
+        macroBufferBytes={new Uint8Array(512)}
+      />
+    </div>
+  );
+};
+
+export const Keycodes_LeftSubcategory = () => {
+  return (
+    <div className="keycodes-left-subcategory">
+      <KeycodesLeftSub
+        layerCount={4}
+        labelLang="en-us"
+        macroKey={null}
+        macroMaxCount={15}
+        macroMaxBufferSize={512}
+        macroBufferBytes={new Uint8Array(512)}
+      />
+    </div>
+  );
+};

--- a/src/components/configure/keycodes/Keycodes.tsx
+++ b/src/components/configure/keycodes/Keycodes.tsx
@@ -20,6 +20,7 @@ import {
   IMacroBuffer,
   MacroBuffer,
 } from '../../../services/macro/Macro';
+import { KeymapCategory } from '../../../services/hid/KeycodeList';
 
 type OwnProps = {};
 
@@ -269,6 +270,30 @@ export default class Keycodes extends React.Component<KeycodesProps, OwnState> {
       keys = [];
     }
     const macrEditMode = this.props.macroKey != null;
+    let subCategory: KeymapCategory = 'basic';
+    let keycodekeys: JSX.Element[] = [];
+    keys.forEach((key, index) => {
+      const isMacro = key.keymap.kinds.includes('macro');
+      const endKind: KeymapCategory =
+        key.keymap.kinds[key.keymap.kinds.length - 1];
+      if (1 < key.keymap.kinds.length && subCategory != endKind) {
+        subCategory = endKind;
+        keycodekeys.push(
+          <div className="sub-category">
+            <span>{subCategory.split('_').join(' ').toUpperCase()}</span>
+          </div>
+        );
+      }
+      keycodekeys.push(
+        <KeycodeKey
+          index={index}
+          key={`${this.state.category}${index}`}
+          value={key}
+          draggable={true}
+          clickable={isMacro && !macrEditMode}
+        />
+      );
+    });
     return (
       <React.Fragment>
         <div className="key-categories">
@@ -315,18 +340,7 @@ export default class Keycodes extends React.Component<KeycodesProps, OwnState> {
               this.props.keyboardWidth! + 144 /* = (PADDING + KeycodeKey)*2 */,
           }}
         >
-          {keys.map((key, index) => {
-            const isMacro = key.keymap.kinds.includes('macro');
-            return (
-              <KeycodeKey
-                index={index}
-                key={`${this.state.category}${index}`}
-                value={key}
-                draggable={true}
-                clickable={isMacro && !macrEditMode}
-              />
-            );
-          })}
+          {keycodekeys}
           {this.state.category == IKeycodeCategory.ANY && (
             <KeycodeAddKey key={'add'} />
           )}

--- a/src/components/configure/keycodes/Keycodes.tsx
+++ b/src/components/configure/keycodes/Keycodes.tsx
@@ -81,7 +81,7 @@ export default class Keycodes extends React.Component<KeycodesProps, OwnState> {
    * Sort them with prefix matching.
    * The label keys are listed higher than the meta keys.
    */
-  private filterKeys(searchKey: string): Key[] {
+  protected filterKeys(searchKey: string): Key[] {
     const search = searchKey.toLowerCase();
     let allKeys: Key[] = Object.values(this.state.categoryKeys).flat();
 
@@ -270,21 +270,18 @@ export default class Keycodes extends React.Component<KeycodesProps, OwnState> {
       keys = [];
     }
     const macrEditMode = this.props.macroKey != null;
-    let subCategory: KeymapCategory = 'basic';
-    let keycodekeys: JSX.Element[] = [];
+    let categoryKeys: { [name: string]: JSX.Element[] } = {};
     keys.forEach((key, index) => {
       const isMacro = key.keymap.kinds.includes('macro');
-      const endKind: KeymapCategory =
+      const subCategoryName: KeymapCategory =
         key.keymap.kinds[key.keymap.kinds.length - 1];
-      if (1 < key.keymap.kinds.length && subCategory != endKind) {
-        subCategory = endKind;
-        keycodekeys.push(
-          <div className="sub-category">
-            <span>{subCategory.split('_').join(' ').toUpperCase()}</span>
-          </div>
-        );
+      if (
+        !Object.prototype.hasOwnProperty.call(categoryKeys, subCategoryName)
+      ) {
+        categoryKeys[subCategoryName] = [];
       }
-      keycodekeys.push(
+
+      categoryKeys[subCategoryName].push(
         <KeycodeKey
           index={index}
           key={`${this.state.category}${index}`}
@@ -294,6 +291,19 @@ export default class Keycodes extends React.Component<KeycodesProps, OwnState> {
         />
       );
     });
+
+    const keycodekeys: JSX.Element[] = Object.keys(categoryKeys).map(
+      (sub, index) => {
+        return (
+          <div className="sub-category-group" key={index}>
+            <div className="sub-category">
+              <span>{sub.split('_').join(' ').toUpperCase()}</span>
+            </div>
+            <div className="sub-category-keys">{categoryKeys[sub]}</div>
+          </div>
+        );
+      }
+    );
     return (
       <React.Fragment>
         <div className="key-categories">

--- a/src/components/configure/keymap/Keymap.scss
+++ b/src/components/configure/keymap/Keymap.scss
@@ -5,6 +5,7 @@
   flex-direction: row;
   justify-content: center;
   height: 78px;
+  z-index: 3;
   .diff {
     display: flex;
     flex-direction: row;

--- a/src/services/hid/Composition.test.ts
+++ b/src/services/hid/Composition.test.ts
@@ -1624,7 +1624,7 @@ describe('Composition', () => {
           EXPECT_UNICODE_LIST,
           EXPECT_LOOSE_KEYCODE_LIST,
         ];
-        checkKind(validList, invalidList, KeycodeCompositionKind.def_layer);
+        checkKind(validList, invalidList, KeycodeCompositionKind.df);
       });
       describe('toggle layer', () => {
         const validList = [EXPECT_TOGGLE_LAYER_LIST];
@@ -1647,7 +1647,7 @@ describe('Composition', () => {
           EXPECT_UNICODE_LIST,
           EXPECT_LOOSE_KEYCODE_LIST,
         ];
-        checkKind(validList, invalidList, KeycodeCompositionKind.toggle_layer);
+        checkKind(validList, invalidList, KeycodeCompositionKind.tl);
       });
       describe('one shot layer', () => {
         const validList = [EXPECT_ONE_SHOT_LAYER_LIST];
@@ -1670,11 +1670,7 @@ describe('Composition', () => {
           EXPECT_UNICODE_LIST,
           EXPECT_LOOSE_KEYCODE_LIST,
         ];
-        checkKind(
-          validList,
-          invalidList,
-          KeycodeCompositionKind.one_shot_layer
-        );
+        checkKind(validList, invalidList, KeycodeCompositionKind.osl);
       });
       describe('one shot mod', () => {
         const validList = [EXPECT_ONE_SHOT_MOD_LIST];
@@ -1697,7 +1693,7 @@ describe('Composition', () => {
           EXPECT_UNICODE_LIST,
           EXPECT_LOOSE_KEYCODE_LIST,
         ];
-        checkKind(validList, invalidList, KeycodeCompositionKind.one_shot_mod);
+        checkKind(validList, invalidList, KeycodeCompositionKind.osm);
       });
       describe('tap dance', () => {
         const validList = [EXPECT_TAP_DANCE_LIST];
@@ -1743,11 +1739,7 @@ describe('Composition', () => {
           EXPECT_UNICODE_LIST,
           EXPECT_LOOSE_KEYCODE_LIST,
         ];
-        checkKind(
-          validList,
-          invalidList,
-          KeycodeCompositionKind.layer_tap_toggle
-        );
+        checkKind(validList, invalidList, KeycodeCompositionKind.tt);
       });
       describe('layer mod', () => {
         const validList = [EXPECT_LAYER_MOD_LIST];

--- a/src/services/hid/Composition.ts
+++ b/src/services/hid/Composition.ts
@@ -103,12 +103,12 @@ export type IKeycodeCompositionKind =
   | 'layer_tap'
   | 'to'
   | 'momentary'
-  | 'def_layer'
-  | 'toggle_layer'
-  | 'one_shot_layer'
-  | 'one_shot_mod'
+  | 'df'
+  | 'tl'
+  | 'osl'
+  | 'osm'
   | 'tap_dance'
-  | 'layer_tap_toggle'
+  | 'tt'
   | 'layer_mod'
   | 'swap_hands'
   | 'mod_tap'
@@ -126,12 +126,12 @@ export const KeycodeCompositionKind: {
   layer_tap: 'layer_tap',
   to: 'to',
   momentary: 'momentary',
-  def_layer: 'def_layer',
-  toggle_layer: 'toggle_layer',
-  one_shot_layer: 'one_shot_layer',
-  one_shot_mod: 'one_shot_mod',
+  df: 'df',
+  tl: 'tl',
+  osl: 'osm',
+  osm: 'osm',
   tap_dance: 'tap_dance',
-  layer_tap_toggle: 'layer_tap_toggle',
+  tt: 'tt',
   layer_mod: 'layer_mod',
   swap_hands: 'swap_hands',
   mod_tap: 'mod_tap',
@@ -151,12 +151,12 @@ const keycodeCompositionKindRangeMap: {
   layer_tap: { min: QK_LAYER_TAP_MIN, max: QK_LAYER_TAP_MAX },
   to: { min: QK_TO_MIN, max: QK_TO_MAX },
   momentary: { min: QK_MOMENTARY_MIN, max: QK_MOMENTARY_MAX },
-  def_layer: { min: QK_DEF_LAYER_MIN, max: QK_DEF_LAYER_MAX },
-  toggle_layer: { min: QK_TOGGLE_LAYER_MIN, max: QK_TOGGLE_LAYER_MAX },
-  one_shot_layer: { min: QK_ONE_SHOT_LAYER_MIN, max: QK_ONE_SHOT_LAYER_MAX },
-  one_shot_mod: { min: QK_ONE_SHOT_MOD_MIN, max: QK_ONE_SHOT_MOD_MAX },
+  df: { min: QK_DEF_LAYER_MIN, max: QK_DEF_LAYER_MAX },
+  tl: { min: QK_TOGGLE_LAYER_MIN, max: QK_TOGGLE_LAYER_MAX },
+  osl: { min: QK_ONE_SHOT_LAYER_MIN, max: QK_ONE_SHOT_LAYER_MAX },
+  osm: { min: QK_ONE_SHOT_MOD_MIN, max: QK_ONE_SHOT_MOD_MAX },
   tap_dance: { min: QK_TAP_DANCE_MIN, max: QK_TAP_DANCE_MAX },
-  layer_tap_toggle: {
+  tt: {
     min: QK_LAYER_TAP_TOGGLE_MIN,
     max: QK_LAYER_TAP_TOGGLE_MAX,
   },
@@ -851,7 +851,7 @@ export class DefLayerComposition implements IMomentaryComposition {
         name: { short: label, long: label },
         keywords: [],
       },
-      kinds: ['def_layer'],
+      kinds: ['layers', 'df'],
       desc: `Switches the default layer(${layer}). The default layer is the always-active base layer that other layers stack on top of.`,
       option: layer,
     };
@@ -898,7 +898,7 @@ export class ToggleLayerComposition implements IMomentaryComposition {
         name: { short: label, long: label },
         keywords: [],
       },
-      kinds: ['layers', 'toggle_layer'],
+      kinds: ['layers', 'tl'],
       desc: `Toggles layer(${layer}), activating it if it's inactive and vice versa.`,
       option: layer,
     };
@@ -945,7 +945,7 @@ export class OneShotLayerComposition implements IOneShotLayerComposition {
         name: { short: label, long: label },
         keywords: [],
       },
-      kinds: ['layers', 'one_shot_layer'],
+      kinds: ['layers', 'osl'],
       desc: `Momentarily activates layer(${layer}) until the next key is pressed.`,
       option: layer,
     };
@@ -998,7 +998,7 @@ export class OneShotModComposition implements IOneShotModComposition {
         name: { short: 'OSM', long: 'OSM' },
         keywords: [],
       },
-      kinds: ['one_shot_mod'],
+      kinds: ['layers', 'osm'],
       desc: `Momentarily activates modifier(s) until the next key is pressed.`,
     };
   }
@@ -1016,7 +1016,7 @@ export class OneShotModComposition implements IOneShotModComposition {
           name: { short: 'OSM', long: 'OSM' },
           keywords: [],
         },
-        kinds: ['one_shot_mod'],
+        kinds: ['layers', 'osm'],
         desc: `Momentarily activates modifier(s) until the next key is pressed.`,
       },
     ];
@@ -1074,7 +1074,7 @@ export class LayerTapToggleComposition implements ILayerTapToggleComposition {
         name: { short: '', long: '' },
         keywords: [],
       },
-      kinds: ['layers', 'layer_tap_toggle'],
+      kinds: ['layers', 'tt'],
       desc: `If you hold the key down, layer(${layer}) is activated, and then is de-activated when you let go.`,
       option: layer,
     };
@@ -1614,7 +1614,7 @@ export class KeycodeCompositionFactory implements IKeycodeCompositionFactory {
   }
 
   isDefLayer(): boolean {
-    return this.getKind() === KeycodeCompositionKind.def_layer;
+    return this.getKind() === KeycodeCompositionKind.df;
   }
 
   isFunction(): boolean {
@@ -1630,7 +1630,7 @@ export class KeycodeCompositionFactory implements IKeycodeCompositionFactory {
   }
 
   isLayerTapToggle(): boolean {
-    return this.getKind() === KeycodeCompositionKind.layer_tap_toggle;
+    return this.getKind() === KeycodeCompositionKind.tt;
   }
 
   isLooseKeycode(): boolean {
@@ -1654,11 +1654,11 @@ export class KeycodeCompositionFactory implements IKeycodeCompositionFactory {
   }
 
   isOneShotLayer(): boolean {
-    return this.getKind() === KeycodeCompositionKind.one_shot_layer;
+    return this.getKind() === KeycodeCompositionKind.osl;
   }
 
   isOneShotMod(): boolean {
-    return this.getKind() === KeycodeCompositionKind.one_shot_mod;
+    return this.getKind() === KeycodeCompositionKind.osm;
   }
 
   isSwapHands(): boolean {
@@ -1674,7 +1674,7 @@ export class KeycodeCompositionFactory implements IKeycodeCompositionFactory {
   }
 
   isToggleLayer(): boolean {
-    return this.getKind() === KeycodeCompositionKind.toggle_layer;
+    return this.getKind() === KeycodeCompositionKind.tl;
   }
 
   isUnicode(): boolean {

--- a/src/services/hid/Composition.ts
+++ b/src/services/hid/Composition.ts
@@ -128,7 +128,7 @@ export const KeycodeCompositionKind: {
   momentary: 'momentary',
   df: 'df',
   tl: 'tl',
-  osl: 'osm',
+  osl: 'osl',
   osm: 'osm',
   tap_dance: 'tap_dance',
   tt: 'tt',

--- a/src/services/hid/Composition.ts
+++ b/src/services/hid/Composition.ts
@@ -709,9 +709,9 @@ export class LayerTapComposition implements ILayerTapComposition {
         name: this.key.keycodeInfo
           ? this.key.keycodeInfo.name
           : { short: 'LT', long: 'LT' },
-        keywords: [],
+        keywords: ['layer tap'],
       },
-      kinds: ['layer_tap'],
+      kinds: ['layers'],
       desc: `Momentarily activates Layer(${layer}) when held, and sends keycode when tapped.`,
       option: layer,
     };
@@ -757,7 +757,7 @@ export class ToComposition implements IToComposition {
         name: { short: '', long: '' },
         keywords: [],
       },
-      kinds: ['layers', 'to'],
+      kinds: ['layers'],
       desc: `Activates layer(${layer}) and de-activates all other layers (except your default layer).`,
       option: layer,
     };
@@ -802,9 +802,9 @@ export class MomentaryComposition implements IMomentaryComposition {
         code: code,
         label: label,
         name: { short: label, long: label },
-        keywords: [],
+        keywords: ['momentary'],
       },
-      kinds: ['layers', 'momentary'],
+      kinds: ['layers'],
       desc: `Momentarily activates layer(${layer}). As soon as you let go of the key, the layer is deactivated.`,
       option: layer,
     };
@@ -849,9 +849,9 @@ export class DefLayerComposition implements IMomentaryComposition {
         code: code,
         label: label,
         name: { short: label, long: label },
-        keywords: [],
+        keywords: ['default layer'],
       },
-      kinds: ['layers', 'df'],
+      kinds: ['layers'],
       desc: `Switches the default layer(${layer}). The default layer is the always-active base layer that other layers stack on top of.`,
       option: layer,
     };
@@ -896,9 +896,9 @@ export class ToggleLayerComposition implements IMomentaryComposition {
         code: code,
         label: label,
         name: { short: label, long: label },
-        keywords: [],
+        keywords: ['toggle layer'],
       },
-      kinds: ['layers', 'tl'],
+      kinds: ['layers'],
       desc: `Toggles layer(${layer}), activating it if it's inactive and vice versa.`,
       option: layer,
     };
@@ -945,7 +945,7 @@ export class OneShotLayerComposition implements IOneShotLayerComposition {
         name: { short: label, long: label },
         keywords: [],
       },
-      kinds: ['layers', 'osl'],
+      kinds: ['layers'],
       desc: `Momentarily activates layer(${layer}) until the next key is pressed.`,
       option: layer,
     };
@@ -1074,7 +1074,7 @@ export class LayerTapToggleComposition implements ILayerTapToggleComposition {
         name: { short: '', long: '' },
         keywords: [],
       },
-      kinds: ['layers', 'tt'],
+      kinds: ['layers'],
       desc: `If you hold the key down, layer(${layer}) is activated, and then is de-activated when you let go.`,
       option: layer,
     };

--- a/src/services/hid/KeyCategoryList.ts
+++ b/src/services/hid/KeyCategoryList.ts
@@ -389,7 +389,7 @@ export const KEY_SUB_CATEGORY_COMMAND: IKeycodeCategoryInfo = {
 };
 // Func0, Func1, Func2, Func3, Func4, Func5, Func6, Func7, Func8, Func9, Func10, Func11, Func12, Func13, Func14, Func15, Func16, Func17, Func18, Func19, Func20, Func21, Func22, Func23, Func24, Func25, Func26, Func27, Func28, Func29, Func30, Func31
 export const KEY_SUB_CATEGORY_EMBED_FUNCTION: IKeycodeCategoryInfo = {
-  kinds: ['special', 'embed_function'],
+  kinds: ['special', 'func'],
   codes: [
     192,
     193,
@@ -437,7 +437,7 @@ export const KEY_SUB_CATEGORY_APPLICATION: IKeycodeCategoryInfo = {
 };
 // Power,  System Power Down, Sleep, Wake, Screen+, Screen-
 export const KEY_SUB_CATEGORY_DEVICE: IKeycodeCategoryInfo = {
-  kinds: ['device'],
+  kinds: ['device', 'device'],
   codes: [102, 165, 166, 167, 189, 190],
 };
 // Mouse↑, Mouse↓, Mouse←, Mouse→, Mouse Btn1, Mouse Btn2, Mouse Btn3, Mouse Btn4, Mouse Btn5, Mouse Wh↑, Mouse Wh↓, Mouse Wh←, Mouse Wh→, Mouse Acc0, Mouse Acc1, Mouse Acc2

--- a/src/services/hid/KeycodeList.ts
+++ b/src/services/hid/KeycodeList.ts
@@ -17,7 +17,7 @@ export type KeymapCategory =
   | 'device'
   | 'edit'
   | 'f'
-  | 'embed_function'
+  | 'func'
   | 'grave_escape'
   | 'gui'
   | 'int'


### PR DESCRIPTION
Show subcategories in the keycodes area for users to find a key easily.

<img width="1939" alt="スクリーンショット 2021-10-04 17 01 12" src="https://user-images.githubusercontent.com/316463/135816179-d7c80d21-f888-4500-9bf1-acbad593b12a.png">

In case of the search reslults, the subcategories are also shown.
<img width="1938" alt="スクリーンショット 2021-10-04 17 08 10" src="https://user-images.githubusercontent.com/316463/135816200-fe33cb09-51eb-4a77-9897-56a3d5cc3301.png">

