### PR TITLE
Select default bootloader for Firmware flashing

### DIFF
--- a/src/actions/keyboards.actions.ts
+++ b/src/actions/keyboards.actions.ts
@@ -14,6 +14,7 @@ import {
   IStore,
 } from '../services/storage/Storage';
 import { ThunkAction, ThunkDispatch } from 'redux-thunk';
+import { IBootloaderType } from '../services/firmware/Types';
 
 export const KEYBOARDS_APP_ACTIONS = '@FIXME!App'; // FIXME!
 export const KEYBOARDS_APP_UPDATE_PHASE = `${KEYBOARDS_APP_ACTIONS}/UpdatePhase`;
@@ -186,6 +187,7 @@ export const KEYBOARDS_EDIT_DEFINITION_UPDATE_FIRMWARE_DESCRIPTION = `${KEYBOARD
 export const KEYBOARDS_EDIT_DEFINITION_UPDATE_FIRMWARE_SOURCE_CODE_URL = `${KEYBOARDS_EDIT_DEFINITION_ACTIONS}/UpdateFirmwareSourceCodeUrl`;
 export const KEYBOARDS_EDIT_DEFINITION_CLEAR_FIRMWARE_FORM = `${KEYBOARDS_EDIT_DEFINITION_ACTIONS}/ClearFirmwareForm`;
 export const KEYBOARDS_EDIT_DEFINITION_UPDATE_FLASH_SUPPORT = `${KEYBOARDS_EDIT_DEFINITION_ACTIONS}/UpdateFlashSupport`;
+export const KEYBOARDS_EDIT_DEFINITION_UPDATE_DEFAULT_BOOTLOADER_TYPE = `${KEYBOARDS_EDIT_DEFINITION_ACTIONS}/UpdateDefaultBootloaderType`;
 export const KEYBOARDS_EDIT_DEFINITION_UPDATE_ORGANIZATION_EVIDENCE = `${KEYBOARDS_EDIT_DEFINITION_ACTIONS}/UpdateOrganizationEvidence`;
 export const KEYBOARDS_EDIT_DEFINITION_UPDATE_ORGANIZATION_ID = `${KEYBOARDS_EDIT_DEFINITION_ACTIONS}/UpdateOrganizationId`;
 export const KEYBOARDS_EDIT_DEFINITION_UPDATE_AUTHOR_TYPE = `${KEYBOARDS_EDIT_DEFINITION_ACTIONS}/UpdateAuthorType`;
@@ -396,6 +398,12 @@ export const KeyboardsEditDefinitionActions = {
     return {
       type: KEYBOARDS_EDIT_DEFINITION_UPDATE_FLASH_SUPPORT,
       value: flashSupport,
+    };
+  },
+  updateDefaultBootloaderType: (defaultBootloaderType: IBootloaderType) => {
+    return {
+      type: KEYBOARDS_EDIT_DEFINITION_UPDATE_DEFAULT_BOOTLOADER_TYPE,
+      value: defaultBootloaderType,
     };
   },
   updateOrganizationEvidence: (organizationEvidence: string) => {

--- a/src/actions/storage.action.ts
+++ b/src/actions/storage.action.ts
@@ -35,6 +35,7 @@ import { IDeviceInformation } from '../services/hid/Hid';
 import { sendEventToGoogleAnalytics } from '../utils/GoogleAnalytics';
 import { CatalogAppActions } from './catalog.action';
 import * as qs from 'qs';
+import { IBootloaderType } from '../services/firmware/Types';
 
 export const STORAGE_ACTIONS = '@Storage';
 export const STORAGE_UPDATE_KEYBOARD_DEFINITION = `${STORAGE_ACTIONS}/UpdateKeyboardDefinition`;
@@ -1275,6 +1276,8 @@ export const storageActionsThunk = {
       const firmwareSourceCodeUrl =
         keyboards.editdefinition.firmwareSourceCodeUrl;
       const flashSupport = keyboards.editdefinition.flashSupport;
+      const defaultBootloaderType =
+        keyboards.editdefinition.defaultBootloaderType;
       const definitionDocument = entities.keyboardDefinitionDocument!;
       const keyboardName = definitionDocument.name;
       const result = await storage.instance!.uploadFirmware(
@@ -1284,6 +1287,7 @@ export const storageActionsThunk = {
         firmwareDescription,
         firmwareSourceCodeUrl,
         flashSupport,
+        defaultBootloaderType,
         keyboardName
       );
       if (result.success) {
@@ -1357,7 +1361,8 @@ export const storageActionsThunk = {
       name: string,
       description: string,
       sourceCodeUrl: string,
-      flashSupport: boolean
+      flashSupport: boolean,
+      defaultBootloaderType: IBootloaderType
     ): ThunkPromiseAction<void> =>
     async (
       dispatch: ThunkDispatch<RootState, undefined, ActionTypes>,
@@ -1372,7 +1377,8 @@ export const storageActionsThunk = {
         name,
         description,
         sourceCodeUrl,
-        flashSupport
+        flashSupport,
+        defaultBootloaderType
       );
       if (result.success) {
         await dispatch(

--- a/src/components/catalog/keyboard/firmware/CatalogFirmware.container.ts
+++ b/src/components/catalog/keyboard/firmware/CatalogFirmware.container.ts
@@ -40,6 +40,11 @@ const mapDispatchToProps = (_dispatch: any) => {
     flashFirmwareDialog: {
       open: (firmware: IFirmware) => {
         _dispatch(FlashFirmwareDialogActions.clear());
+        _dispatch(
+          FlashFirmwareDialogActions.updateBootloaderType(
+            firmware.default_bootloader_type
+          )
+        );
         _dispatch(FlashFirmwareDialogActions.updateFirmware(firmware));
       },
       close: () => {

--- a/src/components/keyboards/editdefinition/firmwareform/FirmwareForm.container.ts
+++ b/src/components/keyboards/editdefinition/firmwareform/FirmwareForm.container.ts
@@ -4,6 +4,7 @@ import FirmwareForm from './FirmwareForm';
 import { KeyboardsEditDefinitionActions } from '../../../../actions/keyboards.actions';
 import { storageActionsThunk } from '../../../../actions/storage.action';
 import { IFirmware } from '../../../../services/storage/Storage';
+import { IBootloaderType } from '../../../../services/firmware/Types';
 
 const mapStateToProps = (state: RootState) => {
   return {
@@ -13,6 +14,7 @@ const mapStateToProps = (state: RootState) => {
     firmwareDescription: state.keyboards.editdefinition.firmwareDescription,
     firmwareSourceCodeUrl: state.keyboards.editdefinition.firmwareSourceCodeUrl,
     flashSupport: state.keyboards.editdefinition.flashSupport,
+    defaultBootloaderType: state.keyboards.editdefinition.defaultBootloaderType,
   };
 };
 export type FirmwareFormStateType = ReturnType<typeof mapStateToProps>;
@@ -48,6 +50,13 @@ const mapDispatchToProps = (_dispatch: any) => {
         KeyboardsEditDefinitionActions.updateFlashSupport(flashSupport)
       );
     },
+    updateDefaultBootloaderType: (defaultBootloaderType: IBootloaderType) => {
+      _dispatch(
+        KeyboardsEditDefinitionActions.updateDefaultBootloaderType(
+          defaultBootloaderType
+        )
+      );
+    },
     clearFirmwareForm: () => {
       _dispatch(KeyboardsEditDefinitionActions.clearFirmwareForm());
     },
@@ -72,7 +81,8 @@ const mapDispatchToProps = (_dispatch: any) => {
       name: string,
       description: string,
       sourceCodeUrl: string,
-      flashSupport: boolean
+      flashSupport: boolean,
+      defaultBootloaderType: IBootloaderType
     ) => {
       _dispatch(
         storageActionsThunk.updateFirmware(
@@ -80,7 +90,8 @@ const mapDispatchToProps = (_dispatch: any) => {
           name,
           description,
           sourceCodeUrl,
-          flashSupport
+          flashSupport,
+          defaultBootloaderType
         )
       );
     },

--- a/src/components/keyboards/editdefinition/firmwareform/FirmwareForm.tsx
+++ b/src/components/keyboards/editdefinition/firmwareform/FirmwareForm.tsx
@@ -23,6 +23,7 @@ import {
 } from '@mui/material';
 import { IFirmware } from '../../../../services/storage/Storage';
 import moment from 'moment';
+import { IBootloaderType } from '../../../../services/firmware/Types';
 
 type OwnProps = {};
 type FirmwareFormProps = OwnProps &
@@ -110,14 +111,16 @@ export default function FirmwareForm(props: FirmwareFormProps) {
     name: string,
     description: string,
     sourceCodeUrl: string,
-    flashSupport: boolean
+    flashSupport: boolean,
+    defaultBootloaderType: IBootloaderType
   ) => {
     props.updateFirmware!(
       firmware,
       name,
       description,
       sourceCodeUrl,
-      flashSupport
+      flashSupport,
+      defaultBootloaderType
     );
   };
 
@@ -233,6 +236,28 @@ export default function FirmwareForm(props: FirmwareFormProps) {
               </Select>
             </FormControl>
           </div>
+          {props.flashSupport ? (
+            <div className="edit-definition-firmware-form-row">
+              <FormControl>
+                <FormLabel component="legend">
+                  Default Bootloader Type
+                </FormLabel>
+                <Select
+                  value={props.defaultBootloaderType}
+                  onChange={(event) => {
+                    props.updateDefaultBootloaderType!(
+                      event.target.value as IBootloaderType
+                    );
+                  }}
+                >
+                  <MenuItem value="caterina">caterina</MenuItem>
+                  <MenuItem value="dfu">dfu</MenuItem>
+                </Select>
+              </FormControl>
+            </div>
+          ) : (
+            ''
+          )}
           <div className="edit-definition-firmware-form-buttons">
             <Button
               color="primary"
@@ -307,7 +332,9 @@ type IFirmwareCardProps = {
     // eslint-disable-next-line no-unused-vars
     sourceCodeUrl: string,
     // eslint-disable-next-line no-unused-vars
-    flashSupport: boolean
+    flashSupport: boolean,
+    // eslint-disable-next-line no-unused-vars
+    defaultBootloaderType: IBootloaderType
   ) => void;
 };
 
@@ -327,7 +354,8 @@ function FirmwareCard(props: IFirmwareCardProps) {
     name: string,
     description: string,
     sourceCodeUrl: string,
-    flashSupport: boolean
+    flashSupport: boolean,
+    defaultBootloaderType: IBootloaderType
   ) => {
     setOpen(false);
     props.onClickEditDialogUpdate(
@@ -335,7 +363,8 @@ function FirmwareCard(props: IFirmwareCardProps) {
       name,
       description,
       sourceCodeUrl,
-      flashSupport
+      flashSupport,
+      defaultBootloaderType
     );
   };
 
@@ -355,6 +384,15 @@ function FirmwareCard(props: IFirmwareCardProps) {
             SHA256: {props.firmware.hash}
             <br />
             Flash Support: {props.firmware.flash_support ? 'Yes' : 'No'}
+            {props.firmware.flash_support ? (
+              <React.Fragment>
+                <br />
+                Default Bootloader Type:{' '}
+                {props.firmware.default_bootloader_type}
+              </React.Fragment>
+            ) : (
+              ''
+            )}
           </Typography>
         </CardContent>
         <CardActions className="edit-definition-firmware-form-card-buttons">
@@ -455,7 +493,9 @@ type IEditDialogProps = {
     // eslint-disable-next-line no-unused-vars
     sourceCodeUrl: string,
     // eslint-disable-next-line no-unused-vars
-    flashSupport: boolean
+    flashSupport: boolean,
+    // eslint-disable-next-line no-unused-vars
+    defaultBootloaderType: IBootloaderType
   ) => void;
 };
 
@@ -464,6 +504,8 @@ function EditDialog(props: IEditDialogProps) {
   const [description, setDescription] = useState<string>('');
   const [sourceCodeUrl, setSourceCodeUrl] = useState<string>('');
   const [flashSupport, setFlashSupport] = useState<boolean>(false);
+  const [defaultBootloaderType, setDefaultBootloaderType] =
+    useState<IBootloaderType>('caterina');
 
   useEffect(() => {
     if (props.open) {
@@ -471,6 +513,7 @@ function EditDialog(props: IEditDialogProps) {
       setDescription(props.firmware.description);
       setSourceCodeUrl(props.firmware.sourceCodeUrl);
       setFlashSupport(props.firmware.flash_support);
+      setDefaultBootloaderType(props.firmware.default_bootloader_type);
     }
   }, [props.open]);
 
@@ -548,6 +591,22 @@ function EditDialog(props: IEditDialogProps) {
             <MenuItem value="yes">Yes</MenuItem>
           </Select>
         </FormControl>
+        {flashSupport ? (
+          <FormControl className="edit-firmware-dialog-item">
+            <FormLabel component="legend">Default Bootloader Type</FormLabel>
+            <Select
+              value={defaultBootloaderType}
+              onChange={(event) => {
+                setDefaultBootloaderType(event.target.value as IBootloaderType);
+              }}
+            >
+              <MenuItem value="caterina">caterina</MenuItem>
+              <MenuItem value="dfu">dfu</MenuItem>
+            </Select>
+          </FormControl>
+        ) : (
+          ''
+        )}
       </DialogContent>
       <DialogActions>
         <Button onClick={() => props.onClickCancel()}>Cancel</Button>
@@ -559,7 +618,8 @@ function EditDialog(props: IEditDialogProps) {
               name,
               description,
               sourceCodeUrl,
-              flashSupport
+              flashSupport,
+              defaultBootloaderType
             )
           }
           disabled={!validateFirmwareForm()}

--- a/src/services/provider/Firebase.ts
+++ b/src/services/provider/Firebase.ts
@@ -37,6 +37,7 @@ import { IAuth, IAuthenticationResult } from '../auth/Auth';
 import { IFirmwareCodePlace, IKeyboardFeatures } from '../../store/state';
 import { IDeviceInformation } from '../hid/Hid';
 import * as crypto from 'crypto';
+import { IBootloaderType } from '../firmware/Types';
 
 const config = {
   apiKey: process.env.REACT_APP_FIREBASE_API_KEY,
@@ -91,6 +92,8 @@ export class FirebaseProvider implements IStorage, IAuth {
           sourceCodeUrl: firmware.source_code_url,
           created_at: firmware.created_at.toDate(),
           flash_support: firmware.flash_support || false,
+          default_bootloader_type:
+            firmware.default_bootloader_type || 'caterina',
         });
       });
     }
@@ -1058,6 +1061,7 @@ export class FirebaseProvider implements IStorage, IAuth {
     firmwareDescription: string,
     firmwareSourceCodeUrl: string,
     flashSupport: boolean,
+    defaultBootloaderType: IBootloaderType,
     keyboardName: string,
     // eslint-disable-next-line no-unused-vars
     progress?: (uploadedRate: number) => void
@@ -1101,6 +1105,7 @@ export class FirebaseProvider implements IStorage, IAuth {
             filename: filePath,
             hash,
             flash_support: flashSupport,
+            default_bootloader_type: defaultBootloaderType,
           };
           await this.db
             .collection('keyboards')
@@ -1222,7 +1227,8 @@ export class FirebaseProvider implements IStorage, IAuth {
     firmwareName: string,
     firmwareDescription: string,
     firmwareSourceCodeUrl: string,
-    flashSupport: boolean
+    flashSupport: boolean,
+    defaultBootloaderType: IBootloaderType
   ): Promise<IResult> {
     const definitionDocument = await this.db
       .collection('keyboards')
@@ -1241,6 +1247,7 @@ export class FirebaseProvider implements IStorage, IAuth {
             x.description = firmwareDescription;
             x.source_code_url = firmwareSourceCodeUrl;
             x.flash_support = flashSupport;
+            x.default_bootloader_type = defaultBootloaderType;
           }
           return x;
         });

--- a/src/services/storage/Storage.ts
+++ b/src/services/storage/Storage.ts
@@ -2,6 +2,7 @@ import { LayoutOption } from '../../components/configure/keymap/Keymap';
 import { IFirmwareCodePlace, IKeyboardFeatures } from '../../store/state';
 import { IDeviceInformation } from '../hid/Hid';
 import { KeyboardLabelLang } from '../labellang/KeyLabelLangs';
+import { IBootloaderType } from '../firmware/Types';
 
 export interface IResult {
   readonly success: boolean;
@@ -46,6 +47,7 @@ export interface IFirmware {
   filename: string;
   sourceCodeUrl: string;
   flash_support: boolean;
+  default_bootloader_type: IBootloaderType;
 }
 
 export type IKeyboardDefinitionAuthorType = 'individual' | 'organization';
@@ -347,6 +349,7 @@ export interface IStorage {
     firmwareDescription: string,
     firmwareSourceCodeUrl: string,
     flashSupport: boolean,
+    defaultBootloaderType: IBootloaderType,
     keyboardName: string
   ): Promise<IResult>;
   fetchFirmwareFileBlob(
@@ -361,7 +364,8 @@ export interface IStorage {
     firmwareName: string,
     firmwareDescription: string,
     firmwareSourceCodeUrl: string,
-    flashSupport: boolean
+    flashSupport: boolean,
+    defaultBootloaderType: IBootloaderType
   ): Promise<IResult>;
 
   fetchOrganizationById(

--- a/src/store/reducers.ts
+++ b/src/store/reducers.ts
@@ -142,6 +142,7 @@ import {
   KEYBOARDS_EDIT_DEFINITION_UPDATE_ORGANIZATION_EVIDENCE,
   KEYBOARDS_EDIT_DEFINITION_UPDATE_ORGANIZATION_ID,
   KEYBOARDS_EDIT_DEFINITION_UPDATE_AUTHOR_TYPE,
+  KEYBOARDS_EDIT_DEFINITION_UPDATE_DEFAULT_BOOTLOADER_TYPE,
 } from '../actions/keyboards.actions';
 import { MOD_LEFT } from '../services/hid/Composition';
 import { LayoutOption } from '../components/configure/keymap/Keymap';
@@ -406,6 +407,9 @@ const keyboardsEditKeyboardReducer = (
       break;
     case KEYBOARDS_EDIT_DEFINITION_UPDATE_FLASH_SUPPORT:
       draft.keyboards.editdefinition.flashSupport = action.value;
+      break;
+    case KEYBOARDS_EDIT_DEFINITION_UPDATE_DEFAULT_BOOTLOADER_TYPE:
+      draft.keyboards.editdefinition.defaultBootloaderType = action.value;
       break;
     case KEYBOARDS_EDIT_DEFINITION_UPDATE_ORGANIZATION_EVIDENCE:
       draft.keyboards.editdefinition.organizationEvidence = action.value;

--- a/src/store/state.ts
+++ b/src/store/state.ts
@@ -327,6 +327,7 @@ export type RootState = {
       firmwareDescription: string;
       firmwareSourceCodeUrl: string;
       flashSupport: boolean;
+      defaultBootloaderType: IBootloaderType;
       authorType: IKeyboardDefinitionAuthorType;
       organizationId: string | undefined;
       organizationEvidence: string;
@@ -544,6 +545,7 @@ export const INIT_STATE: RootState = {
       firmwareDescription: '',
       firmwareSourceCodeUrl: '',
       flashSupport: false,
+      defaultBootloaderType: 'caterina',
       authorType: 'individual',
       organizationId: undefined,
       organizationEvidence: '',


### PR DESCRIPTION
Fix #714

This pull request adds a new feature to select a default bootloader for flashing firmware.

The firmware management form has a new UI to select the default bootloader type.

![Screenshot_20220818_081232](https://user-images.githubusercontent.com/261787/185259611-7bc020da-e6c3-4e6f-b197-76f86d14bed8.png)

![Screenshot_20220818_081255](https://user-images.githubusercontent.com/261787/185259622-19618044-137d-40d5-8d78-551d7c3d1764.png)

And, the default bootloader type is shown as default on the flashing firmware dialog.

![Screenshot_20220818_081332](https://user-images.githubusercontent.com/261787/185259770-d33d9ce4-f9ed-4d53-b42a-d65b964fa254.png)

