### PR TITLE
Fix the issue that layer(n) key code can't be set as HOLD.

### DIFF
--- a/src/components/configure/customkey/CustomKey.tsx
+++ b/src/components/configure/customkey/CustomKey.tsx
@@ -188,7 +188,7 @@ export default class CustomKey extends React.Component<OwnProps, OwnState> {
     let comp: ModTapComposition | LayerTapComposition | SwapHandsComposition;
 
     const kinds = holdKey.kinds;
-    if (kinds.includes('layer_tap')) {
+    if (kinds.includes('layers')) {
       comp = new LayerTapComposition(holdKey.option!, tapKey);
     } else if (kinds.includes('mod_tap')) {
       comp = new ModTapComposition(


### PR DESCRIPTION
Fix #653 

The `kinds` value of the layer tap key code type has been changed from `['layer_tap']` to `['layers']` at the following:

https://github.com/remap-keys/remap/pull/652/files#diff-a71e51a06fb00d42c594909bc454adf29e077a9397a63a6e2c344b0a2884d468L714-R714

But, the check logic of whether the key code filled in is a layer tap or not was not updated. That is, the logic used the `layer_tap` to judge to check it.By the change above, the `layers` should be used to judge whether it is a layer tap or not.

![Screenshot_20211005_084334](https://user-images.githubusercontent.com/261787/135938882-dd7604fc-65bd-48a1-95b6-677f36e75129.png)
