### PR TITLE
Fix the error when fetching organizations.

### DIFF
--- a/src/actions/storage.action.ts
+++ b/src/actions/storage.action.ts
@@ -437,7 +437,7 @@ export const storageActionsThunk = {
       .documents!.filter((doc) => doc.authorType === 'organization')
       .map((doc) => doc.organizationId)
       .reduce((result, id) => {
-        if (id !== undefined) {
+        if (id !== undefined && !result.includes(id)) {
           result.push(id);
         }
         return result;
@@ -964,7 +964,7 @@ export const storageActionsThunk = {
         .filter((doc) => doc.authorType === 'organization')
         .map((doc) => doc.organizationId)
         .reduce((result, id) => {
-          if (id !== undefined) {
+          if (id !== undefined && !result.includes(id)) {
             result.push(id);
           }
           return result;


### PR DESCRIPTION
If a user has 10 or more keyboards in Remap and the all keyboards are registered with the author type "organization", the error occurs when fetching organization data from Firestore. The cause is that 11 or more query condition values are passed to the `in` query operator. To fix this issue, we need to remove the use of `in` query. Instead, send queries multiple times.