### PR TITLE
Fix the issue when going back to Draft.

### DIFF
--- a/src/services/provider/Firebase.ts
+++ b/src/services/provider/Firebase.ts
@@ -308,7 +308,7 @@ export class FirebaseProvider implements IStorage, IAuth {
     otherPlaceHowToGet: string,
     otherPlaceSourceCodeEvidence: string,
     otherPlacePublisherEvidence: string,
-    contactInformation: string,
+    contactInformation: string | undefined,
     organizationEvidence: string,
     authorType: IKeyboardDefinitionAuthorType,
     organizationId: string | undefined,

--- a/src/services/provider/Firebase.ts
+++ b/src/services/provider/Firebase.ts
@@ -330,10 +330,12 @@ export class FirebaseProvider implements IStorage, IAuth {
         other_place_how_to_get: otherPlaceHowToGet,
         other_place_source_code_evidence: otherPlaceSourceCodeEvidence,
         other_place_publisher_evidence: otherPlacePublisherEvidence,
-        contact_information: contactInformation,
         author_type: authorType,
         status,
       };
+      if (contactInformation) {
+        data.contact_information = contactInformation;
+      }
       if (authorType === 'organization') {
         data.organization_id = organizationId;
         data.organization_evidence = organizationEvidence || '';

--- a/src/services/storage/Storage.ts
+++ b/src/services/storage/Storage.ts
@@ -275,7 +275,7 @@ export interface IStorage {
     otherPlaceHowToGet: string,
     otherPlaceSourceCodeEvidence: string,
     otherPlacePublisherEvidence: string,
-    contactInformation: string,
+    contactInformation: string | undefined,
     organizationEvidence: string,
     authorType: IKeyboardDefinitionAuthorType,
     organizationId: string | undefined,


### PR DESCRIPTION
When trying going back to Draft for the keyboard which doesn't have a contact information, the error occurs because the contact_information is undefined. This pull request fixes the issue.