### PR TITLE
show the designer icon in the catalog list and detail

### DIFF
--- a/src/components/catalog/keyboard/CatalogKeyboard.scss
+++ b/src/components/catalog/keyboard/CatalogKeyboard.scss
@@ -30,18 +30,6 @@
     width: 100%;
   }
 
-  &-header {
-    background-color: $primary;
-    color: white;
-    padding: 16px;
-    margin-bottom: 16px;
-
-    & h1 {
-      font-size: 32px;
-      font-weight: bold;
-    }
-  }
-
   @include mq(sm) {
     &-header {
       padding: 8px;

--- a/src/components/catalog/keyboard/CatalogKeyboardHeader.scss
+++ b/src/components/catalog/keyboard/CatalogKeyboardHeader.scss
@@ -1,17 +1,26 @@
 @import '../../../variables';
 
 .catalog-keyboard-header {
-  background-color: $primary;
   color: white;
   width: 100%;
   max-width: 960px;
-  margin-top: 8px;
-  margin-bottom: 16px;
+  margin: 8px 0px;
   display: flex;
-  flex-direction: row;
-  align-items: center;
+  flex-direction: column;
+  align-items: flex-start;
   justify-content: space-between;
   flex-wrap: wrap;
+
+  &-wrapper {
+    display: flex;
+    flex-direction: row;
+    width: 100%;
+    padding: 16px 16px 16px 8px;
+    background-color: $primary;
+    align-items: center;
+    justify-content: space-between;
+    flex-wrap: wrap;
+  }
 
   &-title {
     display: flex;
@@ -52,7 +61,8 @@
     margin-left: auto;
 
     &-github {
-      margin-left: 16px;
+      margin-left: 8px;
+      margin-right: 16px;
     }
 
     &-home {

--- a/src/components/catalog/keyboard/CatalogKeyboardHeader.tsx
+++ b/src/components/catalog/keyboard/CatalogKeyboardHeader.tsx
@@ -56,21 +56,7 @@ export const CatalogKeyboardHeader = ({
 
   return (
     <header className="catalog-keyboard-header">
-      <div className="catalog-keyboard-header-title">
-        <Typography variant="h1">{definitionDocument.name}</Typography>
-        <Typography variant="subtitle1">
-          designed by{' '}
-          <a
-            href={designerWebsiteUrl}
-            target="_blank"
-            rel="noreferrer"
-            title="Keyboard Owner"
-          >
-            {designerName}
-          </a>
-        </Typography>
-      </div>
-      <div className="catalog-keyboard-header-links">
+      <div className="catalog-keyboard-header-wrapper">
         <div className="catalog-keyboard-header-links-github">
           <a
             href={designerWebsiteUrl}
@@ -81,47 +67,63 @@ export const CatalogKeyboardHeader = ({
             <Avatar alt={designerName} src={designerIconImageUrl} />
           </a>
         </div>
-        {definitionDocument.stores.length > 0 ? (
-          <div className="catalog-keyboard-header-links-stores">
-            <IconButton
-              aria-controls="stores-menu"
-              aria-haspopup={true}
-              title="Stores"
-              onClick={onClickStoresMenu}
-            >
-              <Store htmlColor="white" fontSize="large" />
-            </IconButton>
-            <Menu
-              id="stores-menu"
-              anchorEl={storesMenuAnchorEl}
-              keepMounted
-              open={Boolean(storesMenuAnchorEl)}
-              onClose={onCloseStoresMenu}
-            >
-              {definitionDocument.stores.map((store, index) => {
-                return (
-                  <MenuItem key={index}>
-                    <Link href={store.url} target="_blank" rel="noreferrer">
-                      {store.name}
-                    </Link>
-                  </MenuItem>
-                );
-              })}
-            </Menu>
-          </div>
-        ) : null}
-        {definitionDocument.websiteUrl ? (
-          <div className="catalog-keyboard-header-links-home">
+        <div className="catalog-keyboard-header-title">
+          <Typography variant="h1">{definitionDocument.name}</Typography>
+          <Typography variant="subtitle1">
+            designed by{' '}
             <a
-              href={definitionDocument.websiteUrl}
+              href={designerWebsiteUrl}
               target="_blank"
               rel="noreferrer"
-              title="Keyboard Website"
+              title="Keyboard Owner"
             >
-              <Home htmlColor="white" fontSize="large" />
+              {designerName}
             </a>
-          </div>
-        ) : null}
+          </Typography>
+        </div>
+        <div className="catalog-keyboard-header-links">
+          {definitionDocument.stores.length > 0 ? (
+            <div className="catalog-keyboard-header-links-stores">
+              <IconButton
+                aria-controls="stores-menu"
+                aria-haspopup={true}
+                title="Stores"
+                onClick={onClickStoresMenu}
+              >
+                <Store htmlColor="white" fontSize="large" />
+              </IconButton>
+              <Menu
+                id="stores-menu"
+                anchorEl={storesMenuAnchorEl}
+                keepMounted
+                open={Boolean(storesMenuAnchorEl)}
+                onClose={onCloseStoresMenu}
+              >
+                {definitionDocument.stores.map((store, index) => {
+                  return (
+                    <MenuItem key={index}>
+                      <Link href={store.url} target="_blank" rel="noreferrer">
+                        {store.name}
+                      </Link>
+                    </MenuItem>
+                  );
+                })}
+              </Menu>
+            </div>
+          ) : null}
+          {definitionDocument.websiteUrl ? (
+            <div className="catalog-keyboard-header-links-home">
+              <a
+                href={definitionDocument.websiteUrl}
+                target="_blank"
+                rel="noreferrer"
+                title="Keyboard Website"
+              >
+                <Home htmlColor="white" fontSize="large" />
+              </a>
+            </div>
+          ) : null}
+        </div>
       </div>
     </header>
   );

--- a/src/components/catalog/search/CatalogSearch.scss
+++ b/src/components/catalog/search/CatalogSearch.scss
@@ -135,6 +135,12 @@
     }
   }
 
+  &-icon {
+    margin-left: 8px;
+    margin-right: 16px;
+    margin-top: 8px;
+  }
+
   &-name {
     margin: 0;
     font-size: 1.6rem;

--- a/src/components/catalog/search/CatalogSearch.tsx
+++ b/src/components/catalog/search/CatalogSearch.tsx
@@ -5,6 +5,7 @@ import {
 } from './CatalogSearch.container';
 import './CatalogSearch.scss';
 import {
+  Avatar,
   Grid,
   Card,
   CardContent,
@@ -16,6 +17,7 @@ import {
 import SearchRoundedIcon from '@mui/icons-material/SearchRounded';
 import {
   getGitHubUserDisplayName,
+  getGitHubUserName,
   IKeyboardDefinitionDocument,
   IOrganization,
 } from '../../../services/storage/Storage';
@@ -202,10 +204,19 @@ function KeyboardCard(props: KeyboardCardProps) {
     return true;
   };
 
+  const isIndividual = props.definition.authorType === 'individual';
+  const organization: IOrganization =
+    props.organizationMap[props.definition.organizationId!];
   const designerName =
-    !props.definition.authorType || props.definition.authorType === 'individual'
+    !props.definition.authorType || isIndividual
       ? getGitHubUserDisplayName(props.definition)
-      : props.organizationMap[props.definition.organizationId!].name;
+      : organization.name;
+  const designerIconImageUrl =
+    !props.definition.authorType || isIndividual
+      ? `https://avatars.githubusercontent.com/${getGitHubUserName(
+          props.definition
+        )}`
+      : organization.icon_image_url;
 
   return (
     <Card className="catalog-search-result-card">
@@ -236,6 +247,9 @@ function KeyboardCard(props: KeyboardCardProps) {
           <div className="catalog-search-result-card-wrapper">
             <div className="catalog-search-result-card-content">
               <div className="catalog-search-result-card-header">
+                <div className="catalog-search-result-card-icon">
+                  <Avatar alt={designerName} src={designerIconImageUrl} />
+                </div>
                 <div className="catalog-search-result-card-header-name-container">
                   <h2 className="catalog-search-result-card-name">
                     {props.definition.name}


### PR DESCRIPTION
Show a designer's icon in the catalog list.
<img width="1002" alt="スクリーンショット 2022-04-11 14 52 17" src="https://user-images.githubusercontent.com/316463/162675860-1114ae01-080c-4b34-852e-712fc0067d02.png">

In the case of mobile displays.
<img width="351" alt="スクリーンショット 2022-04-11 14 52 59" src="https://user-images.githubusercontent.com/316463/162675898-301e4b41-fb59-44b8-93c6-f3e6bb6b7489.png">

Show a designer's icon in the catalog detail.
<img width="1048" alt="スクリーンショット 2022-04-11 14 35 02" src="https://user-images.githubusercontent.com/316463/162675940-31d76821-5dc6-484e-afa6-35f221f4f2f0.png">


