### PR TITLE
Change the logic to determine the display name of the authenticated user

### DIFF
--- a/src/components/configure/keymaplist/KeymapListPopover.tsx
+++ b/src/components/configure/keymaplist/KeymapListPopover.tsx
@@ -187,9 +187,7 @@ export default class KeymapListPopover extends React.Component<
                 open={this.state.openKeymapSaveDialog}
                 savedKeymapData={this.state.savedKeymapData}
                 authorUid={this.props.auth!.getCurrentAuthenticatedUser().uid}
-                authorDisplayName={
-                  this.props.auth!.getCurrentAuthenticatedUser().displayName!
-                }
+                authorDisplayName={this.props.auth!.getCurrentAuthenticatedUserDisplayName()}
                 onClose={() => {
                   this.onCloseKeymapSaveDialog();
                 }}

--- a/src/services/auth/Auth.ts
+++ b/src/services/auth/Auth.ts
@@ -17,6 +17,7 @@ export interface IAuth {
   // eslint-disable-next-line no-unused-vars
   subscribeAuthStatus(callback: (user: firebase.User | null) => void): void;
   getCurrentAuthenticatedUser(): firebase.User;
+  getCurrentAuthenticatedUserDisplayName(): string;
   signOut(): Promise<void>;
 }
 

--- a/src/services/provider/Firebase.test.ts
+++ b/src/services/provider/Firebase.test.ts
@@ -1,4 +1,6 @@
 import { FirebaseProvider } from './Firebase';
+import firebase from 'firebase/app';
+import * as sinon from 'sinon';
 
 describe('FirebaseProvider', () => {
   test('createFirmwareFilename', () => {
@@ -11,5 +13,89 @@ describe('FirebaseProvider', () => {
       timestamp
     );
     expect(actual).toEqual('keyboard-name-1-12345.hex');
+  });
+
+  describe('getCurrentAuthenticatedUserDisplayName', () => {
+    test('user.displayName', () => {
+      const subject: FirebaseProvider = {
+        getCurrentAuthenticatedUser(): firebase.User {
+          return {
+            displayName: 'displayName1',
+          } as firebase.User;
+        },
+      } as FirebaseProvider;
+      subject.getCurrentAuthenticatedUserDisplayName =
+        FirebaseProvider.prototype.getCurrentAuthenticatedUserDisplayName;
+      expect(subject.getCurrentAuthenticatedUserDisplayName()).toEqual(
+        'displayName1'
+      );
+    });
+
+    test('user.providerData[0].displayName', () => {
+      const subject: FirebaseProvider = {
+        getCurrentAuthenticatedUser(): firebase.User {
+          return {
+            displayName: null,
+            providerData: [{ displayName: 'displayName2' }],
+          } as firebase.User;
+        },
+      } as FirebaseProvider;
+      subject.getCurrentAuthenticatedUserDisplayName =
+        FirebaseProvider.prototype.getCurrentAuthenticatedUserDisplayName;
+      expect(subject.getCurrentAuthenticatedUserDisplayName()).toEqual(
+        'displayName2'
+      );
+    });
+
+    test('user.email', () => {
+      const subject: FirebaseProvider = {
+        getCurrentAuthenticatedUser(): firebase.User {
+          return {
+            displayName: null,
+            providerData: [{ displayName: null }],
+            email: 'displayName3@example.com',
+          } as firebase.User;
+        },
+      } as FirebaseProvider;
+      subject.getCurrentAuthenticatedUserDisplayName =
+        FirebaseProvider.prototype.getCurrentAuthenticatedUserDisplayName;
+      expect(subject.getCurrentAuthenticatedUserDisplayName()).toEqual(
+        'displayName3'
+      );
+    });
+
+    test('user.email', () => {
+      const subject: FirebaseProvider = {
+        getCurrentAuthenticatedUser(): firebase.User {
+          return {
+            displayName: null,
+            providerData: [{ displayName: null }],
+            email: 'displayName3@example.com',
+          } as firebase.User;
+        },
+      } as FirebaseProvider;
+      subject.getCurrentAuthenticatedUserDisplayName =
+        FirebaseProvider.prototype.getCurrentAuthenticatedUserDisplayName;
+      expect(subject.getCurrentAuthenticatedUserDisplayName()).toEqual(
+        'displayName3'
+      );
+    });
+
+    test('noname', () => {
+      const subject: FirebaseProvider = {
+        getCurrentAuthenticatedUser(): firebase.User {
+          return {
+            displayName: null,
+            providerData: [{ displayName: null }],
+            email: null,
+          } as firebase.User;
+        },
+      } as FirebaseProvider;
+      subject.getCurrentAuthenticatedUserDisplayName =
+        FirebaseProvider.prototype.getCurrentAuthenticatedUserDisplayName;
+      expect(subject.getCurrentAuthenticatedUserDisplayName()).toEqual(
+        '(no name)'
+      );
+    });
   });
 });

--- a/src/services/provider/Firebase.ts
+++ b/src/services/provider/Firebase.ts
@@ -643,6 +643,25 @@ export class FirebaseProvider implements IStorage, IAuth {
     return this.auth.currentUser!;
   }
 
+  getCurrentAuthenticatedUserDisplayName(): string {
+    const user = this.getCurrentAuthenticatedUser();
+    let displayName: string | undefined | null = user.displayName;
+    if (displayName) {
+      return displayName;
+    }
+    for (const userInfo of user.providerData) {
+      displayName = userInfo?.displayName;
+      if (displayName) {
+        return displayName;
+      }
+    }
+    const email = user.email;
+    if (email && 0 < email.indexOf('@')) {
+      return email.substring(0, email.indexOf('@'));
+    }
+    return '(no name)';
+  }
+
   async signOut(): Promise<void> {
     await this.auth.signOut();
   }


### PR DESCRIPTION
Fix #713 

This pull request changes the logic how to determine the display name of the authenticated user when storing a key mapping data.