### PR TITLE
Add support for extended keycode of BLE Micro Pro

### DIFF
--- a/src/actions/bmpExtendedKeycode.action.ts
+++ b/src/actions/bmpExtendedKeycode.action.ts
@@ -8,7 +8,8 @@ import { IBmpExtendedKeycode } from '../services/hid/bmp/BmpExtendedKeycode';
 export const BMP_EXTENDED_KEYCODE_EDITOR_ACTIONS = '@BmpExtendedKeyEditor';
 export const BMP_EXTENDED_KEYCODE_EDITOR_UPDATE_KEY = `${BMP_EXTENDED_KEYCODE_EDITOR_ACTIONS}/UpdateBmpExtendedKey`;
 export const BMP_EXTENDED_KEYCODE_EDITOR_UPDATE_EXTENDED_KEY_CODE = `${BMP_EXTENDED_KEYCODE_EDITOR_ACTIONS}/UpdateBmpExtendedKeycode`;
-export const BMP_EXTENDED_KEYCODE_EDITOR_CLEAR_KEY = `${BMP_EXTENDED_KEYCODE_EDITOR_ACTIONS}/UpdateBmpExtendedKey`;
+export const BMP_EXTENDED_KEYCODE_EDITOR_SET_MODIFIED = `${BMP_EXTENDED_KEYCODE_EDITOR_ACTIONS}/SetModified`;
+export const BMP_EXTENDED_KEYCODE_EDITOR_CLEAR_KEY = `${BMP_EXTENDED_KEYCODE_EDITOR_ACTIONS}/ClearBmpExtendedKey`;
 
 export const BmpExtendedKeycodeEditorActions = {
   updateExtendedKey: (id: number) => {
@@ -21,6 +22,12 @@ export const BmpExtendedKeycodeEditorActions = {
     return {
       type: BMP_EXTENDED_KEYCODE_EDITOR_UPDATE_EXTENDED_KEY_CODE,
       value: extendedKeycode,
+    };
+  },
+  setModified: (modified: boolean) => {
+    return {
+      type: BMP_EXTENDED_KEYCODE_EDITOR_SET_MODIFIED,
+      value: modified,
     };
   },
   clearExtendedKey: () => {

--- a/src/actions/bmpExtendedKeycode.action.ts
+++ b/src/actions/bmpExtendedKeycode.action.ts
@@ -2,16 +2,24 @@ import { Key } from '../components/configure/keycodekey/KeyGen';
 import { ThunkAction, ThunkDispatch } from 'redux-thunk';
 import { RootState } from '../store/state';
 import { NotificationActions } from './actions';
+import { BMP_EXTENDED_MIN } from '../services/hid/KeycodeInfoListBmp';
 
 export const BMP_EXTENDED_KEYCODE_EDITOR_ACTIONS = '@BmpExtendedKeyEditor';
 export const BMP_EXTENDED_KEYCODE_EDITOR_UPDATE_KEY = `${BMP_EXTENDED_KEYCODE_EDITOR_ACTIONS}/UpdateBmpExtendedKey`;
+export const BMP_EXTENDED_KEYCODE_EDITOR_UPDATE_EXTENDED_KEY_CODE = `${BMP_EXTENDED_KEYCODE_EDITOR_ACTIONS}/UpdateBmpExtendedKeycode`;
 export const BMP_EXTENDED_KEYCODE_EDITOR_CLEAR_KEY = `${BMP_EXTENDED_KEYCODE_EDITOR_ACTIONS}/UpdateBmpExtendedKey`;
 
 export const BmpExtendedKeycodeEditorActions = {
-  updateExtendedKey: (key: Key) => {
+  updateExtendedKey: (id: number) => {
     return {
       type: BMP_EXTENDED_KEYCODE_EDITOR_UPDATE_KEY,
-      value: key,
+      value: id,
+    };
+  },
+  updateExtendedKeycode: (extendedKeycode: Uint8Array) => {
+    return {
+      type: BMP_EXTENDED_KEYCODE_EDITOR_UPDATE_EXTENDED_KEY_CODE,
+      value: extendedKeycode,
     };
   },
   clearExtendedKey: () => {
@@ -39,6 +47,13 @@ export const BmpExtendedKeycodeActionsThunk = {
       dispatch: ThunkDispatch<RootState, undefined, ActionTypes>,
       getState: () => RootState
     ) => {
-      dispatch(BmpExtendedKeycodeEditorActions.updateExtendedKey(key));
+      const { entities } = getState();
+      const id = key.keymap.code - BMP_EXTENDED_MIN;
+      dispatch(
+        BmpExtendedKeycodeEditorActions.updateExtendedKeycode(
+          entities.device.extendedKeycode[id]
+        )
+      );
+      dispatch(BmpExtendedKeycodeEditorActions.updateExtendedKey(id));
     },
 };

--- a/src/actions/bmpExtendedKeycode.action.ts
+++ b/src/actions/bmpExtendedKeycode.action.ts
@@ -1,0 +1,44 @@
+import { Key } from '../components/configure/keycodekey/KeyGen';
+import { ThunkAction, ThunkDispatch } from 'redux-thunk';
+import { RootState } from '../store/state';
+import { NotificationActions } from './actions';
+
+export const BMP_EXTENDED_KEYCODE_EDITOR_ACTIONS = '@BmpExtendedKeyEditor';
+export const BMP_EXTENDED_KEYCODE_EDITOR_UPDATE_KEY = `${BMP_EXTENDED_KEYCODE_EDITOR_ACTIONS}/UpdateBmpExtendedKey`;
+export const BMP_EXTENDED_KEYCODE_EDITOR_CLEAR_KEY = `${BMP_EXTENDED_KEYCODE_EDITOR_ACTIONS}/UpdateBmpExtendedKey`;
+
+export const BmpExtendedKeycodeEditorActions = {
+  updateExtendedKey: (key: Key) => {
+    return {
+      type: BMP_EXTENDED_KEYCODE_EDITOR_UPDATE_KEY,
+      value: key,
+    };
+  },
+  clearExtendedKey: () => {
+    return {
+      type: BMP_EXTENDED_KEYCODE_EDITOR_CLEAR_KEY,
+    };
+  },
+};
+
+type ActionTypes = ReturnType<
+  | typeof BmpExtendedKeycodeEditorActions[keyof typeof BmpExtendedKeycodeEditorActions]
+  | typeof NotificationActions[keyof typeof NotificationActions]
+>;
+type ThunkPromiseAction<T> = ThunkAction<
+  Promise<T>,
+  RootState,
+  undefined,
+  ActionTypes
+>;
+
+export const BmpExtendedKeycodeActionsThunk = {
+  updateBmpExtendedKey:
+    (key: Key): ThunkPromiseAction<void> =>
+    async (
+      dispatch: ThunkDispatch<RootState, undefined, ActionTypes>,
+      getState: () => RootState
+    ) => {
+      dispatch(BmpExtendedKeycodeEditorActions.updateExtendedKey(key));
+    },
+};

--- a/src/actions/bmpExtendedKeycode.action.ts
+++ b/src/actions/bmpExtendedKeycode.action.ts
@@ -2,7 +2,8 @@ import { Key } from '../components/configure/keycodekey/KeyGen';
 import { ThunkAction, ThunkDispatch } from 'redux-thunk';
 import { RootState } from '../store/state';
 import { NotificationActions } from './actions';
-import { BMP_EXTENDED_MIN } from '../services/hid/KeycodeInfoListBmp';
+import { BMP_EXTENDED_MIN } from '../services/hid/bmp/KeycodeInfoListBmp';
+import { IBmpExtendedKeycode } from '../services/hid/bmp/BmpExtendedKeycode';
 
 export const BMP_EXTENDED_KEYCODE_EDITOR_ACTIONS = '@BmpExtendedKeyEditor';
 export const BMP_EXTENDED_KEYCODE_EDITOR_UPDATE_KEY = `${BMP_EXTENDED_KEYCODE_EDITOR_ACTIONS}/UpdateBmpExtendedKey`;
@@ -16,7 +17,7 @@ export const BmpExtendedKeycodeEditorActions = {
       value: id,
     };
   },
-  updateExtendedKeycode: (extendedKeycode: Uint8Array) => {
+  updateExtendedKeycode: (extendedKeycode: IBmpExtendedKeycode) => {
     return {
       type: BMP_EXTENDED_KEYCODE_EDITOR_UPDATE_EXTENDED_KEY_CODE,
       value: extendedKeycode,

--- a/src/actions/hid.action.ts
+++ b/src/actions/hid.action.ts
@@ -16,7 +16,7 @@ import { StorageActions, storageActionsThunk } from './storage.action';
 import { sendEventToGoogleAnalytics } from '../utils/GoogleAnalytics';
 import { LayoutOption } from '../components/configure/keymap/Keymap';
 import { maxValueByBitLength } from '../utils/NumberUtils';
-import { array } from 'prop-types';
+import { IBmpExtendedKeycode } from '../services/hid/bmp/BmpExtendedKeycode';
 
 const PRODUCT_PREFIX_FOR_BLE_MICRO_PRO = '(BMP)';
 
@@ -111,10 +111,13 @@ export const HidActions = {
     };
   },
 
-  updateBmpExtendedKeycode: (id: number, buffer: Uint8Array) => {
+  updateBmpExtendedKeycode: (
+    id: number,
+    extendedKeycode: IBmpExtendedKeycode
+  ) => {
     return {
       type: HID_UPDATE_BMP_EXTENDED_KEYCODE,
-      value: { id: id, buffer: buffer },
+      value: { id: id, extendedKeycode: extendedKeycode },
     };
   },
 };
@@ -312,7 +315,7 @@ export const hidActionsThunk = {
           dispatch(
             HidActions.updateBmpExtendedKeycode(
               idx,
-              extendedKeycodeResult.buffer!
+              extendedKeycodeResult.extendedKeycode!
             )
           );
         }

--- a/src/actions/hid.action.ts
+++ b/src/actions/hid.action.ts
@@ -17,6 +17,7 @@ import { sendEventToGoogleAnalytics } from '../utils/GoogleAnalytics';
 import { LayoutOption } from '../components/configure/keymap/Keymap';
 import { maxValueByBitLength } from '../utils/NumberUtils';
 import { IBmpExtendedKeycode } from '../services/hid/bmp/BmpExtendedKeycode';
+import { BmpExtendedKeycodeEditorActions } from './bmpExtendedKeycode.action';
 
 const PRODUCT_PREFIX_FOR_BLE_MICRO_PRO = '(BMP)';
 
@@ -500,6 +501,7 @@ export const hidActionsThunk = {
             return;
           }
         }
+        dispatch(BmpExtendedKeycodeEditorActions.setModified(false));
         const result = await keyboard.storeKeymapPersistentlyForBleMicroPro();
         if (!result.success) {
           console.error(result.cause);

--- a/src/actions/hid.action.ts
+++ b/src/actions/hid.action.ts
@@ -484,6 +484,22 @@ export const hidActionsThunk = {
         }
       }
       if (entities.device.bleMicroPro) {
+        for (
+          let idx = 0;
+          idx < entities.device.extendedKeycode.maxCount;
+          idx++
+        ) {
+          const result = await keyboard.setBmpExtendedKeycode(
+            idx,
+            entities.device.extendedKeycode[idx]
+          );
+          if (!result.success) {
+            console.error(result.cause);
+            dispatch(NotificationActions.addError(result.error!, result.cause));
+            dispatch(HeaderActions.updateFlashing(false));
+            return;
+          }
+        }
         const result = await keyboard.storeKeymapPersistentlyForBleMicroPro();
         if (!result.success) {
           console.error(result.cause);

--- a/src/components/configure/bmpExtendedKeycodeEditor/BmpExtendedKeycodeEditor.container.ts
+++ b/src/components/configure/bmpExtendedKeycodeEditor/BmpExtendedKeycodeEditor.container.ts
@@ -31,6 +31,7 @@ const mapDispatchToProps = (_dispatch: any) => {
         BmpExtendedKeycodeEditorActions.updateExtendedKeycode(extendedKeycode)
       );
       _dispatch(HidActions.updateBmpExtendedKeycode(id, extendedKeycode));
+      _dispatch(BmpExtendedKeycodeEditorActions.setModified(true));
     },
   };
 };

--- a/src/components/configure/bmpExtendedKeycodeEditor/BmpExtendedKeycodeEditor.container.ts
+++ b/src/components/configure/bmpExtendedKeycodeEditor/BmpExtendedKeycodeEditor.container.ts
@@ -3,6 +3,7 @@ import BmpExtendedKeycodeEditor from './BmpExtendedKeycodeEditor';
 import { RootState } from '../../../store/state';
 import { BmpExtendedKeycodeEditorActions } from '../../../actions/bmpExtendedKeycode.action';
 import { IBmpExtendedKeycode } from '../../../services/hid/bmp/BmpExtendedKeycode';
+import { HidActions } from '../../../actions/hid.action';
 
 const mapStateToProps = (state: RootState) => {
   return {
@@ -10,6 +11,7 @@ const mapStateToProps = (state: RootState) => {
     extendedKeycode: state.configure.bmpExtendedKeycodeEditor.extendedKeycode,
     keyboardWidth: state.app.keyboardWidth,
     keyboardHeight: state.app.keyboardHeight,
+    labelLang: state.app.labelLang,
   };
 };
 export type BmpExtendedKeycodeEditorStateType = ReturnType<
@@ -21,10 +23,14 @@ const mapDispatchToProps = (_dispatch: any) => {
     closeBmpExtendedKeycodeEditor: () => {
       _dispatch(BmpExtendedKeycodeEditorActions.clearExtendedKey());
     },
-    updateBmpExtendedKeycode: (extendedKeycode: IBmpExtendedKeycode) => {
+    updateBmpExtendedKeycode: (
+      id: number,
+      extendedKeycode: IBmpExtendedKeycode
+    ) => {
       _dispatch(
         BmpExtendedKeycodeEditorActions.updateExtendedKeycode(extendedKeycode)
       );
+      _dispatch(HidActions.updateBmpExtendedKeycode(id, extendedKeycode));
     },
   };
 };

--- a/src/components/configure/bmpExtendedKeycodeEditor/BmpExtendedKeycodeEditor.container.ts
+++ b/src/components/configure/bmpExtendedKeycodeEditor/BmpExtendedKeycodeEditor.container.ts
@@ -30,6 +30,11 @@ const mapDispatchToProps = (_dispatch: any) => {
       _dispatch(
         BmpExtendedKeycodeEditorActions.updateExtendedKeycode(extendedKeycode)
       );
+    },
+    applyBmpExtendedKeycodeUpdate: (
+      id: number,
+      extendedKeycode: IBmpExtendedKeycode
+    ) => {
       _dispatch(HidActions.updateBmpExtendedKeycode(id, extendedKeycode));
       _dispatch(BmpExtendedKeycodeEditorActions.setModified(true));
     },

--- a/src/components/configure/bmpExtendedKeycodeEditor/BmpExtendedKeycodeEditor.container.ts
+++ b/src/components/configure/bmpExtendedKeycodeEditor/BmpExtendedKeycodeEditor.container.ts
@@ -2,6 +2,7 @@ import { connect } from 'react-redux';
 import BmpExtendedKeycodeEditor from './BmpExtendedKeycodeEditor';
 import { RootState } from '../../../store/state';
 import { BmpExtendedKeycodeEditorActions } from '../../../actions/bmpExtendedKeycode.action';
+import { IBmpExtendedKeycode } from '../../../services/hid/bmp/BmpExtendedKeycode';
 
 const mapStateToProps = (state: RootState) => {
   return {
@@ -19,6 +20,11 @@ const mapDispatchToProps = (_dispatch: any) => {
   return {
     closeBmpExtendedKeycodeEditor: () => {
       _dispatch(BmpExtendedKeycodeEditorActions.clearExtendedKey());
+    },
+    updateBmpExtendedKeycode: (extendedKeycode: IBmpExtendedKeycode) => {
+      _dispatch(
+        BmpExtendedKeycodeEditorActions.updateExtendedKeycode(extendedKeycode)
+      );
     },
   };
 };

--- a/src/components/configure/bmpExtendedKeycodeEditor/BmpExtendedKeycodeEditor.container.ts
+++ b/src/components/configure/bmpExtendedKeycodeEditor/BmpExtendedKeycodeEditor.container.ts
@@ -12,6 +12,7 @@ const mapStateToProps = (state: RootState) => {
     keyboardWidth: state.app.keyboardWidth,
     keyboardHeight: state.app.keyboardHeight,
     labelLang: state.app.labelLang,
+    layerCount: state.entities.device.layerCount,
   };
 };
 export type BmpExtendedKeycodeEditorStateType = ReturnType<
@@ -23,10 +24,7 @@ const mapDispatchToProps = (_dispatch: any) => {
     closeBmpExtendedKeycodeEditor: () => {
       _dispatch(BmpExtendedKeycodeEditorActions.clearExtendedKey());
     },
-    updateBmpExtendedKeycode: (
-      id: number,
-      extendedKeycode: IBmpExtendedKeycode
-    ) => {
+    updateBmpExtendedKeycode: (extendedKeycode: IBmpExtendedKeycode) => {
       _dispatch(
         BmpExtendedKeycodeEditorActions.updateExtendedKeycode(extendedKeycode)
       );

--- a/src/components/configure/bmpExtendedKeycodeEditor/BmpExtendedKeycodeEditor.container.ts
+++ b/src/components/configure/bmpExtendedKeycodeEditor/BmpExtendedKeycodeEditor.container.ts
@@ -1,0 +1,31 @@
+import { connect } from 'react-redux';
+import BmpExtendedKeycodeEditor from './BmpExtendedKeycodeEditor';
+import { RootState } from '../../../store/state';
+import { BmpExtendedKeycodeEditorActions } from '../../../actions/bmpExtendedKeycode.action';
+
+const mapStateToProps = (state: RootState) => {
+  return {
+    extendedKey: state.configure.bmpExtendedKeycodeEditor.key,
+    keyboardWidth: state.app.keyboardWidth,
+    keyboardHeight: state.app.keyboardHeight,
+  };
+};
+export type BmpExtendedKeycodeEditorStateType = ReturnType<
+  typeof mapStateToProps
+>;
+
+const mapDispatchToProps = (_dispatch: any) => {
+  return {
+    closeBmpExtendedKeycodeEditor: () => {
+      _dispatch(BmpExtendedKeycodeEditorActions.clearExtendedKey());
+    },
+  };
+};
+export type BmpExtendedKeycodeEditorActionsType = ReturnType<
+  typeof mapDispatchToProps
+>;
+
+export default connect(
+  mapStateToProps,
+  mapDispatchToProps
+)(BmpExtendedKeycodeEditor);

--- a/src/components/configure/bmpExtendedKeycodeEditor/BmpExtendedKeycodeEditor.container.ts
+++ b/src/components/configure/bmpExtendedKeycodeEditor/BmpExtendedKeycodeEditor.container.ts
@@ -5,7 +5,8 @@ import { BmpExtendedKeycodeEditorActions } from '../../../actions/bmpExtendedKey
 
 const mapStateToProps = (state: RootState) => {
   return {
-    extendedKey: state.configure.bmpExtendedKeycodeEditor.key,
+    extendedKeyId: state.configure.bmpExtendedKeycodeEditor.id,
+    extendedKeycode: state.configure.bmpExtendedKeycodeEditor.extendedKeycode,
     keyboardWidth: state.app.keyboardWidth,
     keyboardHeight: state.app.keyboardHeight,
   };

--- a/src/components/configure/bmpExtendedKeycodeEditor/BmpExtendedKeycodeEditor.scss
+++ b/src/components/configure/bmpExtendedKeycodeEditor/BmpExtendedKeycodeEditor.scss
@@ -1,0 +1,33 @@
+@import '../../../variables';
+
+.bmp-extended-keycode-editor-wrapper {
+  display: flex;
+  flex-direction: row;
+  justify-content: center;
+  align-items: center;
+}
+
+.bmp-extended-keycode-editor-content {
+  width: 662px;
+  display: flex;
+  flex-direction: column;
+
+  &-title {
+    background-color: white;
+    font-size: 18px;
+    font-weight: 600;
+    z-index: 1;
+    padding: 8px;
+  }
+  &-footer {
+    width: 100%;
+    display: flex;
+    flex-direction: row;
+    flex-wrap: wrap;
+    padding: 8px;
+
+    :last-child {
+      margin-left: auto !important;
+    }
+  }
+}

--- a/src/components/configure/bmpExtendedKeycodeEditor/BmpExtendedKeycodeEditor.scss
+++ b/src/components/configure/bmpExtendedKeycodeEditor/BmpExtendedKeycodeEditor.scss
@@ -44,6 +44,10 @@
   }
 }
 
+.bmp-extended-keycode-editor-keycode-base {
+  height: 100%;
+}
+
 .bmp-extended-keycode-editor-layer-input {
   width: 50px;
   margin-right: 5px;

--- a/src/components/configure/bmpExtendedKeycodeEditor/BmpExtendedKeycodeEditor.scss
+++ b/src/components/configure/bmpExtendedKeycodeEditor/BmpExtendedKeycodeEditor.scss
@@ -31,3 +31,15 @@
     }
   }
 }
+
+.bmp-extended-keycode-editor-layer-input {
+  width: 50px;
+  margin-right: 5px;
+}
+
+.bmp-extneded-keycode-editor-key {
+  width: 50px;
+  height: 50px;
+  margin: 5px;
+  border: solid;
+}

--- a/src/components/configure/bmpExtendedKeycodeEditor/BmpExtendedKeycodeEditor.scss
+++ b/src/components/configure/bmpExtendedKeycodeEditor/BmpExtendedKeycodeEditor.scss
@@ -38,6 +38,10 @@
     flex-direction: row;
     flex-wrap: wrap;
     padding: 8px;
+
+    :last-child {
+      margin-left: auto !important;
+    }
   }
   .drag-over {
     background-color: gray;

--- a/src/components/configure/bmpExtendedKeycodeEditor/BmpExtendedKeycodeEditor.scss
+++ b/src/components/configure/bmpExtendedKeycodeEditor/BmpExtendedKeycodeEditor.scss
@@ -12,6 +12,19 @@
   display: flex;
   flex-direction: column;
 
+  &-keys {
+    background-color: white;
+    display: flex;
+    flex-direction: row;
+    flex-wrap: wrap;
+    align-items: center;
+    min-height: 90px;
+    width: 100%;
+    overflow-x: hidden;
+    z-index: 1;
+    padding: 4px;
+    border-bottom: 1px solid rgba(0, 0, 0, 0.2);
+  }
   &-title {
     background-color: white;
     font-size: 18px;
@@ -25,10 +38,9 @@
     flex-direction: row;
     flex-wrap: wrap;
     padding: 8px;
-
-    :last-child {
-      margin-left: auto !important;
-    }
+  }
+  .drag-over {
+    background-color: gray;
   }
 }
 
@@ -37,7 +49,11 @@
   margin-right: 5px;
 }
 
-.bmp-extneded-keycode-editor-key {
+.bmp-extended-keycode-editor-key-area {
+  display: flex;
+}
+
+.bmp-extended-keycode-editor-key {
   width: 50px;
   height: 50px;
   margin: 5px;

--- a/src/components/configure/bmpExtendedKeycodeEditor/BmpExtendedKeycodeEditor.tsx
+++ b/src/components/configure/bmpExtendedKeycodeEditor/BmpExtendedKeycodeEditor.tsx
@@ -51,7 +51,7 @@ export default class BmpExtendedKeycodeEditor extends React.Component<
       <div className="bmp-extended-keycode-editor-wrapper">
         <div className="bmp-extended-keycode-editor-content">
           <div className="bmp-extended-keycode-editor-content-title">
-            Bmp Extended Keycode Editor (ID:{this.props.extendedKeyId})
+            BMP Extended Keycode Editor (ID:{this.props.extendedKeyId})
           </div>
           <div className="bmp-extended-keycode-editor-content-keys">
             <div>
@@ -148,16 +148,16 @@ interface BmpExtendedKeyProp {
 
 function ExtendedKey(props: BmpExtendedKeyProp) {
   switch (props.extendedKeycode.getKind()) {
-    case ExtendedKind.TLT:
+    case ExtendedKind.TRI_LAYER_TAP:
       return TltExtend(props);
-    case ExtendedKind.LTE:
+    case ExtendedKind.LAYER_TAP_EXTENDED:
       return LteExtend(props);
-    case ExtendedKind.TDD:
+    case ExtendedKind.TAP_DANCE_DOUBLE:
       return TddExtend(props);
-    case ExtendedKind.TDH:
+    case ExtendedKind.TAP_DANCE_HOLD:
       return TdhExtend(props);
     default:
-      return <div>None</div>;
+      return <div></div>;
   }
 }
 
@@ -269,7 +269,6 @@ function TltExtend(props: BmpExtendedKeyProp) {
 
   return (
     <div>
-      <div>Tri-Layer-Tap</div>
       <label htmlFor="layer1">Layer1:</label>
       {LayerInput(tlt.getLayer1(), 'layer1', (e) => {
         tlt.setLayer1(Number(e.target.value));
@@ -304,7 +303,6 @@ function LteExtend(props: BmpExtendedKeyProp) {
 
   return (
     <div>
-      <div>Layer-Tap-Extend</div>
       <label htmlFor="layer1">Layer1:</label>
       {LayerInput(lte.getLayer(), 'layer1', (e) => {
         lte.setLayer(Number(e.target.value));
@@ -333,7 +331,6 @@ function TddExtend(props: BmpExtendedKeyProp) {
 
   return (
     <div>
-      <div>Tap-Dance-Double</div>
       <div className="bmp-extended-keycode-editor-key-area">
         <ExtendedKeyElement
           keymap={tdd.getKey1(props.labelLang)}
@@ -364,7 +361,6 @@ function TdhExtend(props: BmpExtendedKeyProp) {
 
   return (
     <div>
-      <div>Tap-Dance-Hold</div>
       <div className="bmp-extended-keycode-editor-key-area">
         <ExtendedKeyElement
           keymap={tdh.getKey1(props.labelLang)}

--- a/src/components/configure/bmpExtendedKeycodeEditor/BmpExtendedKeycodeEditor.tsx
+++ b/src/components/configure/bmpExtendedKeycodeEditor/BmpExtendedKeycodeEditor.tsx
@@ -21,7 +21,7 @@ import { IKeymap } from '../../../services/hid/Hid';
 import { genKey, Key } from '../keycodekey/KeyGen';
 import { RootState } from '../../../store/state';
 import { KeyboardLabelLang } from '../../../services/labellang/KeyLabelLangs';
-import CustomKey from '../customkey/CustomKey';
+import CustomKey, { PopoverPosition } from '../customkey/CustomKey';
 
 type BmpExtendedKeycodeEditorOwnProps = {};
 type BmpExtendedKeycodeEditorOwnState = {};
@@ -150,6 +150,11 @@ function ExtendedKeyElement(props: {
 }) {
   const [onDragOver, setOnDragOver] = useState(false);
   const [openCustomKey, setOpenCustomKey] = useState(false);
+  const [popoverPosition, setPopoverPosition] = useState<PopoverPosition>({
+    left: 0,
+    top: 0,
+    side: 'right',
+  });
   const draggingKey = useSelector((state: RootState) => {
     return state.configure.keycodeKey.draggingKey;
   });
@@ -169,7 +174,12 @@ function ExtendedKeyElement(props: {
           if (draggingKey) props.onChange(draggingKey);
           setOnDragOver(false);
         }}
-        onClick={() => {
+        onClick={(e: React.MouseEvent<HTMLInputElement>) => {
+          setPopoverPosition({
+            left: e.clientX,
+            top: e.clientY,
+            side: 'right',
+          });
           setOpenCustomKey(true);
         }}
       >
@@ -178,7 +188,7 @@ function ExtendedKeyElement(props: {
       <CustomKey
         id="customkey-popover"
         open={openCustomKey}
-        position={{ left: 0, top: 0, side: 'right' }}
+        position={popoverPosition}
         value={genKey(props.keymap)}
         layerCount={0}
         labelLang={props.labelLang}
@@ -187,7 +197,6 @@ function ExtendedKeyElement(props: {
           setOpenCustomKey(false);
         }}
         onChange={(key: Key) => {
-          console.log(key);
           props.onChange(key);
         }}
       ></CustomKey>

--- a/src/components/configure/bmpExtendedKeycodeEditor/BmpExtendedKeycodeEditor.tsx
+++ b/src/components/configure/bmpExtendedKeycodeEditor/BmpExtendedKeycodeEditor.tsx
@@ -89,6 +89,21 @@ export default class BmpExtendedKeycodeEditor extends React.Component<
             >
               BACK
             </Button>
+            <Button
+              size="small"
+              variant="contained"
+              color="primary"
+              disableElevation
+              onClick={() => {
+                this.props.applyBmpExtendedKeycodeUpdate!(
+                  this.props.extendedKeyId!,
+                  this.props.extendedKeycode!
+                );
+                this.props.closeBmpExtendedKeycodeEditor!();
+              }}
+            >
+              APPPLY
+            </Button>
           </div>
         </div>
       </div>

--- a/src/components/configure/bmpExtendedKeycodeEditor/BmpExtendedKeycodeEditor.tsx
+++ b/src/components/configure/bmpExtendedKeycodeEditor/BmpExtendedKeycodeEditor.tsx
@@ -22,8 +22,6 @@ import { Key } from '../keycodekey/KeyGen';
 import { RootState } from '../../../store/state';
 import { KeyboardLabelLang } from '../../../services/labellang/KeyLabelLangs';
 
-const KEY_DIFF_HEIGHT = 78;
-
 type BmpExtendedKeycodeEditorOwnProps = {};
 type BmpExtendedKeycodeEditorOwnState = {};
 
@@ -51,35 +49,32 @@ export default class BmpExtendedKeycodeEditor extends React.Component<
           <div className="bmp-extended-keycode-editor-content-title">
             Bmp Extended Keycode Editor (ID:{this.props.extendedKeyId})
           </div>
-          <div>
-            <ExtendedKindSelect
-              extendedKeycode={this.props.extendedKeycode!}
-              onChange={(value) => {
-                this.props.updateBmpExtendedKeycode!(
-                  this.props.extendedKeyId!,
-                  value
-                );
-              }}
-            ></ExtendedKindSelect>
-
-            <div
-              style={{
-                height: this.props.keyboardHeight,
-              }}
-            >
-              <ExtendedKey
+          <div className="bmp-extended-keycode-editor-content-keys">
+            <div>
+              <ExtendedKindSelect
                 extendedKeycode={this.props.extendedKeycode!}
-                labelLang={this.props.labelLang!}
-                onChange={(key) =>
+                onChange={(value) => {
                   this.props.updateBmpExtendedKeycode!(
                     this.props.extendedKeyId!,
-                    key
-                  )
-                }
-              ></ExtendedKey>
+                    value
+                  );
+                }}
+              ></ExtendedKindSelect>
+
+              <div>
+                <ExtendedKey
+                  extendedKeycode={this.props.extendedKeycode!}
+                  labelLang={this.props.labelLang!}
+                  onChange={(key) =>
+                    this.props.updateBmpExtendedKeycode!(
+                      this.props.extendedKeyId!,
+                      key
+                    )
+                  }
+                ></ExtendedKey>
+              </div>
             </div>
           </div>
-
           <div className="bmp-extended-keycode-editor-content-footer">
             <Button
               size="small"
@@ -151,19 +146,24 @@ function ExtendedKeyElement(props: {
   keymap: IKeymap;
   onDrop: (dropped: Key) => void;
 }) {
+  const [onDragOver, setOnDragOver] = useState(false);
   const draggingKey = useSelector((state: RootState) => {
     return state.configure.keycodeKey.draggingKey;
   });
 
   return (
     <div
-      className="bmp-extneded-keycode-editor-key"
+      className={['keycodekey', onDragOver && 'drag-over'].join(' ')}
       onDragOver={(event) => {
         event.preventDefault();
+        setOnDragOver(true);
       }}
-      onDragLeave={() => {}}
+      onDragLeave={() => {
+        setOnDragOver(false);
+      }}
       onDrop={() => {
         if (draggingKey) props.onDrop(draggingKey);
+        setOnDragOver(false);
       }}
     >
       {props.keymap.keycodeInfo.label}
@@ -260,14 +260,16 @@ function TddExtend(props: BmpExtendedKeyProp) {
   return (
     <div>
       <div>Tap-Dance-Double</div>
-      <ExtendedKeyElement
-        keymap={tdd.getKey1(props.labelLang)}
-        onDrop={handleDrop1}
-      />
-      <ExtendedKeyElement
-        keymap={tdd.getKey2(props.labelLang)}
-        onDrop={handleDrop2}
-      />
+      <div className="bmp-extended-keycode-editor-key-area">
+        <ExtendedKeyElement
+          keymap={tdd.getKey1(props.labelLang)}
+          onDrop={handleDrop1}
+        />
+        <ExtendedKeyElement
+          keymap={tdd.getKey2(props.labelLang)}
+          onDrop={handleDrop2}
+        />
+      </div>
     </div>
   );
 }
@@ -287,14 +289,16 @@ function TdhExtend(props: BmpExtendedKeyProp) {
   return (
     <div>
       <div>Tap-Dance-Hold</div>
-      <ExtendedKeyElement
-        keymap={tdh.getKey1(props.labelLang)}
-        onDrop={handleDrop1}
-      />
-      <ExtendedKeyElement
-        keymap={tdh.getKey2(props.labelLang)}
-        onDrop={handleDrop2}
-      />
+      <div className="bmp-extended-keycode-editor-key-area">
+        <ExtendedKeyElement
+          keymap={tdh.getKey1(props.labelLang)}
+          onDrop={handleDrop1}
+        />
+        <ExtendedKeyElement
+          keymap={tdh.getKey2(props.labelLang)}
+          onDrop={handleDrop2}
+        />
+      </div>
     </div>
   );
 }

--- a/src/components/configure/bmpExtendedKeycodeEditor/BmpExtendedKeycodeEditor.tsx
+++ b/src/components/configure/bmpExtendedKeycodeEditor/BmpExtendedKeycodeEditor.tsx
@@ -18,9 +18,10 @@ import {
 import lodash from 'lodash';
 import { useDispatch, useSelector } from 'react-redux';
 import { IKeymap } from '../../../services/hid/Hid';
-import { Key } from '../keycodekey/KeyGen';
+import { genKey, Key } from '../keycodekey/KeyGen';
 import { RootState } from '../../../store/state';
 import { KeyboardLabelLang } from '../../../services/labellang/KeyLabelLangs';
+import CustomKey from '../customkey/CustomKey';
 
 type BmpExtendedKeycodeEditorOwnProps = {};
 type BmpExtendedKeycodeEditorOwnState = {};
@@ -144,29 +145,52 @@ function ExtendedKey(props: BmpExtendedKeyProp) {
 
 function ExtendedKeyElement(props: {
   keymap: IKeymap;
-  onDrop: (dropped: Key) => void;
+  labelLang: KeyboardLabelLang;
+  onChange: (key: Key) => void;
 }) {
   const [onDragOver, setOnDragOver] = useState(false);
+  const [openCustomKey, setOpenCustomKey] = useState(false);
   const draggingKey = useSelector((state: RootState) => {
     return state.configure.keycodeKey.draggingKey;
   });
 
   return (
-    <div
-      className={['keycodekey', onDragOver && 'drag-over'].join(' ')}
-      onDragOver={(event) => {
-        event.preventDefault();
-        setOnDragOver(true);
-      }}
-      onDragLeave={() => {
-        setOnDragOver(false);
-      }}
-      onDrop={() => {
-        if (draggingKey) props.onDrop(draggingKey);
-        setOnDragOver(false);
-      }}
-    >
-      {props.keymap.keycodeInfo.label}
+    <div>
+      <div
+        className={['keycodekey', onDragOver && 'drag-over'].join(' ')}
+        onDragOver={(event) => {
+          event.preventDefault();
+          setOnDragOver(true);
+        }}
+        onDragLeave={() => {
+          setOnDragOver(false);
+        }}
+        onDrop={() => {
+          if (draggingKey) props.onChange(draggingKey);
+          setOnDragOver(false);
+        }}
+        onClick={() => {
+          setOpenCustomKey(true);
+        }}
+      >
+        {props.keymap.keycodeInfo.label}
+      </div>
+      <CustomKey
+        id="customkey-popover"
+        open={openCustomKey}
+        position={{ left: 0, top: 0, side: 'right' }}
+        value={genKey(props.keymap)}
+        layerCount={0}
+        labelLang={props.labelLang}
+        bleMicroPro={true}
+        onClose={() => {
+          setOpenCustomKey(false);
+        }}
+        onChange={(key: Key) => {
+          console.log(key);
+          props.onChange(key);
+        }}
+      ></CustomKey>
     </div>
   );
 }
@@ -215,7 +239,8 @@ function TltExtend(props: BmpExtendedKeyProp) {
       })}
       <ExtendedKeyElement
         keymap={tlt.getKey(props.labelLang)}
-        onDrop={handleDrop}
+        labelLang={props.labelLang}
+        onChange={handleDrop}
       />
     </div>
   );
@@ -239,7 +264,8 @@ function LteExtend(props: BmpExtendedKeyProp) {
       })}
       <ExtendedKeyElement
         keymap={lte.getKey(props.labelLang)}
-        onDrop={handleDrop}
+        labelLang={props.labelLang}
+        onChange={handleDrop}
       />
     </div>
   );
@@ -263,11 +289,13 @@ function TddExtend(props: BmpExtendedKeyProp) {
       <div className="bmp-extended-keycode-editor-key-area">
         <ExtendedKeyElement
           keymap={tdd.getKey1(props.labelLang)}
-          onDrop={handleDrop1}
+          labelLang={props.labelLang}
+          onChange={handleDrop1}
         />
         <ExtendedKeyElement
           keymap={tdd.getKey2(props.labelLang)}
-          onDrop={handleDrop2}
+          labelLang={props.labelLang}
+          onChange={handleDrop2}
         />
       </div>
     </div>
@@ -292,11 +320,13 @@ function TdhExtend(props: BmpExtendedKeyProp) {
       <div className="bmp-extended-keycode-editor-key-area">
         <ExtendedKeyElement
           keymap={tdh.getKey1(props.labelLang)}
-          onDrop={handleDrop1}
+          labelLang={props.labelLang}
+          onChange={handleDrop1}
         />
         <ExtendedKeyElement
           keymap={tdh.getKey2(props.labelLang)}
-          onDrop={handleDrop2}
+          labelLang={props.labelLang}
+          onChange={handleDrop2}
         />
       </div>
     </div>

--- a/src/components/configure/bmpExtendedKeycodeEditor/BmpExtendedKeycodeEditor.tsx
+++ b/src/components/configure/bmpExtendedKeycodeEditor/BmpExtendedKeycodeEditor.tsx
@@ -22,6 +22,9 @@ import { genKey, Key } from '../keycodekey/KeyGen';
 import { RootState } from '../../../store/state';
 import { KeyboardLabelLang } from '../../../services/labellang/KeyLabelLangs';
 import CustomKey, { PopoverPosition } from '../customkey/CustomKey';
+import { KeyLabel } from '../keycap/Keycap';
+import { buildHoldKeyLabel } from '../customkey/TabHoldTapKey';
+import { buildModLabel } from '../customkey/Modifiers';
 
 type BmpExtendedKeycodeEditorOwnProps = {};
 type BmpExtendedKeycodeEditorOwnState = {};
@@ -159,6 +162,16 @@ function ExtendedKeyElement(props: {
     return state.configure.keycodeKey.draggingKey;
   });
 
+  const key = genKey(props.keymap, props.labelLang);
+  const holdLabel = buildHoldKeyLabel(props.keymap, props.keymap.isAny);
+  let modifierLabel =
+    holdLabel === ''
+      ? buildModLabel(props.keymap.modifiers || null, props.keymap.direction!)
+      : '';
+  const modifierRightLabel = key.metaRight;
+  const meta = key.meta;
+  modifierLabel = meta ? meta : modifierLabel;
+
   return (
     <div>
       <div
@@ -183,7 +196,18 @@ function ExtendedKeyElement(props: {
           setOpenCustomKey(true);
         }}
       >
-        {props.keymap.keycodeInfo.label}
+        <div className="keycap-base bmp-extended-keycode-editor-keycode-base">
+          <div className="keyroof">
+            <KeyLabel
+              label={key.label}
+              meta={key.meta}
+              modifierLabel={modifierLabel}
+              modifierRightLabel={modifierRightLabel}
+              holdLabel={holdLabel}
+              hasDiff={false}
+            />
+          </div>
+        </div>
       </div>
       <CustomKey
         id="customkey-popover"

--- a/src/components/configure/bmpExtendedKeycodeEditor/BmpExtendedKeycodeEditor.tsx
+++ b/src/components/configure/bmpExtendedKeycodeEditor/BmpExtendedKeycodeEditor.tsx
@@ -10,8 +10,8 @@ import {
 import {
   BmpExtendedKeycodeLte,
   BmpExtendedKeycodeTlt,
-  BmpExtendedKeycodeTdh,
-  BmpExtendedKeycodeTdd,
+  BmpExtendedKeycodeTwoKeyCombination,
+  BmpExtendedKeycodeCombo,
   ExtendedKind,
   IBmpExtendedKeycode,
 } from '../../../services/hid/bmp/BmpExtendedKeycode';
@@ -153,9 +153,10 @@ function ExtendedKey(props: BmpExtendedKeyProp) {
     case ExtendedKind.LAYER_TAP_EXTENDED:
       return LteExtend(props);
     case ExtendedKind.TAP_DANCE_DOUBLE:
-      return TddExtend(props);
     case ExtendedKind.TAP_DANCE_HOLD:
-      return TdhExtend(props);
+      return TwoKeyCombinationExtend(props);
+    case ExtendedKind.COMBO:
+      return ComboExtend(props);
     default:
       return <div></div>;
   }
@@ -317,15 +318,15 @@ function LteExtend(props: BmpExtendedKeyProp) {
   );
 }
 
-function TddExtend(props: BmpExtendedKeyProp) {
+function TwoKeyCombinationExtend(props: BmpExtendedKeyProp) {
   const newKeycode = lodash.cloneDeep(props.extendedKeycode);
-  const tdd = new BmpExtendedKeycodeTdd(newKeycode);
+  const combination = new BmpExtendedKeycodeTwoKeyCombination(newKeycode);
   const handleDrop1 = (dropped: Key) => {
-    tdd.setKey1(dropped.keymap.code);
+    combination.setKey1(dropped.keymap.code);
     props.onChange(newKeycode);
   };
   const handleDrop2 = (dropped: Key) => {
-    tdd.setKey2(dropped.keymap.code);
+    combination.setKey2(dropped.keymap.code);
     props.onChange(newKeycode);
   };
 
@@ -333,12 +334,12 @@ function TddExtend(props: BmpExtendedKeyProp) {
     <div>
       <div className="bmp-extended-keycode-editor-key-area">
         <ExtendedKeyElement
-          keymap={tdd.getKey1(props.labelLang)}
+          keymap={combination.getKey1(props.labelLang)}
           labelLang={props.labelLang}
           onChange={handleDrop1}
         />
         <ExtendedKeyElement
-          keymap={tdd.getKey2(props.labelLang)}
+          keymap={combination.getKey2(props.labelLang)}
           labelLang={props.labelLang}
           onChange={handleDrop2}
         />
@@ -347,15 +348,19 @@ function TddExtend(props: BmpExtendedKeyProp) {
   );
 }
 
-function TdhExtend(props: BmpExtendedKeyProp) {
+function ComboExtend(props: BmpExtendedKeyProp) {
   const newKeycode = lodash.cloneDeep(props.extendedKeycode);
-  const tdh = new BmpExtendedKeycodeTdh(newKeycode);
+  const combo = new BmpExtendedKeycodeCombo(newKeycode);
   const handleDrop1 = (dropped: Key) => {
-    tdh.setKey1(dropped.keymap.code);
+    combo.setKey1(dropped.keymap.code);
     props.onChange(newKeycode);
   };
   const handleDrop2 = (dropped: Key) => {
-    tdh.setKey2(dropped.keymap.code);
+    combo.setKey2(dropped.keymap.code);
+    props.onChange(newKeycode);
+  };
+  const handleDrop3 = (dropped: Key) => {
+    combo.setKey3(dropped.keymap.code);
     props.onChange(newKeycode);
   };
 
@@ -363,14 +368,19 @@ function TdhExtend(props: BmpExtendedKeyProp) {
     <div>
       <div className="bmp-extended-keycode-editor-key-area">
         <ExtendedKeyElement
-          keymap={tdh.getKey1(props.labelLang)}
+          keymap={combo.getKey1(props.labelLang)}
           labelLang={props.labelLang}
           onChange={handleDrop1}
         />
         <ExtendedKeyElement
-          keymap={tdh.getKey2(props.labelLang)}
+          keymap={combo.getKey2(props.labelLang)}
           labelLang={props.labelLang}
           onChange={handleDrop2}
+        />
+        <ExtendedKeyElement
+          keymap={combo.getKey3(props.labelLang)}
+          labelLang={props.labelLang}
+          onChange={handleDrop3}
         />
       </div>
     </div>

--- a/src/components/configure/bmpExtendedKeycodeEditor/BmpExtendedKeycodeEditor.tsx
+++ b/src/components/configure/bmpExtendedKeycodeEditor/BmpExtendedKeycodeEditor.tsx
@@ -7,21 +7,16 @@ import {
   BmpExtendedKeycodeEditorActionsType,
   BmpExtendedKeycodeEditorStateType,
 } from './BmpExtendedKeycodeEditor.container';
+import {
+  ExtendedKind,
+  IBmpExtendedKeycode,
+} from '../../../services/hid/bmp/BmpExtendedKeycode';
+import lodash from 'lodash';
 
 const KEY_DIFF_HEIGHT = 78;
 
-enum ExtendedKind {
-  NONE,
-  TLT,
-  LTE,
-  TDH,
-  TDD,
-}
-
 type BmpExtendedKeycodeEditorOwnProps = {};
-type BmpExtendedKeycodeEditorOwnState = {
-  extendedKind: ExtendedKind;
-};
+type BmpExtendedKeycodeEditorOwnState = {};
 
 type BmpExtendedKeycodeEditorProps = BmpExtendedKeycodeEditorOwnProps &
   Partial<BmpExtendedKeycodeEditorStateType> &
@@ -37,7 +32,7 @@ export default class BmpExtendedKeycodeEditor extends React.Component<
       | Readonly<BmpExtendedKeycodeEditorProps>
   ) {
     super(props);
-    this.state = { extendedKind: props.extendedKeycode![0] };
+    this.state = {};
   }
 
   render() {
@@ -52,14 +47,13 @@ export default class BmpExtendedKeycodeEditor extends React.Component<
           </div>
           <div>
             <ExtendedKindSelect
-              kind={this.state.extendedKind}
-              onChangeKind={(kind) => {
-                this.setState({ extendedKind: kind });
+              extendedKeycode={this.props.extendedKeycode!}
+              onChange={(value) => {
+                this.props.updateBmpExtendedKeycode!(value);
               }}
             ></ExtendedKindSelect>
             <ExtendedKey
-              kind={this.state.extendedKind}
-              onUpdate={(extendedKeycode) => {}}
+              extendedKeycode={this.props.extendedKeycode!}
             ></ExtendedKey>
           </div>
           <div className="bmp-extended-keycode-editor-content-footer">
@@ -80,15 +74,17 @@ export default class BmpExtendedKeycodeEditor extends React.Component<
 }
 
 function ExtendedKindSelect(props: {
-  kind: ExtendedKind;
-  onChangeKind: (kind: ExtendedKind) => void;
+  extendedKeycode: IBmpExtendedKeycode;
+  onChange: (value: IBmpExtendedKeycode) => void;
 }) {
   return (
     <Select
       variant="standard"
-      value={props.kind}
+      value={props.extendedKeycode.getKind()}
       onChange={(e) => {
-        props.onChangeKind(e.target.value as ExtendedKind);
+        const extendedKeycode = lodash.cloneDeep(props.extendedKeycode);
+        extendedKeycode.changeKind(e.target.value as ExtendedKind);
+        props.onChange(extendedKeycode);
       }}
     >
       {Object.keys(ExtendedKind)
@@ -107,36 +103,33 @@ function ExtendedKindSelect(props: {
   );
 }
 
-function ExtendedKey(props: {
-  kind: ExtendedKind;
-  onUpdate: (extendedKeycode: Uint8Array) => void;
-}) {
-  switch (props.kind) {
+function ExtendedKey(props: { extendedKeycode: IBmpExtendedKeycode }) {
+  switch (props.extendedKeycode.getKind()) {
     case ExtendedKind.TLT:
-      return <TltExtend onUpdate={props.onUpdate}></TltExtend>;
+      return <TltExtend extendedKeycode={props.extendedKeycode}></TltExtend>;
     case ExtendedKind.LTE:
-      return <LteExtend onUpdate={props.onUpdate}></LteExtend>;
+      return <LteExtend extendedKeycode={props.extendedKeycode}></LteExtend>;
     case ExtendedKind.TDH:
-      return <TdhExtend onUpdate={props.onUpdate}></TdhExtend>;
+      return <TdhExtend extendedKeycode={props.extendedKeycode}></TdhExtend>;
     case ExtendedKind.TDD:
-      return <TddExtend onUpdate={props.onUpdate}></TddExtend>;
+      return <TddExtend extendedKeycode={props.extendedKeycode}></TddExtend>;
     default:
       return <div>None</div>;
   }
 }
 
-function TltExtend(props: { onUpdate: (extendedKeycode: Uint8Array) => void }) {
+function TltExtend(props: { extendedKeycode: IBmpExtendedKeycode }) {
   return <div>TLT</div>;
 }
 
-function LteExtend(props: { onUpdate: (extendedKeycode: Uint8Array) => void }) {
+function LteExtend(props: { extendedKeycode: IBmpExtendedKeycode }) {
   return <div>LTE</div>;
 }
 
-function TddExtend(props: { onUpdate: (extendedKeycode: Uint8Array) => void }) {
+function TddExtend(props: { extendedKeycode: IBmpExtendedKeycode }) {
   return <div>TDD</div>;
 }
 
-function TdhExtend(props: { onUpdate: (extendedKeycode: Uint8Array) => void }) {
+function TdhExtend(props: { extendedKeycode: IBmpExtendedKeycode }) {
   return <div>TDH</div>;
 }

--- a/src/components/configure/bmpExtendedKeycodeEditor/BmpExtendedKeycodeEditor.tsx
+++ b/src/components/configure/bmpExtendedKeycodeEditor/BmpExtendedKeycodeEditor.tsx
@@ -1,0 +1,57 @@
+/* eslint-disable no-unused-vars */
+/* eslint-disable no-undef */
+import React, { useState } from 'react';
+import './BmpExtendedKeycodeEditor.scss';
+import { Button } from '@mui/material';
+import {
+  BmpExtendedKeycodeEditorActionsType,
+  BmpExtendedKeycodeEditorStateType,
+} from './BmpExtendedKeycodeEditor.container';
+
+const KEY_DIFF_HEIGHT = 78;
+
+type BmpExtendedKeycodeEditorOwnProps = {};
+type BmpExtendedKeycodeEditorOwnState = {};
+
+type BmpExtendedKeycodeEditorProps = BmpExtendedKeycodeEditorOwnProps &
+  Partial<BmpExtendedKeycodeEditorStateType> &
+  Partial<BmpExtendedKeycodeEditorActionsType>;
+
+export default class BmpExtendedKeycodeEditor extends React.Component<
+  BmpExtendedKeycodeEditorProps,
+  BmpExtendedKeycodeEditorOwnState
+> {
+  constructor(
+    props:
+      | BmpExtendedKeycodeEditorProps
+      | Readonly<BmpExtendedKeycodeEditorProps>
+  ) {
+    super(props);
+    this.state = {};
+  }
+  render() {
+    return (
+      <div
+        className="bmp-extended-keycode-editor-wrapper"
+        style={{ height: this.props.keyboardHeight! + KEY_DIFF_HEIGHT }}
+      >
+        <div className="bmp-extended-keycode-editor-content">
+          <div className="bmp-extended-keycode-editor-content-title">
+            Bmp Extended Keycode Editor
+          </div>
+          <div className="bmp-extended-keycode-editor-content-footer">
+            <Button
+              size="small"
+              variant="text"
+              color="primary"
+              disableElevation
+              onClick={this.props.closeBmpExtendedKeycodeEditor!.bind(this)}
+            >
+              BACK
+            </Button>
+          </div>
+        </div>
+      </div>
+    );
+  }
+}

--- a/src/components/configure/bmpExtendedKeycodeEditor/BmpExtendedKeycodeEditor.tsx
+++ b/src/components/configure/bmpExtendedKeycodeEditor/BmpExtendedKeycodeEditor.tsx
@@ -59,10 +59,7 @@ export default class BmpExtendedKeycodeEditor extends React.Component<
               <ExtendedKindSelect
                 extendedKeycode={this.props.extendedKeycode!}
                 onChange={(value) => {
-                  this.props.updateBmpExtendedKeycode!(
-                    this.props.extendedKeyId!,
-                    value
-                  );
+                  this.props.updateBmpExtendedKeycode!(value);
                 }}
               ></ExtendedKindSelect>
 
@@ -70,12 +67,8 @@ export default class BmpExtendedKeycodeEditor extends React.Component<
                 <ExtendedKey
                   extendedKeycode={this.props.extendedKeycode!}
                   labelLang={this.props.labelLang!}
-                  onChange={(key) =>
-                    this.props.updateBmpExtendedKeycode!(
-                      this.props.extendedKeyId!,
-                      key
-                    )
-                  }
+                  layerCount={this.props.layerCount!}
+                  onChange={(key) => this.props.updateBmpExtendedKeycode!(key)}
                 ></ExtendedKey>
               </div>
             </div>
@@ -146,6 +139,7 @@ function ExtendedKindSelect(props: {
 interface BmpExtendedKeyProp {
   extendedKeycode: IBmpExtendedKeycode;
   labelLang: KeyboardLabelLang;
+  layerCount: number;
   onChange: (update: IBmpExtendedKeycode) => void;
 }
 
@@ -168,6 +162,7 @@ function ExtendedKey(props: BmpExtendedKeyProp) {
 function ExtendedKeyElement(props: {
   keymap: IKeymap;
   labelLang: KeyboardLabelLang;
+  layerCount: number;
   onChange: (key: Key) => void;
 }) {
   const [onDragOver, setOnDragOver] = useState(false);
@@ -233,7 +228,7 @@ function ExtendedKeyElement(props: {
         open={openCustomKey}
         position={popoverPosition}
         value={genKey(props.keymap)}
-        layerCount={0}
+        layerCount={props.layerCount}
         labelLang={props.labelLang}
         bleMicroPro={true}
         onClose={() => {
@@ -291,6 +286,7 @@ function TltExtend(props: BmpExtendedKeyProp) {
       <ExtendedKeyElement
         keymap={tlt.getKey(props.labelLang)}
         labelLang={props.labelLang}
+        layerCount={props.layerCount}
         onChange={handleDrop}
       />
     </div>
@@ -315,6 +311,7 @@ function LteExtend(props: BmpExtendedKeyProp) {
       <ExtendedKeyElement
         keymap={lte.getKey(props.labelLang)}
         labelLang={props.labelLang}
+        layerCount={props.layerCount}
         onChange={handleDrop}
       />
     </div>
@@ -341,11 +338,13 @@ function TwoKeyCombinationExtend(props: BmpExtendedKeyProp) {
         <ExtendedKeyElement
           keymap={combination.getKey1(props.labelLang)}
           labelLang={props.labelLang}
+          layerCount={props.layerCount}
           onChange={handleDrop1}
         />
         <ExtendedKeyElement
           keymap={combination.getKey2(props.labelLang)}
           labelLang={props.labelLang}
+          layerCount={props.layerCount}
           onChange={handleDrop2}
         />
       </div>
@@ -375,16 +374,19 @@ function ComboExtend(props: BmpExtendedKeyProp) {
         <ExtendedKeyElement
           keymap={combo.getKey1(props.labelLang)}
           labelLang={props.labelLang}
+          layerCount={props.layerCount}
           onChange={handleDrop1}
         />
         <ExtendedKeyElement
           keymap={combo.getKey2(props.labelLang)}
           labelLang={props.labelLang}
+          layerCount={props.layerCount}
           onChange={handleDrop2}
         />
         <ExtendedKeyElement
           keymap={combo.getKey3(props.labelLang)}
           labelLang={props.labelLang}
+          layerCount={props.layerCount}
           onChange={handleDrop3}
         />
       </div>

--- a/src/components/configure/bmpExtendedKeycodeEditor/BmpExtendedKeycodeEditor.tsx
+++ b/src/components/configure/bmpExtendedKeycodeEditor/BmpExtendedKeycodeEditor.tsx
@@ -14,6 +14,7 @@ import {
   BmpExtendedKeycodeCombo,
   ExtendedKind,
   IBmpExtendedKeycode,
+  BmpExtendedKeycode,
 } from '../../../services/hid/bmp/BmpExtendedKeycode';
 import lodash from 'lodash';
 import { useDispatch, useSelector } from 'react-redux';
@@ -122,7 +123,9 @@ function ExtendedKindSelect(props: {
       onChange={(e) => {
         const extendedKeycode = lodash.cloneDeep(props.extendedKeycode);
         extendedKeycode.changeKind(e.target.value as ExtendedKind);
-        props.onChange(extendedKeycode);
+        props.onChange(
+          BmpExtendedKeycode.createExtendedKeycode(extendedKeycode.getBytes())
+        );
       }}
     >
       {Object.keys(ExtendedKind)
@@ -262,7 +265,7 @@ function LayerInput(
 
 function TltExtend(props: BmpExtendedKeyProp) {
   const newKeycode = lodash.cloneDeep(props.extendedKeycode);
-  const tlt = new BmpExtendedKeycodeTlt(newKeycode);
+  const tlt = new BmpExtendedKeycodeTlt(newKeycode.getBytes());
   const handleDrop = (dropped: Key) => {
     tlt.setKey(dropped.keymap.code);
     props.onChange(newKeycode);
@@ -296,7 +299,7 @@ function TltExtend(props: BmpExtendedKeyProp) {
 
 function LteExtend(props: BmpExtendedKeyProp) {
   const newKeycode = lodash.cloneDeep(props.extendedKeycode);
-  const lte = new BmpExtendedKeycodeLte(newKeycode);
+  const lte = new BmpExtendedKeycodeLte(newKeycode.getBytes());
   const handleDrop = (dropped: Key) => {
     lte.setKey(dropped.keymap.code);
     props.onChange(newKeycode);
@@ -320,7 +323,9 @@ function LteExtend(props: BmpExtendedKeyProp) {
 
 function TwoKeyCombinationExtend(props: BmpExtendedKeyProp) {
   const newKeycode = lodash.cloneDeep(props.extendedKeycode);
-  const combination = new BmpExtendedKeycodeTwoKeyCombination(newKeycode);
+  const combination = new BmpExtendedKeycodeTwoKeyCombination(
+    newKeycode.getBytes()
+  );
   const handleDrop1 = (dropped: Key) => {
     combination.setKey1(dropped.keymap.code);
     props.onChange(newKeycode);
@@ -350,7 +355,7 @@ function TwoKeyCombinationExtend(props: BmpExtendedKeyProp) {
 
 function ComboExtend(props: BmpExtendedKeyProp) {
   const newKeycode = lodash.cloneDeep(props.extendedKeycode);
-  const combo = new BmpExtendedKeycodeCombo(newKeycode);
+  const combo = new BmpExtendedKeycodeCombo(newKeycode.getBytes());
   const handleDrop1 = (dropped: Key) => {
     combo.setKey1(dropped.keymap.code);
     props.onChange(newKeycode);

--- a/src/components/configure/bmpExtendedKeycodeEditor/BmpExtendedKeycodeEditor.tsx
+++ b/src/components/configure/bmpExtendedKeycodeEditor/BmpExtendedKeycodeEditor.tsx
@@ -2,7 +2,7 @@
 /* eslint-disable no-undef */
 import React, { useState } from 'react';
 import './BmpExtendedKeycodeEditor.scss';
-import { Button } from '@mui/material';
+import { Button, Select, MenuItem } from '@mui/material';
 import {
   BmpExtendedKeycodeEditorActionsType,
   BmpExtendedKeycodeEditorStateType,
@@ -10,8 +10,18 @@ import {
 
 const KEY_DIFF_HEIGHT = 78;
 
+enum ExtendedKind {
+  NONE,
+  TLT,
+  LTE,
+  TDH,
+  TDD,
+}
+
 type BmpExtendedKeycodeEditorOwnProps = {};
-type BmpExtendedKeycodeEditorOwnState = {};
+type BmpExtendedKeycodeEditorOwnState = {
+  extendedKind: ExtendedKind;
+};
 
 type BmpExtendedKeycodeEditorProps = BmpExtendedKeycodeEditorOwnProps &
   Partial<BmpExtendedKeycodeEditorStateType> &
@@ -27,8 +37,9 @@ export default class BmpExtendedKeycodeEditor extends React.Component<
       | Readonly<BmpExtendedKeycodeEditorProps>
   ) {
     super(props);
-    this.state = {};
+    this.state = { extendedKind: props.extendedKeycode![0] };
   }
+
   render() {
     return (
       <div
@@ -37,7 +48,19 @@ export default class BmpExtendedKeycodeEditor extends React.Component<
       >
         <div className="bmp-extended-keycode-editor-content">
           <div className="bmp-extended-keycode-editor-content-title">
-            Bmp Extended Keycode Editor
+            Bmp Extended Keycode Editor (ID:{this.props.extendedKeyId})
+          </div>
+          <div>
+            <ExtendedKindSelect
+              kind={this.state.extendedKind}
+              onChangeKind={(kind) => {
+                this.setState({ extendedKind: kind });
+              }}
+            ></ExtendedKindSelect>
+            <ExtendedKey
+              kind={this.state.extendedKind}
+              onUpdate={(extendedKeycode) => {}}
+            ></ExtendedKey>
           </div>
           <div className="bmp-extended-keycode-editor-content-footer">
             <Button
@@ -54,4 +77,66 @@ export default class BmpExtendedKeycodeEditor extends React.Component<
       </div>
     );
   }
+}
+
+function ExtendedKindSelect(props: {
+  kind: ExtendedKind;
+  onChangeKind: (kind: ExtendedKind) => void;
+}) {
+  return (
+    <Select
+      variant="standard"
+      value={props.kind}
+      onChange={(e) => {
+        props.onChangeKind(e.target.value as ExtendedKind);
+      }}
+    >
+      {Object.keys(ExtendedKind)
+        .filter((v) => isNaN(Number(v)))
+        .map((key) => {
+          return (
+            <MenuItem
+              key={`${key}`}
+              value={ExtendedKind[key as keyof typeof ExtendedKind]}
+            >
+              {key}
+            </MenuItem>
+          );
+        })}
+    </Select>
+  );
+}
+
+function ExtendedKey(props: {
+  kind: ExtendedKind;
+  onUpdate: (extendedKeycode: Uint8Array) => void;
+}) {
+  switch (props.kind) {
+    case ExtendedKind.TLT:
+      return <TltExtend onUpdate={props.onUpdate}></TltExtend>;
+    case ExtendedKind.LTE:
+      return <LteExtend onUpdate={props.onUpdate}></LteExtend>;
+    case ExtendedKind.TDH:
+      return <TdhExtend onUpdate={props.onUpdate}></TdhExtend>;
+    case ExtendedKind.TDD:
+      return <TddExtend onUpdate={props.onUpdate}></TddExtend>;
+    default:
+      return <div>None</div>;
+  }
+}
+
+function TltExtend(props: { onUpdate: (extendedKeycode: Uint8Array) => void }) {
+  return <div>TLT</div>;
+}
+
+function LteExtend(props: { onUpdate: (extendedKeycode: Uint8Array) => void }) {
+  return <div>LTE</div>;
+}
+
+function TddExtend(props: { onUpdate: (extendedKeycode: Uint8Array) => void }) {
+  return <div>TDD</div>;
+}
+
+function TdhExtend(props: { onUpdate: (extendedKeycode: Uint8Array) => void }) {
+  return <div>TDH</div>;
 }

--- a/src/components/configure/customkey/TabKey.tsx
+++ b/src/components/configure/customkey/TabKey.tsx
@@ -148,7 +148,7 @@ export default class TabKey extends React.Component<TabKeyProps, OwnState> {
 
   get basicKeymapsWithBmp() {
     if (this.props.bleMicroPro) {
-      const extendKeymaps = KeyCategory.bmp();
+      const extendKeymaps = KeyCategory.bmp(this.props.labelLang);
       return [...this.getBasicKeymaps(), ...extendKeymaps];
     } else {
       return this.getBasicKeymaps();

--- a/src/components/configure/header/Header.container.ts
+++ b/src/components/configure/header/Header.container.ts
@@ -20,6 +20,7 @@ const mapStateToProps = (state: RootState) => {
     vendorId: info?.vendorId || 0,
     showKeyboardList: !!kbd,
     remaps: state.app.remaps,
+    extendedKeycodeModified: state.configure.bmpExtendedKeycodeEditor.modified,
     auth: state.auth.instance,
     signedIn: state.app.signedIn,
   };

--- a/src/components/configure/header/Header.tsx
+++ b/src/components/configure/header/Header.tsx
@@ -103,12 +103,14 @@ export default class Header extends React.Component<HeaderProps, HeaderState> {
   }
 
   render() {
-    this.hasKeysToFlash = this.props.remaps!.reduce(
-      (has: boolean, v: { [pos: string]: IKeymap }) => {
-        return 0 < Object.values(v).length || has;
-      },
-      false
-    );
+    this.hasKeysToFlash =
+      this.props.extendedKeycodeModified ||
+      this.props.remaps!.reduce(
+        (has: boolean, v: { [pos: string]: IKeymap }) => {
+          return 0 < Object.values(v).length || has;
+        },
+        false
+      );
 
     let flashBtnState: FlashButtonState = this.hasKeysToFlash
       ? 'enable'

--- a/src/components/configure/keycap/Keycap.tsx
+++ b/src/components/configure/keycap/Keycap.tsx
@@ -303,7 +303,7 @@ type KeyLabelType = {
   optionChoiceLabel?: string;
   debug?: boolean;
 };
-function KeyLabel(props: KeyLabelType) {
+export function KeyLabel(props: KeyLabelType) {
   if (props.debug) {
     return (
       <React.Fragment>

--- a/src/components/configure/keycodekey/KeycodeKey.container.ts
+++ b/src/components/configure/keycodekey/KeycodeKey.container.ts
@@ -8,6 +8,7 @@ import {
 import { IKeycodeInfo } from '../../../services/hid/Hid';
 import { Key } from './KeyGen';
 import { MacroActionsThunk } from '../../../actions/macro.action';
+import { BmpExtendedKeycodeActionsThunk } from '../../../actions/bmpExtendedKeycode.action';
 
 export class KeycodeInfo implements IKeycodeInfo {
   readonly code: number;
@@ -54,6 +55,9 @@ const mapDispatchToProps = (_dispatch: any) => {
     },
     updateAnyKey: (index: number, anyKey: AnyKey) => {
       _dispatch(AnyKeycodeKeyActions.updateAnyKey(index, anyKey));
+    },
+    selectBmpExtendedKey: (key: Key) => {
+      _dispatch(BmpExtendedKeycodeActionsThunk.updateBmpExtendedKey(key));
     },
   };
 };

--- a/src/components/configure/keycodekey/KeycodeKey.tsx
+++ b/src/components/configure/keycodekey/KeycodeKey.tsx
@@ -57,6 +57,8 @@ export default class KeycodeKey extends React.Component<
     } else {
       if (value.keymap.kinds.includes('macro')) {
         this.props.selectMacroKey!(value);
+      } else if (value.keymap.kinds.includes('bmp-extended')) {
+        this.props.selectBmpExtendedKey!(value);
       } else {
         this.props.selectKey!(value);
       }

--- a/src/components/configure/keycodes/Keycodes.container.ts
+++ b/src/components/configure/keycodes/Keycodes.container.ts
@@ -12,6 +12,7 @@ const mapStateToProps = (state: RootState) => {
     layerCount: state.entities.device.layerCount,
     labelLang: state.app.labelLang,
     bleMicroPro: state.entities.device.bleMicroPro,
+    bmpExtendedKeycodes: state.entities.device.extendedKeycode,
     testMatrix: state.configure.keymapToolbar.testMatrix,
     macroBufferBytes: state.entities.device.macro.bufferBytes,
     macroMaxBufferSize: state.entities.device.macro.maxBufferSize,

--- a/src/components/configure/keycodes/Keycodes.tsx
+++ b/src/components/configure/keycodes/Keycodes.tsx
@@ -21,6 +21,7 @@ import {
   MacroBuffer,
 } from '../../../services/macro/Macro';
 import { KeymapCategory } from '../../../services/hid/KeycodeList';
+import { IBmpExtendedKeycode } from '../../../services/hid/bmp/BmpExtendedKeycode';
 
 type OwnProps = {};
 
@@ -53,12 +54,17 @@ export default class Keycodes extends React.Component<KeycodesProps, OwnState> {
 
   private addBmpCategory(
     categoryKeys: { [category: string]: Key[] },
+    bmpExtendedKeycodes: {
+      [id: number]: IBmpExtendedKeycode;
+    },
     macroEditMode: boolean
   ) {
     const bmpLabel: string = CATEGORY_LABEL_BMP;
     const bmp = macroEditMode
-      ? macroCodeFilter(KeyCategory.bmp())
-      : KeyCategory.bmp();
+      ? macroCodeFilter(
+          KeyCategory.bmp(this.props.labelLang!, bmpExtendedKeycodes)
+        )
+      : KeyCategory.bmp(this.props.labelLang!, bmpExtendedKeycodes);
     if (!Object.prototype.hasOwnProperty.call(categoryKeys, bmpLabel)) {
       categoryKeys[bmpLabel] = genKeys(bmp, this.props.labelLang!);
     }
@@ -194,7 +200,11 @@ export default class Keycodes extends React.Component<KeycodesProps, OwnState> {
       Midi: genKeys(midi, this.props.labelLang!),
     };
     if (this.props.bleMicroPro && !macroEditMode) {
-      this.addBmpCategory(categoryKeys, macroEditMode);
+      this.addBmpCategory(
+        categoryKeys,
+        this.props.bmpExtendedKeycodes!,
+        macroEditMode
+      );
     } else {
       this.removeBmpCategory(categoryKeys);
     }
@@ -243,7 +253,8 @@ export default class Keycodes extends React.Component<KeycodesProps, OwnState> {
   componentDidUpdate(prevProps: KeycodesProps) {
     if (
       this.props.labelLang != prevProps.labelLang ||
-      this.props.macroKey != prevProps.macroKey
+      this.props.macroKey != prevProps.macroKey ||
+      this.props.bmpExtendedKeycodes != prevProps.bmpExtendedKeycodes
     ) {
       const isMacroEditMode = Boolean(this.props.macroKey);
       this.refreshCategoryKeys(prevProps.labelLang || 'en-us', isMacroEditMode);

--- a/src/components/configure/keycodes/Keycodes.tsx
+++ b/src/components/configure/keycodes/Keycodes.tsx
@@ -9,7 +9,7 @@ import { IKeycodeCategory } from '../../../services/hid/Hid';
 import KeycodeAddKey from '../keycodekey/any/AddAnyKeycodeKey.container';
 import { KeyCategory } from '../../../services/hid/KeyCategoryList';
 import { genKeys, Key } from '../keycodekey/KeyGen';
-import { CATEGORY_LABEL_BMP } from '../../../services/hid/KeycodeInfoListBmp';
+import { CATEGORY_LABEL_BMP } from '../../../services/hid/bmp/KeycodeInfoListBmp';
 import { KeyboardLabelLang } from '../../../services/labellang/KeyLabelLangs';
 import {
   CATEGORY_LABEL_ASCII,

--- a/src/components/configure/keycodes/Keycodes.tsx
+++ b/src/components/configure/keycodes/Keycodes.tsx
@@ -9,7 +9,10 @@ import { IKeycodeCategory } from '../../../services/hid/Hid';
 import KeycodeAddKey from '../keycodekey/any/AddAnyKeycodeKey.container';
 import { KeyCategory } from '../../../services/hid/KeyCategoryList';
 import { genKeys, Key } from '../keycodekey/KeyGen';
-import { CATEGORY_LABEL_BMP } from '../../../services/hid/bmp/KeycodeInfoListBmp';
+import {
+  BMP_EXTENDED_MIN,
+  CATEGORY_LABEL_BMP,
+} from '../../../services/hid/bmp/KeycodeInfoListBmp';
 import { KeyboardLabelLang } from '../../../services/labellang/KeyLabelLangs';
 import {
   CATEGORY_LABEL_ASCII,
@@ -284,7 +287,10 @@ export default class Keycodes extends React.Component<KeycodesProps, OwnState> {
     let categoryKeys: { [name: string]: JSX.Element[] } = {};
     keys.forEach((key, index) => {
       const isMacro = key.keymap.kinds.includes('macro');
-      const isBmpExtended = key.keymap.kinds.includes('bmp-extended');
+      const isEditableBmpExtended =
+        key.keymap.kinds.includes('bmp-extended') &&
+        key.keymap.code - BMP_EXTENDED_MIN <
+          this.props.bmpExtendedKeycodes!.maxCount!;
       const subCategoryName: KeymapCategory =
         key.keymap.kinds[key.keymap.kinds.length - 1];
       if (
@@ -299,7 +305,7 @@ export default class Keycodes extends React.Component<KeycodesProps, OwnState> {
           key={`${this.state.category}${index}`}
           value={key}
           draggable={true}
-          clickable={(isMacro || isBmpExtended) && !macrEditMode}
+          clickable={(isMacro || isEditableBmpExtended) && !macrEditMode}
         />
       );
     });

--- a/src/components/configure/keycodes/Keycodes.tsx
+++ b/src/components/configure/keycodes/Keycodes.tsx
@@ -273,6 +273,7 @@ export default class Keycodes extends React.Component<KeycodesProps, OwnState> {
     let categoryKeys: { [name: string]: JSX.Element[] } = {};
     keys.forEach((key, index) => {
       const isMacro = key.keymap.kinds.includes('macro');
+      const isBmpExtended = key.keymap.kinds.includes('bmp-extended');
       const subCategoryName: KeymapCategory =
         key.keymap.kinds[key.keymap.kinds.length - 1];
       if (
@@ -287,7 +288,7 @@ export default class Keycodes extends React.Component<KeycodesProps, OwnState> {
           key={`${this.state.category}${index}`}
           value={key}
           draggable={true}
-          clickable={isMacro && !macrEditMode}
+          clickable={(isMacro || isBmpExtended) && !macrEditMode}
         />
       );
     });

--- a/src/components/configure/remap/Remap.container.ts
+++ b/src/components/configure/remap/Remap.container.ts
@@ -7,7 +7,7 @@ const mapStateToProps = (state: RootState) => {
     hoverKey: state.configure.keycodeKey.hoverKey,
     keyboardWidth: state.app.keyboardWidth, // DO NOT REMOVE!! This component should be updated when the keyboardWidth is set
     macroKey: state.configure.macroEditor.key,
-    bmpExtendedKey: state.configure.bmpExtendedKeycodeEditor.key,
+    bmpExtendedKey: state.configure.bmpExtendedKeycodeEditor.id,
   };
 };
 export type RemapStateType = ReturnType<typeof mapStateToProps>;

--- a/src/components/configure/remap/Remap.container.ts
+++ b/src/components/configure/remap/Remap.container.ts
@@ -7,6 +7,7 @@ const mapStateToProps = (state: RootState) => {
     hoverKey: state.configure.keycodeKey.hoverKey,
     keyboardWidth: state.app.keyboardWidth, // DO NOT REMOVE!! This component should be updated when the keyboardWidth is set
     macroKey: state.configure.macroEditor.key,
+    bmpExtendedKey: state.configure.bmpExtendedKeycodeEditor.key,
   };
 };
 export type RemapStateType = ReturnType<typeof mapStateToProps>;

--- a/src/components/configure/remap/Remap.scss
+++ b/src/components/configure/remap/Remap.scss
@@ -28,6 +28,12 @@
     padding-bottom: 32px;
     background-color: white;
   }
+  .bmp-extended {
+    display: flex;
+    flex-direction: column;
+    padding-bottom: 32px;
+    background-color: white;
+  }
 }
 .keycode {
   display: flex;

--- a/src/components/configure/remap/Remap.tsx
+++ b/src/components/configure/remap/Remap.tsx
@@ -8,6 +8,7 @@ import { RemapActionsType, RemapStateType } from './Remap.container';
 import { Key } from '../keycodekey/KeyGen';
 import { kinds2CategoryLabel } from '../customkey/AutocompleteKeys';
 import MacroEditor from '../macroeditor/MacroEditor.container';
+import BmpExtendedKeycodeEditor from '../bmpExtendedKeycodeEditor/BmpExtendedKeycodeEditor.container';
 
 type OwnProp = {};
 type RemapPropType = OwnProp &
@@ -43,7 +44,15 @@ export default class Remap extends React.Component<RemapPropType, OwnState> {
           className="keyboard-wrapper"
           style={{ minWidth: this.state.minWidth }}
         >
-          <EditMode mode={this.props.macroKey ? 'macro' : 'keymap'} />
+          <EditMode
+            mode={
+              this.props.macroKey
+                ? 'macro'
+                : this.props.bmpExtendedKey
+                ? 'bmpExtended'
+                : 'keymap'
+            }
+          />
         </div>
         <div className="keycode" style={{ minWidth: this.state.minWidth }}>
           <Keycodes />
@@ -55,7 +64,7 @@ export default class Remap extends React.Component<RemapPropType, OwnState> {
 }
 
 type EditModeType = {
-  mode: 'keymap' | 'macro';
+  mode: 'keymap' | 'macro' | 'bmpExtended';
 };
 function EditMode(props: EditModeType) {
   if (props.mode === 'keymap') {
@@ -68,6 +77,12 @@ function EditMode(props: EditModeType) {
     return (
       <div className="macro">
         <MacroEditor />
+      </div>
+    );
+  } else if (props.mode === 'bmpExtended') {
+    return (
+      <div className="bmp-extended">
+        <BmpExtendedKeycodeEditor />
       </div>
     );
   } else {

--- a/src/components/configure/remap/Remap.tsx
+++ b/src/components/configure/remap/Remap.tsx
@@ -48,7 +48,7 @@ export default class Remap extends React.Component<RemapPropType, OwnState> {
             mode={
               this.props.macroKey
                 ? 'macro'
-                : this.props.bmpExtendedKey
+                : this.props.bmpExtendedKey != null
                 ? 'bmpExtended'
                 : 'keymap'
             }

--- a/src/services/hid/Commands.ts
+++ b/src/services/hid/Commands.ts
@@ -5,6 +5,7 @@ import {
 } from './WebHid';
 import { ICommand } from './Hid';
 import { outputUint8Array } from '../../utils/ArrayUtils';
+import { IBmpExtendedKeycode } from './bmp/BmpExtendedKeycode';
 
 export abstract class AbstractCommand<
   TRequest extends ICommandRequest,
@@ -459,7 +460,6 @@ export class BleMicroProGetExtendedKeycodeCommand extends AbstractCommand<
     return new Uint8Array([0x02, 0xfe, 0x02, req.index & 0xff]);
   }
 
-  // eslint-disable-next-line no-unused-vars
   createResponse(
     resultArray: Uint8Array
   ): IBleMicroProGetExtendedKeycodeCommandResponse {
@@ -473,6 +473,40 @@ export class BleMicroProGetExtendedKeycodeCommand extends AbstractCommand<
       resultArray[0] === 0x02 &&
       resultArray[1] === 0xfe &&
       resultArray[2] === 0x02
+    );
+  }
+}
+
+export interface IBleMicroProSetExtendedKeycodeCommandRequest
+  extends ICommandRequest {
+  index: number;
+  extendedKeycode: IBmpExtendedKeycode;
+}
+
+export class BleMicroProSetExtendedKeycodeCommand extends AbstractCommand<
+  IBleMicroProSetExtendedKeycodeCommandRequest,
+  ICommandResponse
+> {
+  createReport(): Uint8Array {
+    const req = this.getRequest();
+    const cmd = new Uint8Array(10);
+    cmd.set([0x03, 0xfe, 0x02, req.index & 0xff], 0);
+    cmd.set(req.extendedKeycode.getBytes(), 4);
+    return cmd;
+  }
+
+  // eslint-disable-next-line no-unused-vars
+  createResponse(resultArray: Uint8Array): ICommandResponse {
+    return {};
+  }
+
+  isSameRequest(resultArray: Uint8Array): boolean {
+    const req = this.getRequest();
+    return (
+      resultArray[0] === 0x03 &&
+      resultArray[1] === 0xfe &&
+      resultArray[2] === 0x02 &&
+      resultArray[3] === (req.index & 0xff)
     );
   }
 }

--- a/src/services/hid/Commands.ts
+++ b/src/services/hid/Commands.ts
@@ -432,7 +432,11 @@ export class BleMicroProGetExtendedKeycodeCountCommand extends AbstractCommand<
   }
 
   isSameRequest(resultArray: Uint8Array): boolean {
-    return resultArray[0] === 0x02 && resultArray[1] === 0xfe && resultArray[2] === 0x01;
+    return (
+      resultArray[0] === 0x02 &&
+      resultArray[1] === 0xfe &&
+      resultArray[2] === 0x01
+    );
   }
 }
 
@@ -460,12 +464,16 @@ export class BleMicroProGetExtendedKeycodeCommand extends AbstractCommand<
     resultArray: Uint8Array
   ): IBleMicroProGetExtendedKeycodeCommandResponse {
     return {
-      buffer: resultArray.slice(4,10),
+      buffer: resultArray.slice(4, 10),
     };
   }
 
   isSameRequest(resultArray: Uint8Array): boolean {
-    return resultArray[0] === 0x02 && resultArray[1] === 0xfe && resultArray[2] === 0x02;
+    return (
+      resultArray[0] === 0x02 &&
+      resultArray[1] === 0xfe &&
+      resultArray[2] === 0x02
+    );
   }
 }
 export interface IDynamicKeymapMacroGetCountResponse extends ICommandResponse {

--- a/src/services/hid/Commands.ts
+++ b/src/services/hid/Commands.ts
@@ -409,6 +409,33 @@ export class BleMicroProStoreKeymapPersistentlyCommand extends AbstractCommand<
   }
 }
 
+export interface IBleMicroProGetExtendedKeycodeCountCommandResponse
+  extends ICommandResponse {
+  count: number;
+}
+
+export class BleMicroProGetExtendedKeycodeCountCommand extends AbstractCommand<
+  ICommandRequest,
+  IBleMicroProGetExtendedKeycodeCountCommandResponse
+> {
+  createReport(): Uint8Array {
+    return new Uint8Array([0x02, 0xfe, 0x01]);
+  }
+
+  // eslint-disable-next-line no-unused-vars
+  createResponse(
+    resultArray: Uint8Array
+  ): IBleMicroProGetExtendedKeycodeCountCommandResponse {
+    return {
+      count: resultArray[3],
+    };
+  }
+
+  isSameRequest(resultArray: Uint8Array): boolean {
+    return resultArray[0] === 0x02 && resultArray[1] === 0xfe && resultArray[2] === 0x01;
+  }
+}
+
 export interface IDynamicKeymapMacroGetCountResponse extends ICommandResponse {
   count: number;
 }

--- a/src/services/hid/Commands.ts
+++ b/src/services/hid/Commands.ts
@@ -436,6 +436,38 @@ export class BleMicroProGetExtendedKeycodeCountCommand extends AbstractCommand<
   }
 }
 
+export interface IBleMicroProGetExtendedKeycodeCommandRequest
+  extends ICommandRequest {
+  index: number;
+}
+
+export interface IBleMicroProGetExtendedKeycodeCommandResponse
+  extends ICommandResponse {
+  buffer: Uint8Array;
+}
+
+export class BleMicroProGetExtendedKeycodeCommand extends AbstractCommand<
+  IBleMicroProGetExtendedKeycodeCommandRequest,
+  IBleMicroProGetExtendedKeycodeCommandResponse
+> {
+  createReport(): Uint8Array {
+    const req = this.getRequest();
+    return new Uint8Array([0x02, 0xfe, 0x02, req.index & 0xff]);
+  }
+
+  // eslint-disable-next-line no-unused-vars
+  createResponse(
+    resultArray: Uint8Array
+  ): IBleMicroProGetExtendedKeycodeCommandResponse {
+    return {
+      buffer: resultArray.slice(4,10),
+    };
+  }
+
+  isSameRequest(resultArray: Uint8Array): boolean {
+    return resultArray[0] === 0x02 && resultArray[1] === 0xfe && resultArray[2] === 0x02;
+  }
+}
 export interface IDynamicKeymapMacroGetCountResponse extends ICommandResponse {
   count: number;
 }

--- a/src/services/hid/Composition.ts
+++ b/src/services/hid/Composition.ts
@@ -46,6 +46,7 @@ import {
   BMP_EXTENDED_MIN,
   BMP_EXTENDED_MAX,
 } from './bmp/KeycodeInfoListBmp';
+import { IBmpExtendedKeycode } from './bmp/BmpExtendedKeycode';
 
 export const QK_BASIC_MIN = 0b0000_0000_0000_0000;
 export const QK_BASIC_MAX = 0b0000_0000_1111_1111;
@@ -1486,7 +1487,12 @@ export class LooseKeycodeComposition implements ILooseKeycodeComposition {
       });
   }
 
-  static genExtendsBmpExKeymaps(): IKeymap[] {
+  static genExtendsBmpExKeymaps(
+    labelLang: KeyboardLabelLang,
+    extendedKeycodes?: {
+      [id: number]: IBmpExtendedKeycode;
+    }
+  ): IKeymap[] {
     return bmpKeyInfoList
       .filter(
         (k) =>
@@ -1494,6 +1500,7 @@ export class LooseKeycodeComposition implements ILooseKeycodeComposition {
           k.keycodeInfo.code <= BMP_EXTENDED_MAX
       )
       .map((info) => {
+        const id = info.keycodeInfo.code - BMP_EXTENDED_MIN;
         return {
           code: info.keycodeInfo.code,
           isAny: false,
@@ -1501,7 +1508,9 @@ export class LooseKeycodeComposition implements ILooseKeycodeComposition {
           modifiers: [],
           keycodeInfo: info.keycodeInfo,
           kinds: ['extends', 'bmp-extended'],
-          desc: 'Extended keycode',
+          desc: extendedKeycodes
+            ? extendedKeycodes[id]?.getDescription(labelLang)
+            : '',
         };
       });
   }
@@ -1969,7 +1978,7 @@ export class KeycodeCompositionFactory implements IKeycodeCompositionFactory {
     if (keymap === undefined) {
       keymap = [
         ...LooseKeycodeComposition.genExtendsBmpKeymaps(),
-        ...LooseKeycodeComposition.genExtendsBmpExKeymaps(),
+        ...LooseKeycodeComposition.genExtendsBmpExKeymaps(this.labelLang),
       ].find((km) => km.code === this.code);
     }
 

--- a/src/services/hid/Composition.ts
+++ b/src/services/hid/Composition.ts
@@ -45,7 +45,7 @@ import {
   bmpKeyInfoList,
   BMP_EXTENDED_MIN,
   BMP_EXTENDED_MAX,
-} from './KeycodeInfoListBmp';
+} from './bmp/KeycodeInfoListBmp';
 
 export const QK_BASIC_MIN = 0b0000_0000_0000_0000;
 export const QK_BASIC_MAX = 0b0000_0000_1111_1111;

--- a/src/services/hid/Hid.mock.ts
+++ b/src/services/hid/Hid.mock.ts
@@ -1,5 +1,6 @@
 /* eslint-disable no-unused-vars */
 import { KeyboardLabelLang } from '../labellang/KeyLabelLangs';
+import { BmpExtendedKeycode } from './bmp/BmpExtendedKeycode';
 import { MOD_LEFT } from './Composition';
 import {
   ICommand,
@@ -186,7 +187,10 @@ export const mockIKeyboad: IKeyboard = {
   },
   getBmpExtendedKeycode: () => {
     return new Promise((resolve) => {
-      resolve({ success: true, buffer: new Uint8Array(6) });
+      resolve({
+        success: true,
+        extendedKeycode: new BmpExtendedKeycode(new Uint8Array(6)),
+      });
     });
   },
   fetchSwitchMatrixState: () => {

--- a/src/services/hid/Hid.mock.ts
+++ b/src/services/hid/Hid.mock.ts
@@ -184,7 +184,7 @@ export const mockIKeyboad: IKeyboard = {
       resolve({ success: true, count: 32 });
     });
   },
-  getBmpExtendedKeycode: ()  => {
+  getBmpExtendedKeycode: () => {
     return new Promise((resolve) => {
       resolve({ success: true, buffer: new Uint8Array(6) });
     });

--- a/src/services/hid/Hid.mock.ts
+++ b/src/services/hid/Hid.mock.ts
@@ -193,6 +193,13 @@ export const mockIKeyboad: IKeyboard = {
       });
     });
   },
+  setBmpExtendedKeycode: () => {
+    return new Promise((resolve) => {
+      resolve({
+        success: true,
+      });
+    });
+  },
   fetchSwitchMatrixState: () => {
     return new Promise<IResult>((resolve) => {
       resolve({ success: true });

--- a/src/services/hid/Hid.mock.ts
+++ b/src/services/hid/Hid.mock.ts
@@ -189,7 +189,9 @@ export const mockIKeyboad: IKeyboard = {
     return new Promise((resolve) => {
       resolve({
         success: true,
-        extendedKeycode: new BmpExtendedKeycode(new Uint8Array(6)),
+        extendedKeycode: BmpExtendedKeycode.createExtendedKeycode(
+          new Uint8Array(6)
+        ),
       });
     });
   },

--- a/src/services/hid/Hid.mock.ts
+++ b/src/services/hid/Hid.mock.ts
@@ -6,6 +6,7 @@ import {
   IConnectionEventHandler,
   IConnectParams,
   IFetchLayoutOptionsResult,
+  IGetBmpExtendedKeycodeCountResult,
   IGetMacroCountResult,
   IHid,
   IKeyboard,
@@ -177,6 +178,11 @@ export const mockIKeyboad: IKeyboard = {
   storeKeymapPersistentlyForBleMicroPro: (): Promise<IResult> => {
     return new Promise<IResult>((resolve) => {
       resolve({ success: true });
+    });
+  },
+  getBmpExtendedKeycodeCount: (): Promise<IGetBmpExtendedKeycodeCountResult> => {
+    return new Promise<IGetBmpExtendedKeycodeCountResult>((resolve) => {
+      resolve({ success: true, count: 32 });
     });
   },
   fetchSwitchMatrixState: () => {

--- a/src/services/hid/Hid.mock.ts
+++ b/src/services/hid/Hid.mock.ts
@@ -6,7 +6,6 @@ import {
   IConnectionEventHandler,
   IConnectParams,
   IFetchLayoutOptionsResult,
-  IGetBmpExtendedKeycodeCountResult,
   IGetMacroCountResult,
   IHid,
   IKeyboard,
@@ -180,9 +179,14 @@ export const mockIKeyboad: IKeyboard = {
       resolve({ success: true });
     });
   },
-  getBmpExtendedKeycodeCount: (): Promise<IGetBmpExtendedKeycodeCountResult> => {
-    return new Promise<IGetBmpExtendedKeycodeCountResult>((resolve) => {
+  getBmpExtendedKeycodeCount: () => {
+    return new Promise((resolve) => {
       resolve({ success: true, count: 32 });
+    });
+  },
+  getBmpExtendedKeycode: ()  => {
+    return new Promise((resolve) => {
+      resolve({ success: true, buffer: new Uint8Array(6) });
     });
   },
   fetchSwitchMatrixState: () => {

--- a/src/services/hid/Hid.ts
+++ b/src/services/hid/Hid.ts
@@ -173,6 +173,10 @@ export interface IKeyboard {
   storeKeymapPersistentlyForBleMicroPro(): Promise<IResult>;
   getBmpExtendedKeycodeCount(): Promise<IGetBmpExtendedKeycodeCountResult>;
   getBmpExtendedKeycode(index: number): Promise<IGetBmpExtendedKeycodeResult>;
+  setBmpExtendedKeycode(
+    index: number,
+    extendedKeycode: IBmpExtendedKeycode
+  ): Promise<IResult>;
   fetchSwitchMatrixState(): Promise<IFetchSwitchMatrixStateResult>;
   fetchLayoutOptions(): Promise<IFetchLayoutOptionsResult>;
   updateLayoutOptions(value: number): Promise<IResult>;

--- a/src/services/hid/Hid.ts
+++ b/src/services/hid/Hid.ts
@@ -126,6 +126,9 @@ export interface IFetchMacroBufferResult extends IResult {
   buffer?: Uint8Array;
 }
 
+export interface IGetBmpExtendedKeycodeCountResult extends IResult {
+  count?: number;
+}
 export interface IKeyboard {
   getDevice(): HIDDevice;
   getHid(): IHid;
@@ -162,6 +165,7 @@ export interface IKeyboard {
   updateRGBLightColor(hue: number, sat: number): Promise<IResult>;
   resetDynamicKeymap(): Promise<IResult>;
   storeKeymapPersistentlyForBleMicroPro(): Promise<IResult>;
+  getBmpExtendedKeycodeCount(): Promise<IGetBmpExtendedKeycodeCountResult>;
   fetchSwitchMatrixState(): Promise<IFetchSwitchMatrixStateResult>;
   fetchLayoutOptions(): Promise<IFetchLayoutOptionsResult>;
   updateLayoutOptions(value: number): Promise<IResult>;

--- a/src/services/hid/Hid.ts
+++ b/src/services/hid/Hid.ts
@@ -129,6 +129,11 @@ export interface IFetchMacroBufferResult extends IResult {
 export interface IGetBmpExtendedKeycodeCountResult extends IResult {
   count?: number;
 }
+
+export interface IGetBmpExtendedKeycodeResult extends IResult {
+  buffer?: Uint8Array;
+}
+
 export interface IKeyboard {
   getDevice(): HIDDevice;
   getHid(): IHid;
@@ -166,6 +171,7 @@ export interface IKeyboard {
   resetDynamicKeymap(): Promise<IResult>;
   storeKeymapPersistentlyForBleMicroPro(): Promise<IResult>;
   getBmpExtendedKeycodeCount(): Promise<IGetBmpExtendedKeycodeCountResult>;
+  getBmpExtendedKeycode(index: number): Promise<IGetBmpExtendedKeycodeResult>;
   fetchSwitchMatrixState(): Promise<IFetchSwitchMatrixStateResult>;
   fetchLayoutOptions(): Promise<IFetchLayoutOptionsResult>;
   updateLayoutOptions(value: number): Promise<IResult>;

--- a/src/services/hid/Hid.ts
+++ b/src/services/hid/Hid.ts
@@ -1,6 +1,7 @@
 /* eslint-disable no-undef */
 /* eslint-disable no-unused-vars */
 import { KeyboardLabelLang } from '../labellang/KeyLabelLangs';
+import { IBmpExtendedKeycode } from './bmp/BmpExtendedKeycode';
 import {
   IKeycodeCompositionFactory,
   IMod,
@@ -131,7 +132,7 @@ export interface IGetBmpExtendedKeycodeCountResult extends IResult {
 }
 
 export interface IGetBmpExtendedKeycodeResult extends IResult {
-  buffer?: Uint8Array;
+  extendedKeycode?: IBmpExtendedKeycode;
 }
 
 export interface IKeyboard {

--- a/src/services/hid/KeyCategoryList.ts
+++ b/src/services/hid/KeyCategoryList.ts
@@ -14,6 +14,7 @@ import {
 import { IKeycodeCategoryInfo, IKeymap } from './Hid';
 import { range } from '../../utils/ArrayUtils';
 import { encodeMacroText, IMacroBuffer } from '../macro/Macro';
+import { IBmpExtendedKeycode } from './bmp/BmpExtendedKeycode';
 
 export class KeyCategory {
   private static _basic: { [pos: string]: IKeymap[] } = {};
@@ -164,15 +165,19 @@ export class KeyCategory {
     return KeyCategory._device[labelLang];
   }
 
-  static bmp(): IKeymap[] {
-    if (KeyCategory._bmp) {
-      return KeyCategory._bmp;
+  static bmp(
+    labelLang: KeyboardLabelLang,
+    extendedKeycodes?: {
+      [id: number]: IBmpExtendedKeycode;
     }
-
+  ): IKeymap[] {
     const looseKeymaps: IKeymap[] =
       LooseKeycodeComposition.genExtendsBmpKeymaps();
     const extendedKeymaps: IKeymap[] =
-      LooseKeycodeComposition.genExtendsBmpExKeymaps();
+      LooseKeycodeComposition.genExtendsBmpExKeymaps(
+        labelLang,
+        extendedKeycodes
+      );
     KeyCategory._bmp = [...looseKeymaps, ...extendedKeymaps];
     return KeyCategory._bmp;
   }
@@ -442,15 +447,5 @@ export const KEY_CATEGORY_ASCII: IKeycodeCategoryInfo = {
     33, 34, 35, 36, 37, 38, 40, 41, 42, 43, 60, 62, 63, 64, 65, 66, 67, 68, 69,
     70, 71, 72, 73, 74, 75, 76, 77, 78, 79, 80, 81, 82, 83, 84, 85, 86, 87, 88,
     89, 90, 94, 95, 123, 124, 125, 126,
-  ],
-};
-
-// BMP Extended
-export const KEY_SUB_CATEGORY_BMP_EXTENDED: IKeycodeCategoryInfo = {
-  kinds: ['extends', 'bmp', 'bmp-extended'],
-  codes: [
-    24095, 24096, 24097, 24098, 24099, 24100, 24101, 24102, 24103, 24104, 24105,
-    24106, 24107, 24108, 24109, 24110, 24111, 24112, 24113, 24114, 24115, 24116,
-    24117, 24118, 24119, 24120, 24121, 24122, 24123, 24124, 24125, 24126,
   ],
 };

--- a/src/services/hid/KeyCategoryList.ts
+++ b/src/services/hid/KeyCategoryList.ts
@@ -171,7 +171,9 @@ export class KeyCategory {
 
     const looseKeymaps: IKeymap[] =
       LooseKeycodeComposition.genExtendsBmpKeymaps();
-    KeyCategory._bmp = looseKeymaps;
+    const extendedKeymaps: IKeymap[] =
+      LooseKeycodeComposition.genExtendsBmpExKeymaps();
+    KeyCategory._bmp = [...looseKeymaps, ...extendedKeymaps];
     return KeyCategory._bmp;
   }
 
@@ -440,5 +442,15 @@ export const KEY_CATEGORY_ASCII: IKeycodeCategoryInfo = {
     33, 34, 35, 36, 37, 38, 40, 41, 42, 43, 60, 62, 63, 64, 65, 66, 67, 68, 69,
     70, 71, 72, 73, 74, 75, 76, 77, 78, 79, 80, 81, 82, 83, 84, 85, 86, 87, 88,
     89, 90, 94, 95, 123, 124, 125, 126,
+  ],
+};
+
+// BMP Extended
+export const KEY_SUB_CATEGORY_BMP_EXTENDED: IKeycodeCategoryInfo = {
+  kinds: ['extends', 'bmp', 'bmp-extended'],
+  codes: [
+    24095, 24096, 24097, 24098, 24099, 24100, 24101, 24102, 24103, 24104, 24105,
+    24106, 24107, 24108, 24109, 24110, 24111, 24112, 24113, 24114, 24115, 24116,
+    24117, 24118, 24119, 24120, 24121, 24122, 24123, 24124, 24125, 24126,
   ],
 };

--- a/src/services/hid/KeycodeInfoListBmp.ts
+++ b/src/services/hid/KeycodeInfoListBmp.ts
@@ -1,6 +1,8 @@
 import { KeyInfo } from './KeycodeInfoList';
 
 export const CATEGORY_LABEL_BMP = 'BMP';
+export const BMP_EXTENDED_MIN = 24096;
+export const BMP_EXTENDED_MAX = 24127;
 
 export const bmpKeyInfoList: KeyInfo[] = [
   {
@@ -385,6 +387,402 @@ export const bmpKeyInfoList: KeyInfo[] = [
       },
       label: 'xKANA',
       keywords: [],
+    },
+  },
+  {
+    desc: 'Extended keycode 0',
+    keycodeInfo: {
+      code: 24096,
+      name: {
+        long: 'EXTENDED0',
+        short: 'Ex0',
+      },
+      label: 'Ex0',
+      keywords: ['ex0'],
+    },
+  },
+  {
+    desc: 'Extended keycode 1',
+    keycodeInfo: {
+      code: 24097,
+      name: {
+        long: 'EXTENDED1',
+        short: 'Ex1',
+      },
+      label: 'Ex1',
+      keywords: ['ex1'],
+    },
+  },
+  {
+    desc: 'Extended keycode 2',
+    keycodeInfo: {
+      code: 24098,
+      name: {
+        long: 'EXTENDED2',
+        short: 'Ex2',
+      },
+      label: 'Ex2',
+      keywords: ['ex2'],
+    },
+  },
+  {
+    desc: 'Extended keycode 3',
+    keycodeInfo: {
+      code: 24099,
+      name: {
+        long: 'EXTENDED3',
+        short: 'Ex3',
+      },
+      label: 'Ex3',
+      keywords: ['ex3'],
+    },
+  },
+  {
+    desc: 'Extended keycode 4',
+    keycodeInfo: {
+      code: 24100,
+      name: {
+        long: 'EXTENDED4',
+        short: 'Ex4',
+      },
+      label: 'Ex4',
+      keywords: ['ex4'],
+    },
+  },
+  {
+    desc: 'Extended keycode 5',
+    keycodeInfo: {
+      code: 24101,
+      name: {
+        long: 'EXTENDED5',
+        short: 'Ex5',
+      },
+      label: 'Ex5',
+      keywords: ['ex5'],
+    },
+  },
+  {
+    desc: 'Extended keycode 6',
+    keycodeInfo: {
+      code: 24102,
+      name: {
+        long: 'EXTENDED6',
+        short: 'Ex6',
+      },
+      label: 'Ex6',
+      keywords: ['ex6'],
+    },
+  },
+  {
+    desc: 'Extended keycode 7',
+    keycodeInfo: {
+      code: 24103,
+      name: {
+        long: 'EXTENDED7',
+        short: 'Ex7',
+      },
+      label: 'Ex7',
+      keywords: ['ex7'],
+    },
+  },
+  {
+    desc: 'Extended keycode 8',
+    keycodeInfo: {
+      code: 24104,
+      name: {
+        long: 'EXTENDED8',
+        short: 'Ex8',
+      },
+      label: 'Ex8',
+      keywords: ['ex8'],
+    },
+  },
+  {
+    desc: 'Extended keycode 9',
+    keycodeInfo: {
+      code: 24105,
+      name: {
+        long: 'EXTENDED9',
+        short: 'Ex9',
+      },
+      label: 'Ex9',
+      keywords: ['ex9'],
+    },
+  },
+  {
+    desc: 'Extended keycode 10',
+    keycodeInfo: {
+      code: 24106,
+      name: {
+        long: 'EXTENDED10',
+        short: 'Ex10',
+      },
+      label: 'Ex10',
+      keywords: ['ex10'],
+    },
+  },
+  {
+    desc: 'Extended keycode 11',
+    keycodeInfo: {
+      code: 24107,
+      name: {
+        long: 'EXTENDED11',
+        short: 'Ex11',
+      },
+      label: 'Ex11',
+      keywords: ['ex11'],
+    },
+  },
+  {
+    desc: 'Extended keycode 11',
+    keycodeInfo: {
+      code: 24107,
+      name: {
+        long: 'EXTENDED11',
+        short: 'Ex11',
+      },
+      label: 'Ex11',
+      keywords: ['ex11'],
+    },
+  },
+  {
+    desc: 'Extended keycode 12',
+    keycodeInfo: {
+      code: 24108,
+      name: {
+        long: 'EXTENDED12',
+        short: 'Ex12',
+      },
+      label: 'Ex12',
+      keywords: ['ex12'],
+    },
+  },
+  {
+    desc: 'Extended keycode 13',
+    keycodeInfo: {
+      code: 24109,
+      name: {
+        long: 'EXTENDED13',
+        short: 'Ex13',
+      },
+      label: 'Ex13',
+      keywords: ['ex13'],
+    },
+  },
+  {
+    desc: 'Extended keycode 14',
+    keycodeInfo: {
+      code: 24110,
+      name: {
+        long: 'EXTENDED14',
+        short: 'Ex14',
+      },
+      label: 'Ex14',
+      keywords: ['ex14'],
+    },
+  },
+  {
+    desc: 'Extended keycode 15',
+    keycodeInfo: {
+      code: 24111,
+      name: {
+        long: 'EXTENDED15',
+        short: 'Ex15',
+      },
+      label: 'Ex15',
+      keywords: ['ex15'],
+    },
+  },
+  {
+    desc: 'Extended keycode 16',
+    keycodeInfo: {
+      code: 24112,
+      name: {
+        long: 'EXTENDED16',
+        short: 'Ex16',
+      },
+      label: 'Ex16',
+      keywords: ['ex16'],
+    },
+  },
+  {
+    desc: 'Extended keycode 17',
+    keycodeInfo: {
+      code: 24113,
+      name: {
+        long: 'EXTENDED17',
+        short: 'Ex17',
+      },
+      label: 'Ex17',
+      keywords: ['ex17'],
+    },
+  },
+  {
+    desc: 'Extended keycode 18',
+    keycodeInfo: {
+      code: 24114,
+      name: {
+        long: 'EXTENDED18',
+        short: 'Ex18',
+      },
+      label: 'Ex18',
+      keywords: ['ex18'],
+    },
+  },
+  {
+    desc: 'Extended keycode 19',
+    keycodeInfo: {
+      code: 24115,
+      name: {
+        long: 'EXTENDED19',
+        short: 'Ex19',
+      },
+      label: 'Ex19',
+      keywords: ['ex19'],
+    },
+  },
+  {
+    desc: 'Extended keycode 20',
+    keycodeInfo: {
+      code: 24116,
+      name: {
+        long: 'EXTENDED20',
+        short: 'Ex20',
+      },
+      label: 'Ex20',
+      keywords: ['ex20'],
+    },
+  },
+  {
+    desc: 'Extended keycode 21',
+    keycodeInfo: {
+      code: 24117,
+      name: {
+        long: 'EXTENDED21',
+        short: 'Ex21',
+      },
+      label: 'Ex21',
+      keywords: ['ex21'],
+    },
+  },
+  {
+    desc: 'Extended keycode 22',
+    keycodeInfo: {
+      code: 24118,
+      name: {
+        long: 'EXTENDED22',
+        short: 'Ex22',
+      },
+      label: 'Ex22',
+      keywords: ['ex22'],
+    },
+  },
+  {
+    desc: 'Extended keycode 23',
+    keycodeInfo: {
+      code: 24119,
+      name: {
+        long: 'EXTENDED23',
+        short: 'Ex23',
+      },
+      label: 'Ex23',
+      keywords: ['ex23'],
+    },
+  },
+  {
+    desc: 'Extended keycode 24',
+    keycodeInfo: {
+      code: 24120,
+      name: {
+        long: 'EXTENDED24',
+        short: 'Ex24',
+      },
+      label: 'Ex24',
+      keywords: ['ex24'],
+    },
+  },
+  {
+    desc: 'Extended keycode 25',
+    keycodeInfo: {
+      code: 24121,
+      name: {
+        long: 'EXTENDED25',
+        short: 'Ex25',
+      },
+      label: 'Ex25',
+      keywords: ['ex25'],
+    },
+  },
+  {
+    desc: 'Extended keycode 26',
+    keycodeInfo: {
+      code: 24122,
+      name: {
+        long: 'EXTENDED26',
+        short: 'Ex26',
+      },
+      label: 'Ex26',
+      keywords: ['ex26'],
+    },
+  },
+  {
+    desc: 'Extended keycode 27',
+    keycodeInfo: {
+      code: 24123,
+      name: {
+        long: 'EXTENDED27',
+        short: 'Ex27',
+      },
+      label: 'Ex27',
+      keywords: ['ex27'],
+    },
+  },
+  {
+    desc: 'Extended keycode 28',
+    keycodeInfo: {
+      code: 24124,
+      name: {
+        long: 'EXTENDED28',
+        short: 'Ex28',
+      },
+      label: 'Ex28',
+      keywords: ['ex28'],
+    },
+  },
+  {
+    desc: 'Extended keycode 29',
+    keycodeInfo: {
+      code: 24125,
+      name: {
+        long: 'EXTENDED29',
+        short: 'Ex29',
+      },
+      label: 'Ex29',
+      keywords: ['ex29'],
+    },
+  },
+  {
+    desc: 'Extended keycode 30',
+    keycodeInfo: {
+      code: 24126,
+      name: {
+        long: 'EXTENDED30',
+        short: 'Ex30',
+      },
+      label: 'Ex30',
+      keywords: ['ex30'],
+    },
+  },
+  {
+    desc: 'Extended keycode 31',
+    keycodeInfo: {
+      code: 24127,
+      name: {
+        long: 'EXTENDED31',
+        short: 'Ex31',
+      },
+      label: 'Ex31',
+      keywords: ['ex31'],
     },
   },
 ];

--- a/src/services/hid/KeycodeList.ts
+++ b/src/services/hid/KeycodeList.ts
@@ -42,6 +42,7 @@ export type KeymapCategory =
   | 'us-symbol'
   | 'extends'
   | 'bmp'
+  | 'bmp-extended'
   | 'combo'
   | 'midi'
   | 'notes'

--- a/src/services/hid/WebHid.ts
+++ b/src/services/hid/WebHid.ts
@@ -20,10 +20,12 @@ import {
   IGetMacroCountResult,
   IGetMacroBufferSizeResult,
   IFetchMacroBufferResult,
+  IGetBmpExtendedKeycodeCountResult,
 } from './Hid';
 import { KeycodeList } from './KeycodeList';
 import {
   BleMicroProStoreKeymapPersistentlyCommand,
+  BleMicroProGetExtendedKeycodeCountCommand,
   DynamicKeymapGetLayerCountCommand,
   DynamicKeymapMacroGetBufferCommand,
   DynamicKeymapMacroGetBufferSizeCommand,
@@ -695,6 +697,24 @@ export class Keyboard implements IKeyboard {
           }
         }
       );
+      return this.enqueue(command);
+    });
+  }
+
+  getBmpExtendedKeycodeCount(): Promise<IGetBmpExtendedKeycodeCountResult> {
+    return new Promise<IGetBmpExtendedKeycodeCountResult>((resolve)=>{
+      const command = new BleMicroProGetExtendedKeycodeCountCommand({},
+        async (result) => {
+          if (result.success) {
+            resolve({ success: true, count: result.response!.count });
+          } else {
+            resolve({
+              success: false,
+              error: result.error,
+              cause: result.cause,
+            });
+          }
+        });
       return this.enqueue(command);
     });
   }

--- a/src/services/hid/WebHid.ts
+++ b/src/services/hid/WebHid.ts
@@ -738,7 +738,9 @@ export class Keyboard implements IKeyboard {
           if (result.success) {
             resolve({
               success: true,
-              extendedKeycode: new BmpExtendedKeycode(result.response!.buffer),
+              extendedKeycode: BmpExtendedKeycode.createExtendedKeycode(
+                result.response!.buffer
+              ),
             });
           } else {
             resolve({

--- a/src/services/hid/WebHid.ts
+++ b/src/services/hid/WebHid.ts
@@ -704,8 +704,9 @@ export class Keyboard implements IKeyboard {
   }
 
   getBmpExtendedKeycodeCount(): Promise<IGetBmpExtendedKeycodeCountResult> {
-    return new Promise<IGetBmpExtendedKeycodeCountResult>((resolve)=>{
-      const command = new BleMicroProGetExtendedKeycodeCountCommand({},
+    return new Promise<IGetBmpExtendedKeycodeCountResult>((resolve) => {
+      const command = new BleMicroProGetExtendedKeycodeCountCommand(
+        {},
         async (result) => {
           if (result.success) {
             resolve({ success: true, count: result.response!.count });
@@ -716,16 +717,18 @@ export class Keyboard implements IKeyboard {
               cause: result.cause,
             });
           }
-        });
+        }
+      );
       return this.enqueue(command);
     });
   }
 
   getBmpExtendedKeycode(index: number): Promise<IGetBmpExtendedKeycodeResult> {
-    return new Promise<IGetBmpExtendedKeycodeResult>((resolve)=>{
-      const command = new BleMicroProGetExtendedKeycodeCommand({
-        index
-      },
+    return new Promise<IGetBmpExtendedKeycodeResult>((resolve) => {
+      const command = new BleMicroProGetExtendedKeycodeCommand(
+        {
+          index,
+        },
         async (result) => {
           if (result.success) {
             resolve({ success: true, buffer: result.response!.buffer });
@@ -736,11 +739,11 @@ export class Keyboard implements IKeyboard {
               cause: result.cause,
             });
           }
-        });
+        }
+      );
       return this.enqueue(command);
     });
   }
-
 
   getMacroCount(): Promise<IGetMacroCountResult> {
     return new Promise<IGetMacroCountResult>((resolve) => {

--- a/src/services/hid/WebHid.ts
+++ b/src/services/hid/WebHid.ts
@@ -52,6 +52,7 @@ import {
 } from './Composition';
 import { outputUint8Array } from '../../utils/ArrayUtils';
 import { KeyboardLabelLang } from '../labellang/KeyLabelLangs';
+import { BmpExtendedKeycode } from './bmp/BmpExtendedKeycode';
 
 export class Keyboard implements IKeyboard {
   private readonly hid: IHid;
@@ -731,7 +732,10 @@ export class Keyboard implements IKeyboard {
         },
         async (result) => {
           if (result.success) {
-            resolve({ success: true, buffer: result.response!.buffer });
+            resolve({
+              success: true,
+              extendedKeycode: new BmpExtendedKeycode(result.response!.buffer),
+            });
           } else {
             resolve({
               success: false,

--- a/src/services/hid/WebHid.ts
+++ b/src/services/hid/WebHid.ts
@@ -28,6 +28,7 @@ import {
   BleMicroProStoreKeymapPersistentlyCommand,
   BleMicroProGetExtendedKeycodeCountCommand,
   BleMicroProGetExtendedKeycodeCommand,
+  BleMicroProSetExtendedKeycodeCommand,
   DynamicKeymapGetLayerCountCommand,
   DynamicKeymapMacroGetBufferCommand,
   DynamicKeymapMacroGetBufferSizeCommand,
@@ -52,7 +53,10 @@ import {
 } from './Composition';
 import { outputUint8Array } from '../../utils/ArrayUtils';
 import { KeyboardLabelLang } from '../labellang/KeyLabelLangs';
-import { BmpExtendedKeycode } from './bmp/BmpExtendedKeycode';
+import {
+  BmpExtendedKeycode,
+  IBmpExtendedKeycode,
+} from './bmp/BmpExtendedKeycode';
 
 export class Keyboard implements IKeyboard {
   private readonly hid: IHid;
@@ -735,6 +739,34 @@ export class Keyboard implements IKeyboard {
             resolve({
               success: true,
               extendedKeycode: new BmpExtendedKeycode(result.response!.buffer),
+            });
+          } else {
+            resolve({
+              success: false,
+              error: result.error,
+              cause: result.cause,
+            });
+          }
+        }
+      );
+      return this.enqueue(command);
+    });
+  }
+
+  setBmpExtendedKeycode(
+    index: number,
+    extendedKeycode: IBmpExtendedKeycode
+  ): Promise<IResult> {
+    return new Promise<IResult>((resolve) => {
+      const command = new BleMicroProSetExtendedKeycodeCommand(
+        {
+          index,
+          extendedKeycode,
+        },
+        async (result) => {
+          if (result.success) {
+            resolve({
+              success: true,
             });
           } else {
             resolve({

--- a/src/services/hid/WebHid.ts
+++ b/src/services/hid/WebHid.ts
@@ -21,11 +21,13 @@ import {
   IGetMacroBufferSizeResult,
   IFetchMacroBufferResult,
   IGetBmpExtendedKeycodeCountResult,
+  IGetBmpExtendedKeycodeResult,
 } from './Hid';
 import { KeycodeList } from './KeycodeList';
 import {
   BleMicroProStoreKeymapPersistentlyCommand,
   BleMicroProGetExtendedKeycodeCountCommand,
+  BleMicroProGetExtendedKeycodeCommand,
   DynamicKeymapGetLayerCountCommand,
   DynamicKeymapMacroGetBufferCommand,
   DynamicKeymapMacroGetBufferSizeCommand,
@@ -718,6 +720,27 @@ export class Keyboard implements IKeyboard {
       return this.enqueue(command);
     });
   }
+
+  getBmpExtendedKeycode(index: number): Promise<IGetBmpExtendedKeycodeResult> {
+    return new Promise<IGetBmpExtendedKeycodeResult>((resolve)=>{
+      const command = new BleMicroProGetExtendedKeycodeCommand({
+        index
+      },
+        async (result) => {
+          if (result.success) {
+            resolve({ success: true, buffer: result.response!.buffer });
+          } else {
+            resolve({
+              success: false,
+              error: result.error,
+              cause: result.cause,
+            });
+          }
+        });
+      return this.enqueue(command);
+    });
+  }
+
 
   getMacroCount(): Promise<IGetMacroCountResult> {
     return new Promise<IGetMacroCountResult>((resolve) => {

--- a/src/services/hid/bmp/BmpExtendedKeycode.ts
+++ b/src/services/hid/bmp/BmpExtendedKeycode.ts
@@ -1,6 +1,9 @@
 import { KeyboardLabelLang } from '../../labellang/KeyLabelLangs';
 import { IKeymap } from '../Hid';
 import { KeycodeList } from '../KeycodeList';
+import { buildHoldKeyLabel } from '../../../components/configure/customkey/TabHoldTapKey';
+import { buildModLabel } from '../../../components/configure/customkey/Modifiers';
+import { genKey } from '../../../components/configure/keycodekey/KeyGen';
 
 /* eslint-disable no-unused-vars */
 export enum ExtendedKind {
@@ -18,12 +21,31 @@ export interface IBmpExtendedKeycode {
   getBytes(): Uint8Array;
   // eslint-disable-next-line no-unused-vars
   changeKind(kind: ExtendedKind): void;
+  // eslint-disable-next-line no-unused-vars
+  getDescription(labelLang: KeyboardLabelLang): string;
 }
 
-export class BmpExtendedKeycode implements IBmpExtendedKeycode {
+export abstract class BmpExtendedKeycode implements IBmpExtendedKeycode {
   private bytes: Uint8Array;
   constructor(bytes: Uint8Array) {
     this.bytes = bytes;
+  }
+
+  static createExtendedKeycode(bytes: Uint8Array): IBmpExtendedKeycode {
+    switch (bytes[0] as ExtendedKind) {
+      case ExtendedKind.LAYER_TAP_EXTENDED:
+        return new BmpExtendedKeycodeLte(bytes);
+      case ExtendedKind.TRI_LAYER_TAP:
+        return new BmpExtendedKeycodeTlt(bytes);
+      case ExtendedKind.TAP_DANCE_DOUBLE:
+        return new BmpExtendedKeycodeTwoKeyCombination(bytes);
+      case ExtendedKind.TAP_DANCE_HOLD:
+        return new BmpExtendedKeycodeTwoKeyCombination(bytes);
+      case ExtendedKind.COMBO:
+        return new BmpExtendedKeycodeCombo(bytes);
+      default:
+        return new BmpExtendedKeycodeNone(bytes);
+    }
   }
 
   getKind(): ExtendedKind {
@@ -37,136 +59,200 @@ export class BmpExtendedKeycode implements IBmpExtendedKeycode {
   changeKind(kind: ExtendedKind): void {
     this.bytes = Uint8Array.from([kind, 0, 0, 0, 0, 0]);
   }
+
+  // eslint-disable-next-line no-unused-vars
+  abstract getDescription(labelLang: KeyboardLabelLang): string;
 }
 
-export class BmpExtendedKeycodeLte {
-  private extendedKey: IBmpExtendedKeycode;
-  constructor(extendedKey: IBmpExtendedKeycode) {
-    this.extendedKey = extendedKey;
+function keyDescription(keymap: IKeymap): string {
+  const key = genKey(keymap);
+  const label = key.label;
+  const holdLabel = buildHoldKeyLabel(key.keymap, key.keymap.isAny);
+  let modifierLabel = key.meta;
+  if (holdLabel === '' && modifierLabel === '') {
+    modifierLabel = buildModLabel(
+      key.keymap.modifiers || null,
+      key.keymap.direction!
+    );
+  }
+
+  const metaRight = key.metaRight ? key.metaRight : '';
+
+  let description = '';
+
+  if (modifierLabel !== '') {
+    description = `(${modifierLabel})${label}`;
+  } else if (metaRight !== '') {
+    description = `(${metaRight})${label}`;
+  } else {
+    description = label;
+  }
+
+  return holdLabel === '' ? description : `[${description}, ${holdLabel}]`;
+}
+
+export class BmpExtendedKeycodeNone extends BmpExtendedKeycode {
+  constructor(bytes: Uint8Array) {
+    super(bytes);
+  }
+
+  // eslint-disable-next-line no-unused-vars
+  getDescription(_labelLang: KeyboardLabelLang): string {
+    return ExtendedKind[this.getKind()];
+  }
+}
+export class BmpExtendedKeycodeLte extends BmpExtendedKeycode {
+  constructor(bytes: Uint8Array) {
+    super(bytes);
+  }
+
+  getDescription(labelLang: KeyboardLabelLang): string {
+    const l1 = this.getLayer();
+    const key = keyDescription(this.getKey(labelLang));
+    return `${ExtendedKind[this.getKind()]}(${l1}, ${key})`;
   }
 
   getLayer(): number {
-    return this.extendedKey.getBytes()[1];
+    return this.getBytes()[1];
   }
 
-  getKey(labelLange: KeyboardLabelLang): IKeymap {
-    const bytes = this.extendedKey.getBytes();
-    return KeycodeList.getKeymap(bytes[2] + (bytes[3] << 8), labelLange);
+  getKey(labelLang: KeyboardLabelLang): IKeymap {
+    const bytes = this.getBytes();
+    return KeycodeList.getKeymap(bytes[2] + (bytes[3] << 8), labelLang);
   }
 
   setLayer(layer: number) {
-    const bytes = this.extendedKey.getBytes();
+    const bytes = this.getBytes();
     bytes[1] = layer & 0x1f;
   }
 
   setKey(code: number) {
-    const bytes = this.extendedKey.getBytes();
+    const bytes = this.getBytes();
     bytes[2] = code & 0xff;
     bytes[3] = (code >> 8) & 0xff;
   }
 }
 
-export class BmpExtendedKeycodeTlt {
-  private extendedKey: IBmpExtendedKeycode;
-  constructor(extendedKey: IBmpExtendedKeycode) {
-    this.extendedKey = extendedKey;
+export class BmpExtendedKeycodeTlt extends BmpExtendedKeycode {
+  constructor(bytes: Uint8Array) {
+    super(bytes);
+  }
+
+  getDescription(labelLang: KeyboardLabelLang): string {
+    const l1 = this.getLayer1();
+    const l2 = this.getLayer2();
+    const l3 = this.getLayer3();
+    const key = keyDescription(this.getKey(labelLang));
+    return `${ExtendedKind[this.getKind()]}(${l1}, ${l2}, ${l3}, ${key})`;
   }
 
   getLayer1(): number {
-    return this.extendedKey.getBytes()[1];
+    return this.getBytes()[1];
   }
   getLayer2(): number {
-    return this.extendedKey.getBytes()[2];
+    return this.getBytes()[2];
   }
 
   getLayer3(): number {
-    return this.extendedKey.getBytes()[3];
+    return this.getBytes()[3];
   }
+
   getKey(labelLange: KeyboardLabelLang): IKeymap {
-    const bytes = this.extendedKey.getBytes();
+    const bytes = this.getBytes();
     return KeycodeList.getKeymap(bytes[4] + (bytes[5] << 8), labelLange);
   }
 
   setLayer1(layer: number) {
-    const bytes = this.extendedKey.getBytes();
+    const bytes = this.getBytes();
     bytes[1] = layer & 0x1f;
   }
 
   setLayer2(layer: number) {
-    const bytes = this.extendedKey.getBytes();
+    const bytes = this.getBytes();
     bytes[2] = layer & 0x1f;
   }
 
   setLayer3(layer: number) {
-    const bytes = this.extendedKey.getBytes();
+    const bytes = this.getBytes();
     bytes[3] = layer & 0x1f;
   }
 
   setKey(code: number) {
-    const bytes = this.extendedKey.getBytes();
+    const bytes = this.getBytes();
     bytes[4] = code & 0xff;
     bytes[5] = (code >> 8) & 0xff;
   }
 }
 
-export class BmpExtendedKeycodeTwoKeyCombination {
-  private extendedKey: IBmpExtendedKeycode;
-  constructor(extendedKey: IBmpExtendedKeycode) {
-    this.extendedKey = extendedKey;
+export class BmpExtendedKeycodeTwoKeyCombination extends BmpExtendedKeycode {
+  constructor(bytes: Uint8Array) {
+    super(bytes);
+  }
+
+  getDescription(labelLang: KeyboardLabelLang): string {
+    const key1 = keyDescription(this.getKey1(labelLang));
+    const key2 = keyDescription(this.getKey2(labelLang));
+    return `${ExtendedKind[this.getKind()]}(${key1}, ${key2})`;
   }
 
   getKey1(labelLange: KeyboardLabelLang): IKeymap {
-    const bytes = this.extendedKey.getBytes();
+    const bytes = this.getBytes();
     return KeycodeList.getKeymap(bytes[1] + (bytes[2] << 8), labelLange);
   }
   getKey2(labelLange: KeyboardLabelLang): IKeymap {
-    const bytes = this.extendedKey.getBytes();
+    const bytes = this.getBytes();
     return KeycodeList.getKeymap(bytes[3] + (bytes[4] << 8), labelLange);
   }
 
   setKey1(code: number) {
-    const bytes = this.extendedKey.getBytes();
+    const bytes = this.getBytes();
     bytes[1] = code & 0xff;
     bytes[2] = (code >> 8) & 0xff;
   }
 
   setKey2(code: number) {
-    const bytes = this.extendedKey.getBytes();
+    const bytes = this.getBytes();
     bytes[3] = code & 0xff;
     bytes[4] = (code >> 8) & 0xff;
   }
 }
 
-export class BmpExtendedKeycodeCombo {
-  private extendedKey: IBmpExtendedKeycode;
-  constructor(extendedKey: IBmpExtendedKeycode) {
-    this.extendedKey = extendedKey;
+export class BmpExtendedKeycodeCombo extends BmpExtendedKeycode {
+  constructor(bytes: Uint8Array) {
+    super(bytes);
+  }
+
+  getDescription(labelLang: KeyboardLabelLang): string {
+    const key1 = keyDescription(this.getKey1(labelLang));
+    const key2 = keyDescription(this.getKey2(labelLang));
+    const key3 = keyDescription(this.getKey3(labelLang));
+    return `${ExtendedKind[this.getKind()]}(${key1}, ${key2}, ${key3})`;
   }
 
   getKey1(labelLange: KeyboardLabelLang): IKeymap {
-    const bytes = this.extendedKey.getBytes();
+    const bytes = this.getBytes();
     return KeycodeList.getKeymap(bytes[1] + (bytes[2] << 8), labelLange);
   }
   getKey2(labelLange: KeyboardLabelLang): IKeymap {
-    const bytes = this.extendedKey.getBytes();
+    const bytes = this.getBytes();
     return KeycodeList.getKeymap(bytes[3], labelLange);
   }
   getKey3(labelLange: KeyboardLabelLang): IKeymap {
-    const bytes = this.extendedKey.getBytes();
+    const bytes = this.getBytes();
     return KeycodeList.getKeymap(bytes[4] + (bytes[5] << 8), labelLange);
   }
 
   setKey1(code: number) {
-    const bytes = this.extendedKey.getBytes();
+    const bytes = this.getBytes();
     bytes[1] = code & 0xff;
     bytes[2] = (code >> 8) & 0xff;
   }
   setKey2(code: number) {
-    const bytes = this.extendedKey.getBytes();
+    const bytes = this.getBytes();
     bytes[3] = code & 0xff;
   }
   setKey3(code: number) {
-    const bytes = this.extendedKey.getBytes();
+    const bytes = this.getBytes();
     bytes[4] = code & 0xff;
     bytes[5] = (code >> 8) & 0xff;
   }

--- a/src/services/hid/bmp/BmpExtendedKeycode.ts
+++ b/src/services/hid/bmp/BmpExtendedKeycode.ts
@@ -2,19 +2,19 @@ import { KeyboardLabelLang } from '../../labellang/KeyLabelLangs';
 import { IKeymap } from '../Hid';
 import { KeycodeList } from '../KeycodeList';
 
+/* eslint-disable no-unused-vars */
 export enum ExtendedKind {
   NONE,
-  LTE,
-  TLT,
-  TDD,
-  TDH,
+  LAYER_TAP_EXTENDED,
+  TRI_LAYER_TAP,
+  TAP_DANCE_DOUBLE,
+  TAP_DANCE_HOLD,
 }
+/* eslint-enable no-unused-vars */
 
 export interface IBmpExtendedKeycode {
   getKind(): ExtendedKind;
   getBytes(): Uint8Array;
-  // eslint-disable-next-line no-unused-vars
-  updateBytes(bytes: Uint8Array): void;
   // eslint-disable-next-line no-unused-vars
   changeKind(kind: ExtendedKind): void;
 }
@@ -31,10 +31,6 @@ export class BmpExtendedKeycode implements IBmpExtendedKeycode {
 
   getBytes(): Uint8Array {
     return this.bytes;
-  }
-
-  updateBytes(bytes: Uint8Array): void {
-    this.bytes = bytes;
   }
 
   changeKind(kind: ExtendedKind): void {

--- a/src/services/hid/bmp/BmpExtendedKeycode.ts
+++ b/src/services/hid/bmp/BmpExtendedKeycode.ts
@@ -9,6 +9,7 @@ export enum ExtendedKind {
   TRI_LAYER_TAP,
   TAP_DANCE_DOUBLE,
   TAP_DANCE_HOLD,
+  COMBO,
 }
 /* eslint-enable no-unused-vars */
 
@@ -108,7 +109,7 @@ export class BmpExtendedKeycodeTlt {
   }
 }
 
-export class BmpExtendedKeycodeTdd {
+export class BmpExtendedKeycodeTwoKeyCombination {
   private extendedKey: IBmpExtendedKeycode;
   constructor(extendedKey: IBmpExtendedKeycode) {
     this.extendedKey = extendedKey;
@@ -136,7 +137,7 @@ export class BmpExtendedKeycodeTdd {
   }
 }
 
-export class BmpExtendedKeycodeTdh {
+export class BmpExtendedKeycodeCombo {
   private extendedKey: IBmpExtendedKeycode;
   constructor(extendedKey: IBmpExtendedKeycode) {
     this.extendedKey = extendedKey;
@@ -148,7 +149,11 @@ export class BmpExtendedKeycodeTdh {
   }
   getKey2(labelLange: KeyboardLabelLang): IKeymap {
     const bytes = this.extendedKey.getBytes();
-    return KeycodeList.getKeymap(bytes[3] + (bytes[4] << 8), labelLange);
+    return KeycodeList.getKeymap(bytes[3], labelLange);
+  }
+  getKey3(labelLange: KeyboardLabelLang): IKeymap {
+    const bytes = this.extendedKey.getBytes();
+    return KeycodeList.getKeymap(bytes[4] + (bytes[5] << 8), labelLange);
   }
 
   setKey1(code: number) {
@@ -156,10 +161,13 @@ export class BmpExtendedKeycodeTdh {
     bytes[1] = code & 0xff;
     bytes[2] = (code >> 8) & 0xff;
   }
-
   setKey2(code: number) {
     const bytes = this.extendedKey.getBytes();
     bytes[3] = code & 0xff;
-    bytes[4] = (code >> 8) & 0xff;
+  }
+  setKey3(code: number) {
+    const bytes = this.extendedKey.getBytes();
+    bytes[4] = code & 0xff;
+    bytes[5] = (code >> 8) & 0xff;
   }
 }

--- a/src/services/hid/bmp/BmpExtendedKeycode.ts
+++ b/src/services/hid/bmp/BmpExtendedKeycode.ts
@@ -1,0 +1,39 @@
+export enum ExtendedKind {
+  NONE,
+  TLT,
+  LTE,
+  TDH,
+  TDD,
+}
+
+export interface IBmpExtendedKeycode {
+  getKind(): ExtendedKind;
+  getBytes(): Uint8Array;
+  // eslint-disable-next-line no-unused-vars
+  updateBytes(bytes: Uint8Array): void;
+  // eslint-disable-next-line no-unused-vars
+  changeKind(kind: ExtendedKind): void;
+}
+
+export class BmpExtendedKeycode implements IBmpExtendedKeycode {
+  private bytes: Uint8Array;
+  constructor(bytes: Uint8Array) {
+    this.bytes = bytes;
+  }
+
+  getKind(): ExtendedKind {
+    return this.bytes[0];
+  }
+
+  getBytes(): Uint8Array {
+    return this.bytes;
+  }
+
+  updateBytes(bytes: Uint8Array): void {
+    this.bytes = bytes;
+  }
+
+  changeKind(kind: ExtendedKind): void {
+    this.bytes = Uint8Array.from([kind, 0, 0, 0, 0, 0]);
+  }
+}

--- a/src/services/hid/bmp/BmpExtendedKeycode.ts
+++ b/src/services/hid/bmp/BmpExtendedKeycode.ts
@@ -55,15 +55,13 @@ export class BmpExtendedKeycodeLte {
 
   setLayer(layer: number) {
     const bytes = this.extendedKey.getBytes();
-    bytes[1] = layer & 0xff;
+    bytes[1] = layer & 0x1f;
   }
 
-  setKey(code: number): IBmpExtendedKeycode {
-    let bytes = Uint8Array.from(this.extendedKey.getBytes());
+  setKey(code: number) {
+    const bytes = this.extendedKey.getBytes();
     bytes[2] = code & 0xff;
     bytes[3] = (code >> 8) & 0xff;
-
-    return new BmpExtendedKeycode(bytes);
   }
 }
 
@@ -90,17 +88,17 @@ export class BmpExtendedKeycodeTlt {
 
   setLayer1(layer: number) {
     const bytes = this.extendedKey.getBytes();
-    bytes[1] = layer & 0xff;
+    bytes[1] = layer & 0x1f;
   }
 
   setLayer2(layer: number) {
     const bytes = this.extendedKey.getBytes();
-    bytes[2] = layer & 0xff;
+    bytes[2] = layer & 0x1f;
   }
 
   setLayer3(layer: number) {
     const bytes = this.extendedKey.getBytes();
-    bytes[3] = layer & 0xff;
+    bytes[3] = layer & 0x1f;
   }
 
   setKey(code: number) {

--- a/src/services/hid/bmp/BmpExtendedKeycode.ts
+++ b/src/services/hid/bmp/BmpExtendedKeycode.ts
@@ -1,9 +1,13 @@
+import { KeyboardLabelLang } from '../../labellang/KeyLabelLangs';
+import { IKeymap } from '../Hid';
+import { KeycodeList } from '../KeycodeList';
+
 export enum ExtendedKind {
   NONE,
-  TLT,
   LTE,
-  TDH,
+  TLT,
   TDD,
+  TDH,
 }
 
 export interface IBmpExtendedKeycode {
@@ -35,5 +39,133 @@ export class BmpExtendedKeycode implements IBmpExtendedKeycode {
 
   changeKind(kind: ExtendedKind): void {
     this.bytes = Uint8Array.from([kind, 0, 0, 0, 0, 0]);
+  }
+}
+
+export class BmpExtendedKeycodeLte {
+  private extendedKey: IBmpExtendedKeycode;
+  constructor(extendedKey: IBmpExtendedKeycode) {
+    this.extendedKey = extendedKey;
+  }
+
+  getLayer(): number {
+    return this.extendedKey.getBytes()[1];
+  }
+
+  getKey(labelLange: KeyboardLabelLang): IKeymap {
+    const bytes = this.extendedKey.getBytes();
+    return KeycodeList.getKeymap(bytes[2] + (bytes[3] << 8), labelLange);
+  }
+
+  setLayer(layer: number) {
+    const bytes = this.extendedKey.getBytes();
+    bytes[1] = layer & 0xff;
+  }
+
+  setKey(code: number): IBmpExtendedKeycode {
+    let bytes = Uint8Array.from(this.extendedKey.getBytes());
+    bytes[2] = code & 0xff;
+    bytes[3] = (code >> 8) & 0xff;
+
+    return new BmpExtendedKeycode(bytes);
+  }
+}
+
+export class BmpExtendedKeycodeTlt {
+  private extendedKey: IBmpExtendedKeycode;
+  constructor(extendedKey: IBmpExtendedKeycode) {
+    this.extendedKey = extendedKey;
+  }
+
+  getLayer1(): number {
+    return this.extendedKey.getBytes()[1];
+  }
+  getLayer2(): number {
+    return this.extendedKey.getBytes()[2];
+  }
+
+  getLayer3(): number {
+    return this.extendedKey.getBytes()[3];
+  }
+  getKey(labelLange: KeyboardLabelLang): IKeymap {
+    const bytes = this.extendedKey.getBytes();
+    return KeycodeList.getKeymap(bytes[4] + (bytes[5] << 8), labelLange);
+  }
+
+  setLayer1(layer: number) {
+    const bytes = this.extendedKey.getBytes();
+    bytes[1] = layer & 0xff;
+  }
+
+  setLayer2(layer: number) {
+    const bytes = this.extendedKey.getBytes();
+    bytes[2] = layer & 0xff;
+  }
+
+  setLayer3(layer: number) {
+    const bytes = this.extendedKey.getBytes();
+    bytes[3] = layer & 0xff;
+  }
+
+  setKey(code: number) {
+    const bytes = this.extendedKey.getBytes();
+    bytes[4] = code & 0xff;
+    bytes[5] = (code >> 8) & 0xff;
+  }
+}
+
+export class BmpExtendedKeycodeTdd {
+  private extendedKey: IBmpExtendedKeycode;
+  constructor(extendedKey: IBmpExtendedKeycode) {
+    this.extendedKey = extendedKey;
+  }
+
+  getKey1(labelLange: KeyboardLabelLang): IKeymap {
+    const bytes = this.extendedKey.getBytes();
+    return KeycodeList.getKeymap(bytes[1] + (bytes[2] << 8), labelLange);
+  }
+  getKey2(labelLange: KeyboardLabelLang): IKeymap {
+    const bytes = this.extendedKey.getBytes();
+    return KeycodeList.getKeymap(bytes[3] + (bytes[4] << 8), labelLange);
+  }
+
+  setKey1(code: number) {
+    const bytes = this.extendedKey.getBytes();
+    bytes[1] = code & 0xff;
+    bytes[2] = (code >> 8) & 0xff;
+  }
+
+  setKey2(code: number) {
+    const bytes = this.extendedKey.getBytes();
+    bytes[3] = code & 0xff;
+    bytes[4] = (code >> 8) & 0xff;
+  }
+}
+
+export class BmpExtendedKeycodeTdh {
+  private extendedKey: IBmpExtendedKeycode;
+  constructor(extendedKey: IBmpExtendedKeycode) {
+    this.extendedKey = extendedKey;
+  }
+
+  getKey1(labelLange: KeyboardLabelLang): IKeymap {
+    const bytes = this.extendedKey.getBytes();
+    return KeycodeList.getKeymap(bytes[1] + (bytes[2] << 8), labelLange);
+  }
+  getKey2(labelLange: KeyboardLabelLang): IKeymap {
+    const bytes = this.extendedKey.getBytes();
+    return KeycodeList.getKeymap(bytes[3] + (bytes[4] << 8), labelLange);
+  }
+
+  setKey1(code: number) {
+    const bytes = this.extendedKey.getBytes();
+    bytes[1] = code & 0xff;
+    bytes[2] = (code >> 8) & 0xff;
+  }
+
+  setKey2(code: number) {
+    const bytes = this.extendedKey.getBytes();
+    bytes[3] = code & 0xff;
+    bytes[4] = (code >> 8) & 0xff;
   }
 }

--- a/src/services/hid/bmp/KeycodeInfoListBmp.ts
+++ b/src/services/hid/bmp/KeycodeInfoListBmp.ts
@@ -1,4 +1,4 @@
-import { KeyInfo } from './KeycodeInfoList';
+import { KeyInfo } from '../KeycodeInfoList';
 
 export const CATEGORY_LABEL_BMP = 'BMP';
 export const BMP_EXTENDED_MIN = 24096;

--- a/src/services/hid/bmp/KeycodeInfoListBmp.ts
+++ b/src/services/hid/bmp/KeycodeInfoListBmp.ts
@@ -534,18 +534,6 @@ export const bmpKeyInfoList: KeyInfo[] = [
     },
   },
   {
-    desc: 'Extended keycode 11',
-    keycodeInfo: {
-      code: 24107,
-      name: {
-        long: 'EXTENDED11',
-        short: 'Ex11',
-      },
-      label: 'Ex11',
-      keywords: ['ex11'],
-    },
-  },
-  {
     desc: 'Extended keycode 12',
     keycodeInfo: {
       code: 24108,

--- a/src/services/hid/ui/Hid.tsx
+++ b/src/services/hid/ui/Hid.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable no-undef */
 import { WebHid } from '../WebHid';
 import React, { useEffect, useState } from 'react';
 import './Hid.scss';
@@ -346,6 +345,10 @@ const Hid = () => {
     console.log(await keyboard!.fetchMacroBuffer(macroSize));
   };
 
+  const handleBmpExtendedKeycodeGetCountClick = async () => {
+    console.log(await keyboard!.getBmpExtendedKeycodeCount());
+  };
+
   return (
     <div className="hid">
       <h1>WebHid Test</h1>
@@ -586,6 +589,11 @@ const Hid = () => {
       <div className="box">
         <label htmlFor="Test">Test</label>
         <input type="text" style={{ width: '300px' }} />
+      </div>
+      <div className="box">
+        <button onClick={handleBmpExtendedKeycodeGetCountClick}>
+          BMP Extended Keycode Get Count
+        </button>
       </div>
       <div>{message}</div>
     </div>

--- a/src/services/hid/ui/Hid.tsx
+++ b/src/services/hid/ui/Hid.tsx
@@ -35,6 +35,8 @@ const Hid = () => {
   const [layoutOptionsValue, setLayoutOptionsValue] = useState<number>(0);
   const [macroOffset, setMacroOffset] = useState<number>(0);
   const [macroSize, setMacroSize] = useState<number>(0);
+  const [bmpExtendedKeycodeIndex, setBmpExtendedKeycodeIndex] =
+    useState<number>(0);
 
   useEffect(() => {
     webHid
@@ -349,6 +351,16 @@ const Hid = () => {
     console.log(await keyboard!.getBmpExtendedKeycodeCount());
   };
 
+  const handleBmpExtendedKeycodeGetClick = async () => {
+    console.log(await keyboard!.getBmpExtendedKeycode(bmpExtendedKeycodeIndex));
+  };
+
+  const handleBmpExtendKeycodeIndexChange = async (
+    event: React.ChangeEvent<HTMLInputElement>
+  ) => {
+    setBmpExtendedKeycodeIndex(Number(event.target.value));
+  };
+
   return (
     <div className="hid">
       <h1>WebHid Test</h1>
@@ -593,6 +605,17 @@ const Hid = () => {
       <div className="box">
         <button onClick={handleBmpExtendedKeycodeGetCountClick}>
           BMP Extended Keycode Get Count
+        </button>
+        <label htmlFor="extendedKeycodeIndex">Index</label>
+        <input
+          type="number"
+          id="extendedKeycodeIndex"
+          min={0}
+          value={bmpExtendedKeycodeIndex}
+          onChange={handleBmpExtendKeycodeIndexChange}
+        />
+        <button onClick={handleBmpExtendedKeycodeGetClick}>
+          Get Extended Keycode
         </button>
       </div>
       <div>{message}</div>

--- a/src/store/reducers.ts
+++ b/src/store/reducers.ts
@@ -188,6 +188,11 @@ import {
   ORGANIZATIONS_EDIT_ORGANIZATION_UPDATE_EMAIL,
   ORGANIZATIONS_EDIT_ORGANIZATION_UPDATE_ORGANIZATION_MEMBERS,
 } from '../actions/organizations.actions';
+import {
+  BMP_EXTENDED_KEYCODE_EDITOR_ACTIONS,
+  BMP_EXTENDED_KEYCODE_EDITOR_UPDATE_KEY,
+  BMP_EXTENDED_KEYCODE_EDITOR_CLEAR_KEY,
+} from '../actions/bmpExtendedKeycode.action';
 
 export type Action = { type: string; value: any };
 
@@ -213,6 +218,8 @@ const reducers = (state: RootState = INIT_STATE, action: Action) =>
       layoutOptionsReducer(action, draft);
     } else if (action.type.startsWith(MACRO_EDITOR_ACTIONS)) {
       macroEditorReducer(action, draft);
+    } else if (action.type.startsWith(BMP_EXTENDED_KEYCODE_EDITOR_ACTIONS)) {
+      bmpExtendedKeycodeReducer(action, draft);
     } else if (action.type.startsWith(NOTIFICATION_ACTIONS)) {
       notificationReducer(action, draft);
     } else if (action.type.startsWith(APP_ACTIONS)) {
@@ -869,6 +876,22 @@ const macroEditorReducer = (
     }
     case MACRO_EDITOR_UPDATE_MACRO_KEYS: {
       draft.configure.macroEditor.macroKeys = action.value;
+      break;
+    }
+  }
+};
+
+const bmpExtendedKeycodeReducer = (
+  action: Action,
+  draft: WritableDraft<RootState>
+) => {
+  switch (action.type) {
+    case BMP_EXTENDED_KEYCODE_EDITOR_UPDATE_KEY: {
+      draft.configure.bmpExtendedKeycodeEditor.key = action.value;
+      break;
+    }
+    case BMP_EXTENDED_KEYCODE_EDITOR_CLEAR_KEY: {
+      draft.configure.bmpExtendedKeycodeEditor.key = null;
       break;
     }
   }

--- a/src/store/reducers.ts
+++ b/src/store/reducers.ts
@@ -59,6 +59,7 @@ import {
   HID_UPDATE_MACRO_MAX_BUFFER_SIZE,
   HID_UPDATE_MACRO_MAX_COUNT,
   HID_UPDATE_BMP_EXTENDED_KEYCODE_MAX_COUNT,
+  HID_UPDATE_BMP_EXTENDED_KEYCODE,
 } from '../actions/hid.action';
 import {
   STORAGE_ACTIONS,
@@ -672,6 +673,10 @@ const hidReducer = (action: Action, draft: WritableDraft<RootState>) => {
     }
     case HID_UPDATE_BMP_EXTENDED_KEYCODE_MAX_COUNT: {
       draft.entities.device.extendedKeycode.maxCount = action.value;
+      break;
+    }
+    case HID_UPDATE_BMP_EXTENDED_KEYCODE: {
+      draft.entities.device.extendedKeycode[action.value.id] = action.value.buffer;
       break;
     }
   }

--- a/src/store/reducers.ts
+++ b/src/store/reducers.ts
@@ -676,7 +676,8 @@ const hidReducer = (action: Action, draft: WritableDraft<RootState>) => {
       break;
     }
     case HID_UPDATE_BMP_EXTENDED_KEYCODE: {
-      draft.entities.device.extendedKeycode[action.value.id] = action.value.buffer;
+      draft.entities.device.extendedKeycode[action.value.id] =
+        action.value.buffer;
       break;
     }
   }

--- a/src/store/reducers.ts
+++ b/src/store/reducers.ts
@@ -685,7 +685,7 @@ const hidReducer = (action: Action, draft: WritableDraft<RootState>) => {
     }
     case HID_UPDATE_BMP_EXTENDED_KEYCODE: {
       draft.entities.device.extendedKeycode[action.value.id] =
-        action.value.buffer;
+        action.value.extendedKeycode;
       break;
     }
   }

--- a/src/store/reducers.ts
+++ b/src/store/reducers.ts
@@ -192,6 +192,7 @@ import {
   BMP_EXTENDED_KEYCODE_EDITOR_ACTIONS,
   BMP_EXTENDED_KEYCODE_EDITOR_UPDATE_KEY,
   BMP_EXTENDED_KEYCODE_EDITOR_CLEAR_KEY,
+  BMP_EXTENDED_KEYCODE_EDITOR_UPDATE_EXTENDED_KEY_CODE,
 } from '../actions/bmpExtendedKeycode.action';
 
 export type Action = { type: string; value: any };
@@ -887,11 +888,15 @@ const bmpExtendedKeycodeReducer = (
 ) => {
   switch (action.type) {
     case BMP_EXTENDED_KEYCODE_EDITOR_UPDATE_KEY: {
-      draft.configure.bmpExtendedKeycodeEditor.key = action.value;
+      draft.configure.bmpExtendedKeycodeEditor.id = action.value;
+      break;
+    }
+    case BMP_EXTENDED_KEYCODE_EDITOR_UPDATE_EXTENDED_KEY_CODE: {
+      draft.configure.bmpExtendedKeycodeEditor.extendedKeycode = action.value;
       break;
     }
     case BMP_EXTENDED_KEYCODE_EDITOR_CLEAR_KEY: {
-      draft.configure.bmpExtendedKeycodeEditor.key = null;
+      draft.configure.bmpExtendedKeycodeEditor.id = null;
       break;
     }
   }

--- a/src/store/reducers.ts
+++ b/src/store/reducers.ts
@@ -193,6 +193,7 @@ import {
   BMP_EXTENDED_KEYCODE_EDITOR_UPDATE_KEY,
   BMP_EXTENDED_KEYCODE_EDITOR_CLEAR_KEY,
   BMP_EXTENDED_KEYCODE_EDITOR_UPDATE_EXTENDED_KEY_CODE,
+  BMP_EXTENDED_KEYCODE_EDITOR_SET_MODIFIED,
 } from '../actions/bmpExtendedKeycode.action';
 
 export type Action = { type: string; value: any };
@@ -893,6 +894,10 @@ const bmpExtendedKeycodeReducer = (
     }
     case BMP_EXTENDED_KEYCODE_EDITOR_UPDATE_EXTENDED_KEY_CODE: {
       draft.configure.bmpExtendedKeycodeEditor.extendedKeycode = action.value;
+      break;
+    }
+    case BMP_EXTENDED_KEYCODE_EDITOR_SET_MODIFIED: {
+      draft.configure.bmpExtendedKeycodeEditor.modified = action.value;
       break;
     }
     case BMP_EXTENDED_KEYCODE_EDITOR_CLEAR_KEY: {

--- a/src/store/reducers.ts
+++ b/src/store/reducers.ts
@@ -58,6 +58,7 @@ import {
   HID_UPDATE_MACRO_BUFFER_BYTES,
   HID_UPDATE_MACRO_MAX_BUFFER_SIZE,
   HID_UPDATE_MACRO_MAX_COUNT,
+  HID_UPDATE_BMP_EXTENDED_KEYCODE_MAX_COUNT,
 } from '../actions/hid.action';
 import {
   STORAGE_ACTIONS,
@@ -667,6 +668,10 @@ const hidReducer = (action: Action, draft: WritableDraft<RootState>) => {
     }
     case HID_UPDATE_MACRO_MAX_COUNT: {
       draft.entities.device.macro.maxCount = action.value;
+      break;
+    }
+    case HID_UPDATE_BMP_EXTENDED_KEYCODE_MAX_COUNT: {
+      draft.entities.device.extendedKeycode.maxCount = action.value;
       break;
     }
   }

--- a/src/store/state.ts
+++ b/src/store/state.ts
@@ -281,11 +281,8 @@ export type RootState = {
       macroKeys: MacroKey[];
     };
     bmpExtendedKeycodeEditor: {
-      key: Key | null;
-      keys: Key[];
-      macroBuffer: IMacroBuffer | null;
-      macro: IMacro | null;
-      macroKeys: MacroKey[];
+      id: number | null;
+      extendedKeycode: Uint8Array | null;
     };
   };
   keyboards: {
@@ -508,11 +505,8 @@ export const INIT_STATE: RootState = {
       macroKeys: [],
     },
     bmpExtendedKeycodeEditor: {
-      key: null,
-      keys: [],
-      macroBuffer: null,
-      macro: null,
-      macroKeys: [],
+      id: null,
+      extendedKeycode: null,
     },
   },
   keyboards: {

--- a/src/store/state.ts
+++ b/src/store/state.ts
@@ -26,6 +26,7 @@ import { IMacro, IMacroBuffer, MacroKey } from '../services/macro/Macro';
 import { IFirmwareWriter } from '../services/firmware/FirmwareWriter';
 import { FirmwareWriterWebApiImpl } from '../services/firmware/FirmwareWriterWebApiImpl';
 import { IBootloaderType } from '../services/firmware/Types';
+import { IBmpExtendedKeycode } from '../services/hid/bmp/BmpExtendedKeycode';
 
 export type ISetupPhase =
   | 'init'
@@ -196,7 +197,7 @@ export type RootState = {
       bleMicroPro: boolean;
       extendedKeycode: {
         maxCount: number;
-        [id: number]: Uint8Array;
+        [id: number]: IBmpExtendedKeycode;
       };
       macro: {
         bufferBytes: Uint8Array;
@@ -282,7 +283,7 @@ export type RootState = {
     };
     bmpExtendedKeycodeEditor: {
       id: number | null;
-      extendedKeycode: Uint8Array | null;
+      extendedKeycode: IBmpExtendedKeycode | null;
     };
   };
   keyboards: {

--- a/src/store/state.ts
+++ b/src/store/state.ts
@@ -280,6 +280,13 @@ export type RootState = {
       macro: IMacro | null;
       macroKeys: MacroKey[];
     };
+    bmpExtendedKeycodeEditor: {
+      key: Key | null;
+      keys: Key[];
+      macroBuffer: IMacroBuffer | null;
+      macro: IMacro | null;
+      macroKeys: MacroKey[];
+    };
   };
   keyboards: {
     app: {
@@ -494,6 +501,13 @@ export const INIT_STATE: RootState = {
       selectedOptions: [],
     },
     macroEditor: {
+      key: null,
+      keys: [],
+      macroBuffer: null,
+      macro: null,
+      macroKeys: [],
+    },
+    bmpExtendedKeycodeEditor: {
       key: null,
       keys: [],
       macroBuffer: null,

--- a/src/store/state.ts
+++ b/src/store/state.ts
@@ -196,7 +196,8 @@ export type RootState = {
       bleMicroPro: boolean;
       extendedKeycode: {
         maxCount: number;
-      }
+        [id: number]: Uint8Array;
+      };
       macro: {
         bufferBytes: Uint8Array;
         maxBufferSize: number;

--- a/src/store/state.ts
+++ b/src/store/state.ts
@@ -194,6 +194,9 @@ export type RootState = {
         [id: number]: string;
       };
       bleMicroPro: boolean;
+      extendedKeycode: {
+        maxCount: number;
+      }
       macro: {
         bufferBytes: Uint8Array;
         maxBufferSize: number;
@@ -414,6 +417,9 @@ export const INIT_STATE: RootState = {
       keymaps: [],
       macros: {},
       bleMicroPro: false,
+      extendedKeycode: {
+        maxCount: 0,
+      },
       macro: {
         bufferBytes: new Uint8Array(),
         maxBufferSize: 0,

--- a/src/store/state.ts
+++ b/src/store/state.ts
@@ -284,6 +284,7 @@ export type RootState = {
     bmpExtendedKeycodeEditor: {
       id: number | null;
       extendedKeycode: IBmpExtendedKeycode | null;
+      modified: boolean;
     };
   };
   keyboards: {
@@ -508,6 +509,7 @@ export const INIT_STATE: RootState = {
     bmpExtendedKeycodeEditor: {
       id: null,
       extendedKeycode: null,
+      modified: false,
     },
   },
   keyboards: {


### PR DESCRIPTION
This pull request add support for extended keycode of BLE Micro Pro by following.

- Add new class representing specification of extended keycode of BLE Micro Pro.
- Add new HID commands reading/writing extended keycode through Raw HID interface.
- Read all extended keycode on opening keyboard if possible.
- Generate keycode list which descripe current extended keycode settings.
- Write updated extended keycode on flash button is clicked.

Firmware version of BMP should be 0.11.2 or later to read/write extended keycodes using RawHID.
For older versions, extended keycode ID can be read/written from/to keymap, but settings are not editable/

Resolves #700 