### PR TITLE
Fix the css broken issue on mobile for each docs.

### DIFF
--- a/src/components/documents/Documents.scss
+++ b/src/components/documents/Documents.scss
@@ -13,10 +13,10 @@
   }
 
   &-container {
-    width: 960px;
+    max-width: 960px;
 
     & h3 {
-      margin-bottom: 24px;
+      margin: 0 16px 24px 16px;
     }
 
     & h4 {


### PR DESCRIPTION
As the title.  This pull request adjusts some CSS to fix the issue that each doc page is not shown normally on mobile.

<img width="287" alt="スクリーンショット 2021-11-21 9 27 36" src="https://user-images.githubusercontent.com/261787/142744785-776098a6-9c9d-4fbe-9c80-ada38650f554.png">

