### PR TITLE
Fix the issue that users cannot fill in to the description field on the keymap store dialog

### DIFF
--- a/src/components/configure/keyeventcapture/KeyEventCapture.tsx
+++ b/src/components/configure/keyeventcapture/KeyEventCapture.tsx
@@ -50,7 +50,8 @@ export default class KeyEventCapture extends React.Component<
   }
 
   onKeyDown(e: React.KeyboardEvent<HTMLDivElement>) {
-    if (e.repeat || (e.target as HTMLElement).tagName === 'INPUT') {
+    const tagName = (e.target as HTMLElement).tagName;
+    if (e.repeat || tagName === 'INPUT' || tagName === 'TEXTAREA') {
       return;
     }
     e.preventDefault();


### PR DESCRIPTION
This pull request fixes the issue which users cannot fill in to the description field on the keymap store/restore dialog.

![remap](https://user-images.githubusercontent.com/261787/185101064-7e8d4341-a646-4b6a-a5fc-d004cbd5b6bc.png)

