### PR TITLE
Fix the issue #717.

### DIFF
--- a/src/components/catalog/header/Header.container.ts
+++ b/src/components/catalog/header/Header.container.ts
@@ -29,6 +29,7 @@ const mapDispatchToProps = (_dispatch: any) => {
       _dispatch(AppActionsThunk.linkToGitHubAccount());
     },
     goToSearch: () => {
+      _dispatch(storageActionsThunk.fetchAllOrganizations());
       _dispatch(storageActionsThunk.searchKeyboardsForCatalog());
       _dispatch(MetaActions.initialize());
     },


### PR DESCRIPTION
Fix #717 

This pull request fixes the issue #717 by adding the logic to load organizations when going back to the search page at clicking the back button on the catalog detail page.