### PR TITLE
Encoder support for KeyboardModel and some classes

### DIFF
--- a/src/models/KeyModel.test.ts
+++ b/src/models/KeyModel.test.ts
@@ -1,0 +1,17 @@
+import KeyModel from './KeyModel';
+
+describe('KeyModel', () => {
+  test('isEncoder', () => {
+    let subject = new KeyModel(null, '0,1', 0, 0, '', 0, 0, 0, 0);
+    expect(subject.isEncoder).toBeTruthy();
+    subject = new KeyModel(null, '0,1', 0, 0, '', 0, 0, 0, null);
+    expect(subject.isEncoder).toBeFalsy();
+  });
+
+  test('encoderId', () => {
+    let subject = new KeyModel(null, '0,1', 0, 0, '', 0, 0, 0, 2);
+    expect(subject.encoderId).toEqual(2);
+    subject = new KeyModel(null, '0,1', 0, 0, '', 0, 0, 0, null);
+    expect(subject.encoderId).toBeNull();
+  });
+});

--- a/src/models/KeyModel.ts
+++ b/src/models/KeyModel.ts
@@ -34,6 +34,7 @@ export default class KeyModel {
   readonly h: number;
   readonly w2: number;
   readonly h2: number;
+  readonly encoderId: number | null;
 
   constructor(
     op: KeyOp | null,
@@ -43,13 +44,15 @@ export default class KeyModel {
     c: string,
     r: number = 0,
     rx: number = 0,
-    ry: number = 0
+    ry: number = 0,
+    encoderId: number | null = null
   ) {
     this.keyOp = op;
     this.x = x;
     this.y = y;
     this.rx = rx;
     this.ry = ry;
+    this.encoderId = encoderId;
     this.location = location;
     const locs = location.split('\n');
     this.pos = locs[0]; // 0 < locs[0].length ? locs[0] : locs[3];
@@ -140,6 +143,10 @@ export default class KeyModel {
 
   get isBackwardsEnter(): boolean {
     return this.isOddly && this.top != this.top2;
+  }
+
+  get isEncoder(): boolean {
+    return this.encoderId !== null;
   }
 
   get style(): CSSProperties {

--- a/src/models/KeyboardModel.test.ts
+++ b/src/models/KeyboardModel.test.ts
@@ -1,0 +1,24 @@
+import { Current, KeymapItem } from './KeyboardModel';
+
+describe('KeymapItem', () => {
+  test('encoder exists', () => {
+    const current = new Current();
+    const subject = new KeymapItem(current, '0,0\n\n\n\n\n\n\n\n\ne0');
+    expect(subject.encoderId).toEqual(0);
+  });
+
+  test('encoder exists', () => {
+    const current = new Current();
+    const subject = new KeymapItem(
+      current,
+      '0,0\n0,6\n0,2\n0,8\n0.9\n1,1\n0,3\n0,5\n0,1\ne1\n0,7\n1,0'
+    );
+    expect(subject.encoderId).toEqual(1);
+  });
+
+  test('encoder not exists', () => {
+    const current = new Current();
+    const subject = new KeymapItem(current, '0,0');
+    expect(subject.encoderId).toBeNull();
+  });
+});

--- a/src/models/KeyboardModel.test.ts
+++ b/src/models/KeyboardModel.test.ts
@@ -1,24 +1,60 @@
 import { Current, KeymapItem } from './KeyboardModel';
+import { OPTION_DEFAULT } from './KeyModel';
 
 describe('KeymapItem', () => {
-  test('encoder exists', () => {
-    const current = new Current();
-    const subject = new KeymapItem(current, '0,0\n\n\n\n\n\n\n\n\ne0');
-    expect(subject.encoderId).toEqual(0);
+  describe('encoderId', () => {
+    test('encoder exists - 1', () => {
+      const current = new Current();
+      const subject = new KeymapItem(current, '0,0\n\n\n\n\n\n\n\n\ne0');
+      expect(subject.encoderId).toEqual(0);
+    });
+
+    test('encoder exists - 2', () => {
+      const current = new Current();
+      const subject = new KeymapItem(
+        current,
+        '0,0\n0,6\n0,2\n0,8\n0.9\n1,1\n0,3\n0,5\n0,1\ne1\n0,7\n1,0'
+      );
+      expect(subject.encoderId).toEqual(1);
+    });
+
+    test('encoder not exists', () => {
+      const current = new Current();
+      const subject = new KeymapItem(current, '0,0');
+      expect(subject.encoderId).toBeNull();
+    });
   });
 
-  test('encoder exists', () => {
-    const current = new Current();
-    const subject = new KeymapItem(
-      current,
-      '0,0\n0,6\n0,2\n0,8\n0.9\n1,1\n0,3\n0,5\n0,1\ne1\n0,7\n1,0'
-    );
-    expect(subject.encoderId).toEqual(1);
-  });
+  describe('option and choice', () => {
+    test('option not found - 1', () => {
+      const current = new Current();
+      const subject = new KeymapItem(current, '0,0');
+      expect(subject.option).toEqual(OPTION_DEFAULT);
+      expect(subject.choice).toEqual(OPTION_DEFAULT);
+    });
 
-  test('encoder not exists', () => {
-    const current = new Current();
-    const subject = new KeymapItem(current, '0,0');
-    expect(subject.encoderId).toBeNull();
+    test('option not found - 2', () => {
+      const current = new Current();
+      const subject = new KeymapItem(current, '0,0\n\n\n\n\n\n\n\n\ne0');
+      expect(subject.option).toEqual(OPTION_DEFAULT);
+      expect(subject.choice).toEqual(OPTION_DEFAULT);
+    });
+
+    test('option found - 1', () => {
+      const current = new Current();
+      const subject = new KeymapItem(current, '0,0\n\n\n1,2');
+      expect(subject.option).toEqual('1');
+      expect(subject.choice).toEqual('2');
+    });
+
+    test('option found - 2', () => {
+      const current = new Current();
+      const subject = new KeymapItem(
+        current,
+        '0,0\n0,6\n0,2\n1,2\n0.9\n1,1\n0,3\n0,5\n0,1\ne1\n0,7\n1,0'
+      );
+      expect(subject.option).toEqual('1');
+      expect(subject.choice).toEqual('2');
+    });
   });
 });

--- a/src/models/KeyboardModel.ts
+++ b/src/models/KeyboardModel.ts
@@ -11,7 +11,7 @@ export type KeyboardViewContent = {
   top: number;
 };
 
-class Current {
+export class Current {
   x = 0;
   y = -1;
   c = '#cccccc';
@@ -81,7 +81,7 @@ class Current {
   }
 }
 
-class KeymapItem {
+export class KeymapItem {
   private _curr: Current;
   readonly op: KeyOp;
   readonly label: string;
@@ -89,6 +89,7 @@ class KeymapItem {
   readonly option: string;
   readonly choice: string;
   private _toBeDelete: boolean;
+  private readonly _encoderId: number | null;
 
   constructor(curr: Current, label: string, op: KeyOp | null = null) {
     this._curr = new Current(curr);
@@ -101,6 +102,13 @@ class KeymapItem {
     this.option = options[0];
     this.choice = options[1];
     this._toBeDelete = false;
+    // Check whether this key is an encoder or not
+    const positions = label.split('\n');
+    if (10 <= positions.length && positions[9].match(/^e[0-9]+$/i)) {
+      this._encoderId = Number(positions[9].substring(1));
+    } else {
+      this._encoderId = null;
+    }
   }
 
   get isDefault(): boolean {
@@ -168,6 +176,10 @@ class KeymapItem {
 
   relocate(curr: Current) {
     this._curr = curr;
+  }
+
+  get encoderId(): number | null {
+    return this._encoderId;
   }
 }
 
@@ -353,7 +365,17 @@ export default class KeyboardModel {
     keymapsList.flat().forEach((item: KeymapItem) => {
       if (item.toBeDeleted) return;
 
-      let model = new KeyModel(item.op, item.label, item.x, item.y, item.c, item.r, item.rx, item.ry); // prettier-ignore
+      const model = new KeyModel(
+        item.op,
+        item.label,
+        item.x,
+        item.y,
+        item.c,
+        item.r,
+        item.rx,
+        item.ry,
+        item.encoderId
+      );
       list.push(model);
     });
     return list;

--- a/src/models/KeyboardModel.ts
+++ b/src/models/KeyboardModel.ts
@@ -85,7 +85,6 @@ export class KeymapItem {
   private _curr: Current;
   readonly op: KeyOp;
   readonly label: string;
-  private pos: string;
   readonly option: string;
   readonly choice: string;
   private _toBeDelete: boolean;
@@ -95,20 +94,18 @@ export class KeymapItem {
     this._curr = new Current(curr);
     this.op = op || {};
     this.label = label;
-    const locs = label.split('\n\n\n');
-    this.pos = locs[0];
+    const locs = label.split('\n');
     const options =
-      locs.length == 2 ? locs[1].split(',') : [OPTION_DEFAULT, OPTION_DEFAULT];
+      4 <= locs.length && 0 < locs[3].length
+        ? locs[3].split(',')
+        : [OPTION_DEFAULT, OPTION_DEFAULT];
     this.option = options[0];
     this.choice = options[1];
+    this._encoderId =
+      10 <= locs.length && locs[9].match(/^e[0-9]+$/i)
+        ? Number(locs[9].substring(1))
+        : null;
     this._toBeDelete = false;
-    // Check whether this key is an encoder or not
-    const positions = label.split('\n');
-    if (10 <= positions.length && positions[9].match(/^e[0-9]+$/i)) {
-      this._encoderId = Number(positions[9].substring(1));
-    } else {
-      this._encoderId = null;
-    }
   }
 
   get isDefault(): boolean {


### PR DESCRIPTION
This pull request adds a new feature to support encoders for `KeyboardModel`  and some other classes. For instance, if some keys have an encoder ID in the VIA JSON file, the `KeyboardModel` object provides whether the key has an encoder ID or not.