### PR TITLE
Fix the issue #677. Check the match of rows and cols for approved keyboards

### DIFF
--- a/src/components/common/keyboarddefformpart/KeyboardDefinitionFormPart.tsx
+++ b/src/components/common/keyboarddefformpart/KeyboardDefinitionFormPart.tsx
@@ -6,6 +6,7 @@ import {
   SchemaValidateError,
   validateIds,
   validateKeyboardDefinitionSchema,
+  validateRowsAndCols,
 } from '../../../services/storage/Validator';
 import {
   Accordion,
@@ -18,6 +19,7 @@ import {
 import { Alert, AlertTitle } from '@material-ui/lab';
 import ExpandMoreIcon from '@material-ui/icons/ExpandMore';
 import './KeyboardDefinitionFormPart.scss';
+import { IKeyboardDefinitionDocument } from '../../../services/storage/Storage';
 
 // eslint-disable-next-line no-undef
 const loadDefinitionFile = async (file: File): Promise<string> => {
@@ -48,6 +50,8 @@ export type KeyboardDefinitionFormPartProps = {
     fileName: string,
     jsonStr: string
   ) => void;
+  keyboardDefinitionDocument?: IKeyboardDefinitionDocument | null;
+  keyboardDefinitionSchema?: KeyboardDefinitionSchema | null;
 };
 /* eslint-enable no-unused-vars */
 
@@ -129,6 +133,22 @@ export class KeyboardDefinitionFormPart extends React.Component<
       if (msg) {
         this.stopLoading();
         this.showErrorMessage('INVALID IDs', msg);
+        return Promise.reject(msg);
+      }
+    }
+
+    if (
+      this.props.keyboardDefinitionDocument &&
+      this.props.keyboardDefinitionSchema &&
+      this.props.keyboardDefinitionDocument.status === 'approved'
+    ) {
+      const msg = validateRowsAndCols(
+        keyboardDefinition,
+        this.props.keyboardDefinitionSchema
+      );
+      if (msg) {
+        this.stopLoading();
+        this.showErrorMessage('INVALID Row and Col', msg);
         return Promise.reject(msg);
       }
     }

--- a/src/components/configure/importDef/ImportDefDialog.container.ts
+++ b/src/components/configure/importDef/ImportDefDialog.container.ts
@@ -6,7 +6,10 @@ import { KeyboardDefinitionSchema } from '../../../gen/types/KeyboardDefinition'
 
 // eslint-disable-next-line no-unused-vars
 const mapStateToProps = (state: RootState) => {
-  return {};
+  return {
+    keyboardDefinitionDocument: state.entities.keyboardDefinitionDocument,
+    keyboardDefinitionSchema: state.entities.keyboardDefinition,
+  };
 };
 export type ConfigurationDialogStateType = ReturnType<typeof mapStateToProps>;
 

--- a/src/components/configure/importDef/ImportDefDialog.tsx
+++ b/src/components/configure/importDef/ImportDefDialog.tsx
@@ -98,6 +98,8 @@ export default class ConfigurationDialog extends React.Component<
               this.onLoadFile(kd, name);
             }}
             size="small"
+            keyboardDefinitionDocument={this.props.keyboardDefinitionDocument}
+            keyboardDefinitionSchema={this.props.keyboardDefinitionSchema}
           />
 
           {this.state.keyboardDefinition && (

--- a/src/services/storage/Validator.ts
+++ b/src/services/storage/Validator.ts
@@ -52,6 +52,19 @@ export const validateIds = (
   return null;
 };
 
+export const validateRowsAndCols = (
+  source: KeyboardDefinitionSchema,
+  target: KeyboardDefinitionSchema
+): string | null => {
+  if (source.matrix.rows !== target.matrix.rows) {
+    return `Not match the Rows: Server:${target.matrix.rows}, Local:${source.matrix.rows}`;
+  }
+  if (source.matrix.cols !== target.matrix.cols) {
+    return `Not match the Cols: Server:${target.matrix.cols}, Local:${source.matrix.cols}`;
+  }
+  return null;
+};
+
 export const validateKeyboardDefinitionSchema = (
   json: Object,
   schemaObject: Object = schema


### PR DESCRIPTION
Fix #677 

When importing a JSON file from local after an already approved keyboard is opened, and when the rows and cols values are not matched, it is failed by this modification of this pull request. This purpose is to avoid that incorrect keymap data is saved and shared. Read #677 for more detail.