### PR TITLE
Fix #676. Add the z-index style to be able to click the layer UI.

### DIFF
--- a/src/components/configure/keymap/Keymap.scss
+++ b/src/components/configure/keymap/Keymap.scss
@@ -55,6 +55,7 @@
     align-items: flex-start;
     min-width: 80px;
     padding-left: $space-l;
+    z-index: 2;
 
     .MuiPagination-ul {
       flex-direction: column;


### PR DESCRIPTION
Fix #676

The keyboard layout UI and the toolber UI have the style `z-index:2`, but the layer UI doesn't have the style. The reason of the issue #676 may be the nothing of the z-index style. This pull request adds the z-index style to the layer UI to fix the issue.

