### PR TITLE
Fetch VIA protocol version at opening a keyboard

### DIFF
--- a/src/actions/hid.action.ts
+++ b/src/actions/hid.action.ts
@@ -30,6 +30,7 @@ export const HID_UPDATE_BLE_MICRO_PRO = `${HID_ACTIONS}/UpdateBleMicroPro`;
 export const HID_UPDATE_MACRO_BUFFER_BYTES = `${HID_ACTIONS}/UpdateMacroBufferBytes`;
 export const HID_UPDATE_MACRO_MAX_BUFFER_SIZE = `${HID_ACTIONS}/UpdateMacroMaxBufferSize`;
 export const HID_UPDATE_MACRO_MAX_COUNT = `${HID_ACTIONS}/UpdateMacroMaxCount`;
+export const HID_UPDATE_VIA_PROTOCOL_VERSION = `${HID_ACTIONS}/UpdateViaProtocolVersion`;
 export const HidActions = {
   connectKeyboard: (keyboard: IKeyboard) => {
     return {
@@ -98,6 +99,13 @@ export const HidActions = {
     return {
       type: HID_UPDATE_MACRO_MAX_COUNT,
       value: count,
+    };
+  },
+
+  updateViaProtocolVersion: (version: number) => {
+    return {
+      type: HID_UPDATE_VIA_PROTOCOL_VERSION,
+      value: version,
     };
   },
 };
@@ -268,6 +276,17 @@ export const hidActionsThunk = {
             .productName.includes(PRODUCT_PREFIX_FOR_BLE_MICRO_PRO)
         )
       );
+      const viaProtocolVersionResult = await keyboard.fetchViaProtocolVersion();
+      if (!viaProtocolVersionResult.success) {
+        dispatch(
+          NotificationActions.addError(
+            'Fetching the VIA protocol version failed.'
+          )
+        );
+        return;
+      }
+      const viaProtocolVersion = viaProtocolVersionResult.viaProtocolVersion!;
+      dispatch(HidActions.updateViaProtocolVersion(viaProtocolVersion));
       const layerResult = await keyboard.fetchLayerCount();
       if (!layerResult.success) {
         dispatch(

--- a/src/components/configure/info/InfoDialog.container.ts
+++ b/src/components/configure/info/InfoDialog.container.ts
@@ -9,6 +9,7 @@ const mapStateToProps = (state: RootState) => {
     keyboardDefinitionDocument: state.entities.keyboardDefinitionDocument,
     auth: state.auth.instance,
     organization: state.entities.organization,
+    viaProtocolVersion: state.entities.device.viaProtocolVersion,
   };
 };
 export type InfoDialogStateType = ReturnType<typeof mapStateToProps>;

--- a/src/components/configure/info/InfoDialog.tsx
+++ b/src/components/configure/info/InfoDialog.tsx
@@ -32,6 +32,7 @@ type OwnState = {
     productName: string;
     vendorId: number;
     productId: number;
+    viaProtocolVersion: number;
   };
   keyboardDef: {
     name: string;
@@ -67,6 +68,7 @@ export default class InfoDialog extends React.Component<
         productName: '',
         vendorId: NaN,
         productId: NaN,
+        viaProtocolVersion: NaN,
       },
       keyboardDef: {
         name: '',
@@ -92,7 +94,10 @@ export default class InfoDialog extends React.Component<
         this.props.keyboardDefinitionDocument.githubDisplayName;
     }
 
-    const deviceInfo = this.props.keyboard!.getInformation();
+    const deviceInfo = {
+      ...this.props.keyboard!.getInformation(),
+      viaProtocolVersion: this.props.viaProtocolVersion!,
+    };
     const keyboardDef = this.props.keyboardDefinition!;
     this.setState({ deviceInfo, keyboardDef });
   }
@@ -132,6 +137,10 @@ export default class InfoDialog extends React.Component<
             <InfoRow
               label="Product ID"
               value={hexadecimal(this.state.deviceInfo.productId, 4)}
+            />
+            <InfoRow
+              label="VIA Protocol Version"
+              value={hexadecimal(this.state.deviceInfo.viaProtocolVersion, 4)}
             />
             <KeyboardDefinitionSection
               keyboardDefinitionDocument={this.props.keyboardDefinitionDocument}

--- a/src/services/hid/Commands.ts
+++ b/src/services/hid/Commands.ts
@@ -634,3 +634,26 @@ export class SetLayoutOptionsCommand extends AbstractCommand<
     return resultArray[0] === 0x03 && resultArray[1] === 0x02;
   }
 }
+
+export interface IGetProtocolVersionResult extends ICommandResponse {
+  protocolVersion: number;
+}
+
+export class GetProtocolVersionCommand extends AbstractCommand<
+  ICommandRequest,
+  IGetProtocolVersionResult
+> {
+  createReport(): Uint8Array {
+    return new Uint8Array([0x01]);
+  }
+
+  createResponse(resultArray: Uint8Array): IGetProtocolVersionResult {
+    return {
+      protocolVersion: (resultArray[1] << 8) | resultArray[2],
+    };
+  }
+
+  isSameRequest(resultArray: Uint8Array): boolean {
+    return resultArray[0] === 0x01;
+  }
+}

--- a/src/services/hid/Hid.mock.ts
+++ b/src/services/hid/Hid.mock.ts
@@ -6,6 +6,7 @@ import {
   IConnectionEventHandler,
   IConnectParams,
   IFetchLayoutOptionsResult,
+  IFetchViaProtocolVersionResult,
   IGetMacroCountResult,
   IHid,
   IKeyboard,
@@ -212,6 +213,11 @@ export const mockIKeyboad: IKeyboard = {
   updateMacroBuffer: (offset: number, buffer: Uint8Array) => {
     return new Promise((resolve) => {
       resolve({ success: true });
+    });
+  },
+  fetchViaProtocolVersion(): Promise<IFetchViaProtocolVersionResult> {
+    return new Promise((resolve) => {
+      resolve({ success: true, viaProtocolVersion: 0x0a });
     });
   },
 };

--- a/src/services/hid/Hid.ts
+++ b/src/services/hid/Hid.ts
@@ -126,6 +126,10 @@ export interface IFetchMacroBufferResult extends IResult {
   buffer?: Uint8Array;
 }
 
+export interface IFetchViaProtocolVersionResult extends IResult {
+  viaProtocolVersion?: number;
+}
+
 export interface IKeyboard {
   getDevice(): HIDDevice;
   getHid(): IHid;
@@ -169,6 +173,7 @@ export interface IKeyboard {
   getMacroBufferSize(): Promise<IGetMacroBufferSizeResult>;
   fetchMacroBuffer(bufferSize: number): Promise<IFetchMacroBufferResult>;
   updateMacroBuffer(offset: number, buffer: Uint8Array): Promise<IResult>;
+  fetchViaProtocolVersion(): Promise<IFetchViaProtocolVersionResult>;
 }
 
 export interface ICommand {

--- a/src/services/hid/WebHid.ts
+++ b/src/services/hid/WebHid.ts
@@ -20,6 +20,7 @@ import {
   IGetMacroCountResult,
   IGetMacroBufferSizeResult,
   IFetchMacroBufferResult,
+  IFetchViaProtocolVersionResult,
 } from './Hid';
 import { KeycodeList } from './KeycodeList';
 import {
@@ -33,6 +34,7 @@ import {
   DynamicKeymapResetCommand,
   DynamicKeymapSetKeycodeCommand,
   GetLayoutOptionsCommand,
+  GetProtocolVersionCommand,
   IDynamicKeymapMacroGetBufferResponse,
   IDynamicKeymapMacroSetBufferResponse,
   IDynamicKeymapReadBufferResponse,
@@ -267,6 +269,26 @@ export class Keyboard implements IKeyboard {
           }
         }
       );
+      return this.enqueue(command);
+    });
+  }
+
+  fetchViaProtocolVersion(): Promise<IFetchViaProtocolVersionResult> {
+    return new Promise<IFetchViaProtocolVersionResult>((resolve) => {
+      const command = new GetProtocolVersionCommand({}, async (result) => {
+        if (result.success) {
+          resolve({
+            success: true,
+            viaProtocolVersion: result.response!.protocolVersion,
+          });
+        } else {
+          resolve({
+            success: false,
+            error: result.error,
+            cause: result.cause,
+          });
+        }
+      });
       return this.enqueue(command);
     });
   }

--- a/src/store/reducers.ts
+++ b/src/store/reducers.ts
@@ -58,6 +58,7 @@ import {
   HID_UPDATE_MACRO_BUFFER_BYTES,
   HID_UPDATE_MACRO_MAX_BUFFER_SIZE,
   HID_UPDATE_MACRO_MAX_COUNT,
+  HID_UPDATE_VIA_PROTOCOL_VERSION,
 } from '../actions/hid.action';
 import {
   STORAGE_ACTIONS,
@@ -680,6 +681,10 @@ const hidReducer = (action: Action, draft: WritableDraft<RootState>) => {
     }
     case HID_UPDATE_MACRO_MAX_COUNT: {
       draft.entities.device.macro.maxCount = action.value;
+      break;
+    }
+    case HID_UPDATE_VIA_PROTOCOL_VERSION: {
+      draft.entities.device.viaProtocolVersion = action.value;
       break;
     }
   }

--- a/src/store/state.ts
+++ b/src/store/state.ts
@@ -201,6 +201,7 @@ export type RootState = {
         maxBufferSize: number;
         maxCount: number;
       };
+      viaProtocolVersion: number;
     };
     keyboards: IKeyboard[]; // authorized keyboard list
     keyboard: IKeyboard | null;
@@ -430,6 +431,7 @@ export const INIT_STATE: RootState = {
         maxBufferSize: 0,
         maxCount: 0,
       },
+      viaProtocolVersion: NaN,
     },
     keyboards: [],
     keyboard: null, // hid.keyboards[i]

--- a/src/store/state.ts
+++ b/src/store/state.ts
@@ -189,8 +189,6 @@ export type RootState = {
       productId: number;
       name: string | null;
       layerCount: number;
-      rowCount: number;
-      columnCount: number;
       keymaps: {
         [pos: string]: IKeymap;
       }[];
@@ -424,8 +422,6 @@ export const INIT_STATE: RootState = {
       productId: NaN,
       name: null,
       layerCount: NaN,
-      rowCount: NaN,
-      columnCount: NaN,
       keymaps: [],
       macros: {},
       bleMicroPro: false,


### PR DESCRIPTION
This pull request adds two new logics like the following:

* Fetching VIA protocol version number at opening a keyboard and storing it to the state.
* Display the VIA protocol version number on a keyboard information dialog.

![Screenshot_20220909_092255](https://user-images.githubusercontent.com/261787/189247746-b6ce3aab-de38-4da2-a3f2-8b3e96d9ac08.png)
