### PR TITLE
Calc the last active layer NOT for generating the blank cheat sheet.`

### DIFF
--- a/src/assets/files/build-info.json
+++ b/src/assets/files/build-info.json
@@ -1,1 +1,1 @@
-{ "buildNumber": 179 }
+{ "buildNumber": 180 }

--- a/src/services/pdf/KeymapPdfGenerator.ts
+++ b/src/services/pdf/KeymapPdfGenerator.ts
@@ -53,8 +53,29 @@ export class KeymapPdfGenerator {
   ) {
     this.model = new KeyboardModel(keymap);
     this.keys = keys;
-    this.layerCount = layerCount;
+    this.layerCount = this.getActiveLayerCount(layerCount);
     this.labelLang = labelLang;
+  }
+
+  /**
+   * This function calculates the last layer number that does not contain meaningful keys after it.
+   *
+   * @param layerCount the number of layers
+   * @returns the active layer number
+   */
+  getActiveLayerCount(layerCount: number): number {
+    let lastActiveLayerCount = 0;
+    for (let i = 0; i < layerCount; i++) {
+      let hasLabel = false;
+      Object.keys(this.keys[i]).forEach((pos) => {
+        const key: Key = this.keys[i][pos];
+        hasLabel = hasLabel || key.keymap.code != 0; // NOT NOOP
+      });
+      if (hasLabel) {
+        lastActiveLayerCount = i;
+      }
+    }
+    return lastActiveLayerCount + 1;
   }
 
   async genPdf(name: string, options?: LayoutOption[]) {


### PR DESCRIPTION
Default keymap's cheat sheet.
<img width="809" alt="スクリーンショット 2022-03-02 17 33 36" src="https://user-images.githubusercontent.com/316463/156325569-726bc307-0d57-41d1-8d86-8082d9161d5c.png">

The layer-3 is filled with NOOP keys. The cheat sheet does not draw it.
<img width="971" alt="スクリーンショット 2022-03-02 17 33 46" src="https://user-images.githubusercontent.com/316463/156325755-40ffacf9-9316-46d8-91fc-29b2420e6c7c.png">

The layer-1 is filled with NOOP keys but includes meaningful keys in layer-2. The cheat sheet draws layer-1.
<img width="971" alt="スクリーンショット 2022-03-02 17 33 53" src="https://user-images.githubusercontent.com/316463/156325900-88793776-cbb5-439d-99a6-f080a815f84f.png">

