### PR TITLE
Fix the firmware download error.

### DIFF
--- a/src/actions/storage.action.ts
+++ b/src/actions/storage.action.ts
@@ -1074,12 +1074,6 @@ export const storageActionsThunk = {
     );
     if (result.success) {
       callback(result.blob!);
-      await dispatch(
-        storageActionsThunk.fetchKeyboardDefinitionById(
-          definitionDocument.id,
-          'firmware'
-        )
-      );
     } else {
       console.error(result.cause!);
       dispatch(NotificationActions.addError(result.error!, result.cause));

--- a/src/components/catalog/keyboard/firmware/CatalogFirmware.container.ts
+++ b/src/components/catalog/keyboard/firmware/CatalogFirmware.container.ts
@@ -1,7 +1,8 @@
 import { connect } from 'react-redux';
-import { RootState } from '../../../../store/state';
+import { ICatalogPhase, RootState } from '../../../../store/state';
 import CatalogFirmware from './CatalogFirmware';
 import { storageActionsThunk } from '../../../../actions/storage.action';
+import { CatalogAppActions } from '../../../../actions/catalog.action';
 
 // eslint-disable-next-line no-unused-vars
 const mapStateToProps = (state: RootState) => {
@@ -21,6 +22,15 @@ const mapDispatchToProps = (_dispatch: any) => {
     ) {
       _dispatch(
         storageActionsThunk.fetchFirmwareFileBlob(firmwareFilePath, callback)
+      );
+    },
+    updateKeyboard: (definitionId: string, nextPhase: ICatalogPhase) => {
+      _dispatch(CatalogAppActions.updatePhase('processing'));
+      _dispatch(
+        storageActionsThunk.fetchKeyboardDefinitionForCatalogById(
+          definitionId,
+          nextPhase
+        )
       );
     },
   };

--- a/src/components/catalog/keyboard/firmware/CatalogFirmware.tsx
+++ b/src/components/catalog/keyboard/firmware/CatalogFirmware.tsx
@@ -17,6 +17,7 @@ import {
 } from '../../../../services/storage/Storage';
 import moment from 'moment';
 import { sendEventToGoogleAnalytics } from '../../../../utils/GoogleAnalytics';
+import { ICatalogPhase } from '../../../../store/state';
 
 type CatalogFirmwareState = {};
 type OwnProps = {};
@@ -54,6 +55,7 @@ export default class CatalogFirmware extends React.Component<
                   firmware={firmware}
                   fetchFirmwareFileBlob={this.props.fetchFirmwareFileBlob!}
                   definitionDocument={this.props.definitionDocument!}
+                  updateKeyboard={this.props.updateKeyboard!}
                 />
               ))}{' '}
             </div>
@@ -79,6 +81,8 @@ type IFirmwareCardProps = {
     callback: (blob: any) => void
   ) => void;
   definitionDocument: IKeyboardDefinitionDocument;
+  // eslint-disable-next-line no-unused-vars
+  updateKeyboard: (definitionId: string, nextPhase: ICatalogPhase) => void;
 };
 
 function FirmwareCard(props: IFirmwareCardProps) {
@@ -98,6 +102,7 @@ function FirmwareCard(props: IFirmwareCardProps) {
       a.href = downloadUrl;
       a.click();
       a.remove();
+      props.updateKeyboard(props.definitionDocument.id, 'firmware');
     });
   };
 

--- a/src/components/keyboards/editdefinition/firmwareform/FirmwareForm.container.ts
+++ b/src/components/keyboards/editdefinition/firmwareform/FirmwareForm.container.ts
@@ -76,6 +76,14 @@ const mapDispatchToProps = (_dispatch: any) => {
         )
       );
     },
+    updateKeyboard: (definitionId: string) => {
+      _dispatch(
+        storageActionsThunk.fetchKeyboardDefinitionById(
+          definitionId,
+          'firmware'
+        )
+      );
+    },
   };
 };
 export type FirmwareFormActionsType = ReturnType<typeof mapDispatchToProps>;

--- a/src/components/keyboards/editdefinition/firmwareform/FirmwareForm.tsx
+++ b/src/components/keyboards/editdefinition/firmwareform/FirmwareForm.tsx
@@ -95,6 +95,7 @@ export default function FirmwareForm(props: FirmwareFormProps) {
       a.href = downloadUrl;
       a.click();
       a.remove();
+      props.updateKeyboard!(props.definitionDocument!.id);
     });
   };
 


### PR DESCRIPTION
When downloading some firmware file from some keyboard catalog page, an error occurs because the logic for admin is called after downloading.