### PR TITLE
Support Custom Keycodes.

### DIFF
--- a/src/actions/catalog.action.ts
+++ b/src/actions/catalog.action.ts
@@ -133,6 +133,7 @@ export const catalogActionsThunk = {
       // eslint-disable-next-line no-unused-vars
       getState: () => RootState
     ) => {
+      const { entities } = getState();
       const labelLang = savedKeymapData.label_lang;
       const layoutOptions = savedKeymapData.layout_options;
       let keycodes: { [pos: string]: IKeymap }[] = [];
@@ -147,7 +148,11 @@ export const catalogActionsThunk = {
         // See: https://github.com/remap-keys/remap/issues/454
         if (i < savedKeycodes.length) {
           Object.keys(savedCode).forEach((pos) => {
-            changes[pos] = KeycodeList.getKeymap(savedCode[pos], labelLang);
+            changes[pos] = KeycodeList.getKeymap(
+              savedCode[pos],
+              labelLang,
+              entities.keyboardDefinition!.customKeycodes
+            );
           });
         }
         keycodes.push(changes);

--- a/src/actions/hid.action.ts
+++ b/src/actions/hid.action.ts
@@ -1,5 +1,11 @@
 import { ThunkAction, ThunkDispatch } from 'redux-thunk';
-import { IHid, IKeyboard, IKeymap, IKeymaps } from '../services/hid/Hid';
+import {
+  ICustomKeycode,
+  IHid,
+  IKeyboard,
+  IKeymap,
+  IKeymaps,
+} from '../services/hid/Hid';
 import { KeycodeList } from '../services/hid/KeycodeList';
 import { KeyboardLabelLang } from '../services/labellang/KeyLabelLangs';
 import { RootState, SetupPhase } from '../store/state';
@@ -138,7 +144,11 @@ export const hidActionsThunk = {
         let kmap: { [pos: string]: IKeymap } = {};
         Object.keys(keymap).forEach((pos) => {
           const km = keymap[pos];
-          const newKm = KeycodeList.getKeymap(km.code, labelLang);
+          const newKm = KeycodeList.getKeymap(
+            km.code,
+            labelLang,
+            entities.keyboardDefinition!.customKeycodes
+          );
           kmap[pos] = newKm;
         });
         newKeymaps.push(kmap);
@@ -302,7 +312,8 @@ export const hidActionsThunk = {
         layerCount,
         entities.keyboardDefinition!.matrix.rows,
         entities.keyboardDefinition!.matrix.cols,
-        app.labelLang
+        app.labelLang,
+        entities.keyboardDefinition!.customKeycodes
       );
       dispatch(HidActions.updateKeymaps(keymaps));
 
@@ -464,7 +475,8 @@ export const hidActionsThunk = {
         entities.device.layerCount,
         entities.keyboardDefinition!.matrix.rows,
         entities.keyboardDefinition!.matrix.cols,
-        app.labelLang
+        app.labelLang,
+        entities.keyboardDefinition!.customKeycodes
       );
       dispatch(HidActions.updateKeymaps(keymaps));
       dispatch(AppActions.remapsInit(entities.device.layerCount));
@@ -527,7 +539,8 @@ export const hidActionsThunk = {
         entities.device.layerCount,
         entities.keyboardDefinition!.matrix.rows,
         entities.keyboardDefinition!.matrix.cols,
-        app.labelLang
+        app.labelLang,
+        entities.keyboardDefinition!.customKeycodes
       );
       dispatch(HidActions.updateKeymaps(keymaps));
     },
@@ -552,7 +565,8 @@ export const hidActionsThunk = {
         entities.device.layerCount,
         entities.keyboardDefinition!.matrix.rows,
         entities.keyboardDefinition!.matrix.cols,
-        app.labelLang
+        app.labelLang,
+        entities.keyboardDefinition!.customKeycodes
       );
       dispatch(HidActions.updateKeymaps(keymaps));
       dispatch(AppActions.remapsInit(entities.device.layerCount));
@@ -632,7 +646,8 @@ const loadKeymap = async (
   layerCount: number,
   rowCount: number,
   columnCount: number,
-  labelLang: KeyboardLabelLang
+  labelLang: KeyboardLabelLang,
+  customKeycodes: ICustomKeycode[] | undefined
 ): Promise<IKeymaps[]> => {
   const keymaps: IKeymaps[] = [];
   for (let i = 0; i < layerCount; i++) {
@@ -640,7 +655,8 @@ const loadKeymap = async (
       i,
       rowCount,
       columnCount,
-      labelLang
+      labelLang,
+      customKeycodes
     );
     if (!keymapsResult.success) {
       // TODO: show error message

--- a/src/components/configure/customkey/CustomKey.stories.tsx
+++ b/src/components/configure/customkey/CustomKey.stories.tsx
@@ -99,6 +99,7 @@ class CustomKeyStory extends React.Component<{}, State> {
           onChange={(key: Key) => {
             this.setKey(key);
           }}
+          customKeycodes={undefined}
         />
       </React.Fragment>
     );

--- a/src/components/configure/customkey/CustomKey.tsx
+++ b/src/components/configure/customkey/CustomKey.tsx
@@ -15,7 +15,7 @@ import {
   SwapHandsComposition,
 } from '../../../services/hid/Composition';
 import TabHoldTapKey, { buildHoldKeyLabel } from './TabHoldTapKey';
-import { IKeymap } from '../../../services/hid/Hid';
+import { ICustomKeycode, IKeymap } from '../../../services/hid/Hid';
 import { KeycodeList } from '../../../services/hid/KeycodeList';
 import { buildModLabel, mods2Number } from './Modifiers';
 import {
@@ -48,6 +48,7 @@ type OwnProps = {
   onClose: () => void;
   // eslint-disable-next-line no-unused-vars
   onChange: (newKey: Key) => void;
+  customKeycodes: ICustomKeycode[] | undefined;
 };
 
 type OwnState = {
@@ -220,10 +221,18 @@ export default class CustomKey extends React.Component<OwnProps, OwnState> {
     this.setState({ hexCode });
     const code = parseInt(hexCode, 16);
     if (Number.isNaN(code)) {
-      const km = KeycodeList.getKeymap(0, this.props.labelLang);
+      const km = KeycodeList.getKeymap(
+        0,
+        this.props.labelLang,
+        this.props.customKeycodes
+      );
       this.setState({ value: km });
     } else {
-      const ret = KeycodeList.getKeymaps(code, this.props.labelLang);
+      const ret = KeycodeList.getKeymaps(
+        code,
+        this.props.labelLang,
+        this.props.customKeycodes
+      );
       if (ret.value) {
         this.onChangeKey(ret.value);
       } else if (ret.holdKey && ret.tapKey) {

--- a/src/components/configure/customkey/TabKey.container.ts
+++ b/src/components/configure/customkey/TabKey.container.ts
@@ -7,6 +7,7 @@ const mapStateToProps = (state: RootState) => {
     macroBufferBytes: state.entities.device.macro.bufferBytes,
     macroMaxBufferSize: state.entities.device.macro.maxBufferSize,
     macroMaxCount: state.entities.device.macro.maxCount,
+    keyboardDefinition: state.entities.keyboardDefinition,
   };
 };
 export type TabKeyStateType = ReturnType<typeof mapStateToProps>;

--- a/src/components/configure/customkey/TabKey.tsx
+++ b/src/components/configure/customkey/TabKey.tsx
@@ -59,7 +59,8 @@ export default class TabKey extends React.Component<TabKeyProps, OwnState> {
       f.isLooseKeycode() ||
       (f.isSwapHands() && SwapHandsComposition.isSwapHandsOptions(code)) ||
       f.isToggleLayer() ||
-      f.isLayerMod()
+      f.isLayerMod() ||
+      f.isViaUserKey()
     );
   }
 
@@ -127,7 +128,10 @@ export default class TabKey extends React.Component<TabKeyProps, OwnState> {
     const keymaps = [
       ...KeyCategory.basic(labelLang),
       ...KeyCategory.symbol(labelLang),
-      ...KeyCategory.functions(labelLang),
+      ...KeyCategory.functions(
+        labelLang,
+        this.props.keyboardDefinition!.customKeycodes
+      ),
       ...KeyCategory.layer(layerCount),
       ...LayerModComposition.genKeymaps(layerCount),
       ...OneShotModComposition.genKeymaps(),

--- a/src/components/configure/keycodes/Keycodes.container.ts
+++ b/src/components/configure/keycodes/Keycodes.container.ts
@@ -17,6 +17,7 @@ const mapStateToProps = (state: RootState) => {
     macroMaxBufferSize: state.entities.device.macro.maxBufferSize,
     macroMaxCount: state.entities.device.macro.maxCount,
     macroKey: state.configure.macroEditor.key,
+    keyboardDefinition: state.entities.keyboardDefinition,
   };
 };
 export type KeycodesStateType = ReturnType<typeof mapStateToProps>;

--- a/src/components/configure/keycodes/Keycodes.tsx
+++ b/src/components/configure/keycodes/Keycodes.tsx
@@ -160,8 +160,16 @@ export default class Keycodes extends React.Component<KeycodesProps, OwnState> {
       : KeyCategory.symbol(labelLang);
     const functions = [
       ...(macroEditMode
-        ? macroCodeFilter(KeyCategory.functions(labelLang))
-        : KeyCategory.functions(labelLang)),
+        ? macroCodeFilter(
+            KeyCategory.functions(
+              labelLang,
+              this.props.keyboardDefinition!.customKeycodes
+            )
+          )
+        : KeyCategory.functions(
+            labelLang,
+            this.props.keyboardDefinition!.customKeycodes
+          )),
       ...(macroEditMode
         ? []
         : KeyCategory.macro(

--- a/src/components/configure/keyeventcapture/KeyEventCapture.container.ts
+++ b/src/components/configure/keyeventcapture/KeyEventCapture.container.ts
@@ -8,6 +8,7 @@ const mapStateToProps = (state: RootState) => {
     selectedLayer: state.configure.keymap.selectedLayer,
     testMatrix: state.configure.keymapToolbar.testMatrix,
     selectedPos: state.configure.keymap.selectedPos,
+    keyboardDefinition: state.entities.keyboardDefinition,
   };
 };
 export type KeyEventCaptureStateType = ReturnType<typeof mapStateToProps>;

--- a/src/components/configure/keyeventcapture/KeyEventCapture.tsx
+++ b/src/components/configure/keyeventcapture/KeyEventCapture.tsx
@@ -137,7 +137,11 @@ export default class KeyEventCapture extends React.Component<
     if (e.key !== 'Alt' && e.altKey) code |= MOD_ALT << 8;
     if (e.key !== 'Meta' && e.metaKey) code |= MOD_GUI << 8;
 
-    const keymap = KeycodeList.getKeymap(code, this.props.labelLang!);
+    const keymap = KeycodeList.getKeymap(
+      code,
+      this.props.labelLang!,
+      this.props.keyboardDefinition!.customKeycodes
+    );
     if (!keymap) {
       return null;
     }

--- a/src/components/configure/keymap/Keymap.container.ts
+++ b/src/components/configure/keymap/Keymap.container.ts
@@ -7,7 +7,7 @@ import {
   KeymapActions,
   KeymapToolbarActions,
 } from '../../../actions/actions';
-import { IKeymap } from '../../../services/hid/Hid';
+import { ICustomKeycode, IKeymap } from '../../../services/hid/Hid';
 import { hidActionsThunk } from '../../../actions/hid.action';
 import { KeycodeList } from '../../../services/hid/KeycodeList';
 import { KeyboardLabelLang } from '../../../services/labellang/KeyLabelLangs';
@@ -32,6 +32,7 @@ const mapStateToProps = (state: RootState) => {
     testMatrix: state.configure.keymapToolbar.testMatrix,
     testedMatrix: state.app.testedMatrix,
     currentTestMatrix: state.app.currentTestMatrix,
+    keyboardDefinition: state.entities.keyboardDefinition,
   };
 };
 export type KeymapStateType = ReturnType<typeof mapStateToProps>;
@@ -46,14 +47,23 @@ const mapDispatchToProps = (_dispatch: any) => {
     onChangeLangLabel: (
       labelLang: KeyboardLabelLang,
       orgKeymap: IKeymap | null,
-      dstKeymap: IKeymap | null
+      dstKeymap: IKeymap | null,
+      customKeycodes: ICustomKeycode[] | undefined
     ) => {
       _dispatch(AppActions.updateLangLabel(labelLang));
       _dispatch(hidActionsThunk.updateKeymaps(labelLang));
 
       if (orgKeymap && dstKeymap) {
-        const newOrgKeymap = KeycodeList.getKeymap(orgKeymap.code, labelLang);
-        const newDstKeymap = KeycodeList.getKeymap(dstKeymap.code, labelLang);
+        const newOrgKeymap = KeycodeList.getKeymap(
+          orgKeymap.code,
+          labelLang,
+          customKeycodes
+        );
+        const newDstKeymap = KeycodeList.getKeymap(
+          dstKeymap.code,
+          labelLang,
+          customKeycodes
+        );
         _dispatch(KeydiffActions.updateKeydiff(newOrgKeymap, newDstKeymap));
       }
     },

--- a/src/components/configure/keymap/Keymap.tsx
+++ b/src/components/configure/keymap/Keymap.tsx
@@ -248,7 +248,8 @@ export default class Keymap extends React.Component<
                 this.props.onChangeLangLabel!(
                   labelLang,
                   this.props.keydiff!.origin,
-                  this.props.keydiff!.destination
+                  this.props.keydiff!.destination,
+                  this.props.keyboardDefinition!.customKeycodes
                 );
               }}
             />
@@ -309,6 +310,7 @@ export default class Keymap extends React.Component<
             onChange={(key: Key) => {
               this.onChangeKeymap(key);
             }}
+            customKeycodes={this.props.keyboardDefinition!.customKeycodes}
           />
         </div>
       </React.Fragment>

--- a/src/components/configure/keymaplist/KeymapListPopover.container.ts
+++ b/src/components/configure/keymaplist/KeymapListPopover.container.ts
@@ -22,6 +22,7 @@ const mapStateToProps = (state: RootState) => {
     sharedKeymaps: state.entities.sharedKeymaps,
     appliedKeymaps: state.entities.appliedKeymaps,
     definitionDocument: state.entities.keyboardDefinitionDocument,
+    keyboardDefinition: state.entities.keyboardDefinition,
   };
 };
 export type KeymapListPopoverStateType = ReturnType<typeof mapStateToProps>;

--- a/src/components/configure/keymaplist/KeymapListPopover.tsx
+++ b/src/components/configure/keymaplist/KeymapListPopover.tsx
@@ -115,7 +115,11 @@ export default class KeymapListPopover extends React.Component<
       if (i < savedKeycodes.length) {
         Object.keys(keymap).forEach((pos) => {
           if (keymap[pos].code != savedCode[pos]) {
-            changes[pos] = KeycodeList.getKeymap(savedCode[pos], labelLang);
+            changes[pos] = KeycodeList.getKeymap(
+              savedCode[pos],
+              labelLang,
+              this.props.keyboardDefinition!.customKeycodes
+            );
           }
         });
       }

--- a/src/services/hid/Composition.test.ts
+++ b/src/services/hid/Composition.test.ts
@@ -35,6 +35,7 @@ import {
   ToComposition,
   ToggleLayerComposition,
   UnicodeComposition,
+  ViaUserKeyComposition,
 } from './Composition';
 
 const EXPECT_BASIC_LIST = [0b0000_0000_0000_0000, 0b0000_0000_1111_1111];
@@ -61,6 +62,7 @@ const EXPECT_UNICODE_LIST = [0b1000_0000_0000_0000, 0b1111_1111_1111_1111];
 const EXPECT_LOOSE_KEYCODE_LIST = [
   0b0101_1100_0000_0000, 0b0101_1111_0010_0001, 0b0101_1100_1111_0111,
 ];
+const EXPECT_VIA_USER_KEY_LIST = [0b0101_1111_1000_0000, 0b0101_1111_1000_1111];
 const EXPECT_UNKNOWN_LIST = [
   0b0101_1011_0000_0000, 0b0101_1111_0000_1111, 0b0101_1101_0001_0001,
 ];
@@ -850,6 +852,45 @@ describe('Composition', () => {
     });
   });
 
+  describe('ViaUserKeyComposition', () => {
+    test('getCode', () => {
+      let subject = new ViaUserKeyComposition({
+        code: 0b0101_1111_1000_0000,
+        isAny: false,
+        kinds: ['via_user_key'],
+        direction: MOD_LEFT,
+        modifiers: [],
+        keycodeInfo: {
+          code: 0b0101_1111_1000_0000,
+          name: {
+            long: 'Custom User 0',
+            short: 'USER 0',
+          },
+          label: 'User 0',
+          keywords: ['user0'],
+        },
+      });
+      expect(subject.getCode()).toEqual(0b0101_1111_1000_0000);
+      subject = new ViaUserKeyComposition({
+        code: 0b0101_1111_1000_1111,
+        isAny: false,
+        kinds: ['via_user_key'],
+        direction: MOD_LEFT,
+        modifiers: [],
+        keycodeInfo: {
+          code: 0,
+          name: {
+            long: '',
+            short: '',
+          },
+          label: '',
+          keywords: [],
+        },
+      });
+      expect(subject.getCode()).toEqual(0b0101_1111_1000_1111);
+    });
+  });
+
   describe('KeycodeCompositionFactory', () => {
     describe('createBasicComposition', () => {
       test('valid', () => {
@@ -1401,6 +1442,29 @@ describe('Composition', () => {
       });
     });
 
+    describe('createViaUserKeyComposition', () => {
+      test('valid', () => {
+        const subject = new KeycodeCompositionFactory(
+          0b0101_1111_1000_0000,
+          'en-us'
+        );
+        expect(subject.isViaUserKey()).toBeTruthy();
+        const actual = subject.createViaUserKeyComposition();
+        expect(actual.genKeymap()!.code).toEqual(0b0101_1111_1000_0000);
+      });
+
+      test('not via user key', () => {
+        const subject = new KeycodeCompositionFactory(
+          0b0000_0001_0000_0000,
+          'en-us'
+        );
+        expect(subject.isViaUserKey()).toBeFalsy();
+        expect(() => {
+          subject.createViaUserKeyComposition();
+        }).toThrowError();
+      });
+    });
+
     test('isAscii', () => {
       let subject = new KeycodeCompositionFactory(
         0b0000_0000_0000_0000,
@@ -1456,6 +1520,7 @@ describe('Composition', () => {
           EXPECT_MOD_TAP_LIST,
           EXPECT_UNICODE_LIST,
           EXPECT_LOOSE_KEYCODE_LIST,
+          EXPECT_VIA_USER_KEY_LIST,
         ];
         checkKind(validList, invalidList, KeycodeCompositionKind.basic);
       });
@@ -1479,6 +1544,7 @@ describe('Composition', () => {
           EXPECT_MOD_TAP_LIST,
           EXPECT_UNICODE_LIST,
           EXPECT_LOOSE_KEYCODE_LIST,
+          EXPECT_VIA_USER_KEY_LIST,
         ];
         checkKind(validList, invalidList, KeycodeCompositionKind.mods);
       });
@@ -1502,6 +1568,7 @@ describe('Composition', () => {
           EXPECT_MOD_TAP_LIST,
           EXPECT_UNICODE_LIST,
           EXPECT_LOOSE_KEYCODE_LIST,
+          EXPECT_VIA_USER_KEY_LIST,
         ];
         checkKind(validList, invalidList, KeycodeCompositionKind.function);
       });
@@ -1525,6 +1592,7 @@ describe('Composition', () => {
           EXPECT_MOD_TAP_LIST,
           EXPECT_UNICODE_LIST,
           EXPECT_LOOSE_KEYCODE_LIST,
+          EXPECT_VIA_USER_KEY_LIST,
         ];
         checkKind(validList, invalidList, KeycodeCompositionKind.macro);
       });
@@ -1548,6 +1616,7 @@ describe('Composition', () => {
           EXPECT_MOD_TAP_LIST,
           EXPECT_UNICODE_LIST,
           EXPECT_LOOSE_KEYCODE_LIST,
+          EXPECT_VIA_USER_KEY_LIST,
         ];
         checkKind(validList, invalidList, KeycodeCompositionKind.layer_tap);
       });
@@ -1571,6 +1640,7 @@ describe('Composition', () => {
           EXPECT_MOD_TAP_LIST,
           EXPECT_UNICODE_LIST,
           EXPECT_LOOSE_KEYCODE_LIST,
+          EXPECT_VIA_USER_KEY_LIST,
         ];
         checkKind(validList, invalidList, KeycodeCompositionKind.to);
       });
@@ -1594,6 +1664,7 @@ describe('Composition', () => {
           EXPECT_MOD_TAP_LIST,
           EXPECT_UNICODE_LIST,
           EXPECT_LOOSE_KEYCODE_LIST,
+          EXPECT_VIA_USER_KEY_LIST,
         ];
         checkKind(validList, invalidList, KeycodeCompositionKind.momentary);
       });
@@ -1617,6 +1688,7 @@ describe('Composition', () => {
           EXPECT_MOD_TAP_LIST,
           EXPECT_UNICODE_LIST,
           EXPECT_LOOSE_KEYCODE_LIST,
+          EXPECT_VIA_USER_KEY_LIST,
         ];
         checkKind(validList, invalidList, KeycodeCompositionKind.df);
       });
@@ -1640,6 +1712,7 @@ describe('Composition', () => {
           EXPECT_MOD_TAP_LIST,
           EXPECT_UNICODE_LIST,
           EXPECT_LOOSE_KEYCODE_LIST,
+          EXPECT_VIA_USER_KEY_LIST,
         ];
         checkKind(validList, invalidList, KeycodeCompositionKind.tl);
       });
@@ -1663,6 +1736,7 @@ describe('Composition', () => {
           EXPECT_MOD_TAP_LIST,
           EXPECT_UNICODE_LIST,
           EXPECT_LOOSE_KEYCODE_LIST,
+          EXPECT_VIA_USER_KEY_LIST,
         ];
         checkKind(validList, invalidList, KeycodeCompositionKind.osl);
       });
@@ -1686,6 +1760,7 @@ describe('Composition', () => {
           EXPECT_MOD_TAP_LIST,
           EXPECT_UNICODE_LIST,
           EXPECT_LOOSE_KEYCODE_LIST,
+          EXPECT_VIA_USER_KEY_LIST,
         ];
         checkKind(validList, invalidList, KeycodeCompositionKind.osm);
       });
@@ -1709,6 +1784,7 @@ describe('Composition', () => {
           EXPECT_MOD_TAP_LIST,
           EXPECT_UNICODE_LIST,
           EXPECT_LOOSE_KEYCODE_LIST,
+          EXPECT_VIA_USER_KEY_LIST,
         ];
         checkKind(validList, invalidList, KeycodeCompositionKind.tap_dance);
       });
@@ -1732,6 +1808,7 @@ describe('Composition', () => {
           EXPECT_MOD_TAP_LIST,
           EXPECT_UNICODE_LIST,
           EXPECT_LOOSE_KEYCODE_LIST,
+          EXPECT_VIA_USER_KEY_LIST,
         ];
         checkKind(validList, invalidList, KeycodeCompositionKind.tt);
       });
@@ -1755,6 +1832,7 @@ describe('Composition', () => {
           EXPECT_MOD_TAP_LIST,
           EXPECT_UNICODE_LIST,
           EXPECT_LOOSE_KEYCODE_LIST,
+          EXPECT_VIA_USER_KEY_LIST,
         ];
         checkKind(validList, invalidList, KeycodeCompositionKind.layer_mod);
       });
@@ -1778,6 +1856,7 @@ describe('Composition', () => {
           EXPECT_MOD_TAP_LIST,
           EXPECT_UNICODE_LIST,
           EXPECT_LOOSE_KEYCODE_LIST,
+          EXPECT_VIA_USER_KEY_LIST,
         ];
         checkKind(validList, invalidList, KeycodeCompositionKind.swap_hands);
       });
@@ -1801,6 +1880,7 @@ describe('Composition', () => {
           EXPECT_SWAP_HANDS_LIST,
           EXPECT_UNICODE_LIST,
           EXPECT_LOOSE_KEYCODE_LIST,
+          EXPECT_VIA_USER_KEY_LIST,
         ];
         checkKind(validList, invalidList, KeycodeCompositionKind.mod_tap);
       });
@@ -1824,6 +1904,7 @@ describe('Composition', () => {
           EXPECT_SWAP_HANDS_LIST,
           EXPECT_MOD_TAP_LIST,
           EXPECT_LOOSE_KEYCODE_LIST,
+          EXPECT_VIA_USER_KEY_LIST,
         ];
         checkKind(validList, invalidList, KeycodeCompositionKind.unicode);
       });
@@ -1847,8 +1928,33 @@ describe('Composition', () => {
           EXPECT_SWAP_HANDS_LIST,
           EXPECT_MOD_TAP_LIST,
           EXPECT_UNICODE_LIST,
+          EXPECT_VIA_USER_KEY_LIST,
         ];
         checkKind(validList, invalidList, KeycodeCompositionKind.loose_keycode);
+      });
+      describe('via user key', () => {
+        const validList = [EXPECT_VIA_USER_KEY_LIST];
+        const invalidList = [
+          EXPECT_BASIC_LIST,
+          EXPECT_MODS_LIST,
+          EXPECT_FUNCTION_LIST,
+          EXPECT_MACRO_LIST,
+          EXPECT_LAYER_TAP_LIST,
+          EXPECT_TO_LIST,
+          EXPECT_MOMENTARY_LIST,
+          EXPECT_DEF_LAYER_LIST,
+          EXPECT_TOGGLE_LAYER_LIST,
+          EXPECT_ONE_SHOT_LAYER_LIST,
+          EXPECT_ONE_SHOT_MOD_LIST,
+          EXPECT_TAP_DANCE_LIST,
+          EXPECT_LAYER_TAP_TOGGLE_LIST,
+          EXPECT_LAYER_MOD_LIST,
+          EXPECT_SWAP_HANDS_LIST,
+          EXPECT_MOD_TAP_LIST,
+          EXPECT_UNICODE_LIST,
+          EXPECT_LOOSE_KEYCODE_LIST,
+        ];
+        checkKind(validList, invalidList, KeycodeCompositionKind.via_user_key);
       });
       describe('unknown', () => {
         test.each(EXPECT_UNKNOWN_LIST)(`unknown`, (value) => {

--- a/src/services/hid/Composition.test.ts
+++ b/src/services/hid/Composition.test.ts
@@ -889,6 +889,58 @@ describe('Composition', () => {
       });
       expect(subject.getCode()).toEqual(0b0101_1111_1000_1111);
     });
+
+    describe('findKeymap', () => {
+      test('customKeycodes is not specified', () => {
+        const actual = ViaUserKeyComposition.findKeymap(
+          0b0101_1111_1000_0000,
+          undefined
+        );
+        expect(actual).not.toBeUndefined();
+        expect(actual!.code).toEqual(0b0101_1111_1000_0000);
+        expect(actual!.desc).toEqual('User 0');
+        expect(actual!.kinds).toEqual(['via_user_key']);
+        expect(actual!.keycodeInfo.name.short).toEqual('USER 0');
+        expect(actual!.keycodeInfo.name.long).toEqual('Custom Keycode 0');
+        expect(actual!.keycodeInfo.label).toEqual('USER 0');
+      });
+
+      test('customKeycodes is specified', () => {
+        const actual = ViaUserKeyComposition.findKeymap(0b0101_1111_1000_0000, [
+          {
+            name: 'customKeycodeName1',
+            shortName: 'customKeycodeShortName1',
+            title: 'customKeycodeTitle1',
+          },
+        ]);
+        expect(actual).not.toBeUndefined();
+        expect(actual!.code).toEqual(0b0101_1111_1000_0000);
+        expect(actual!.desc).toEqual('customKeycodeTitle1');
+        expect(actual!.kinds).toEqual(['via_user_key']);
+        expect(actual!.keycodeInfo.name.short).toEqual(
+          'customKeycodeShortName1'
+        );
+        expect(actual!.keycodeInfo.name.long).toEqual('customKeycodeName1');
+        expect(actual!.keycodeInfo.label).toEqual('customKeycodeName1');
+      });
+
+      test('customKeycodes is specified but empty', () => {
+        const actual = ViaUserKeyComposition.findKeymap(0b0101_1111_1000_0000, [
+          {
+            name: '',
+            shortName: '',
+            title: '',
+          },
+        ]);
+        expect(actual).not.toBeUndefined();
+        expect(actual!.code).toEqual(0b0101_1111_1000_0000);
+        expect(actual!.desc).toEqual('User 0');
+        expect(actual!.kinds).toEqual(['via_user_key']);
+        expect(actual!.keycodeInfo.name.short).toEqual('USER 0');
+        expect(actual!.keycodeInfo.name.long).toEqual('Custom Keycode 0');
+        expect(actual!.keycodeInfo.label).toEqual('USER 0');
+      });
+    });
   });
 
   describe('KeycodeCompositionFactory', () => {
@@ -1449,7 +1501,7 @@ describe('Composition', () => {
           'en-us'
         );
         expect(subject.isViaUserKey()).toBeTruthy();
-        const actual = subject.createViaUserKeyComposition();
+        const actual = subject.createViaUserKeyComposition(undefined);
         expect(actual.genKeymap()!.code).toEqual(0b0101_1111_1000_0000);
       });
 
@@ -1460,7 +1512,7 @@ describe('Composition', () => {
         );
         expect(subject.isViaUserKey()).toBeFalsy();
         expect(() => {
-          subject.createViaUserKeyComposition();
+          subject.createViaUserKeyComposition(undefined);
         }).toThrowError();
       });
     });

--- a/src/services/hid/Composition.ts
+++ b/src/services/hid/Composition.ts
@@ -1577,22 +1577,25 @@ export class ViaUserKeyComposition implements IViaUserKeyComposition {
     const kinds = KEY_SUB_CATEGORY_VIA_USER_KEY.kinds;
     KEY_SUB_CATEGORY_VIA_USER_KEY.codes.forEach((code, index) => {
       let info: KeyInfo | undefined;
-      if (customKeycodes && customKeycodes[index]) {
+      const keyInfo = getKeyInfo(code);
+      if (customKeycodes && customKeycodes[index] && keyInfo) {
         const customKeycode = customKeycodes[index];
         info = {
-          desc: customKeycode.title,
+          desc: customKeycode.title || keyInfo.desc,
           keycodeInfo: {
             code,
-            label: customKeycode.name,
+            label: customKeycode.name || keyInfo.keycodeInfo.label,
             name: {
-              long: customKeycode.name,
-              short: customKeycode.shortName,
+              long: customKeycode.name || keyInfo.keycodeInfo.name.long,
+              short: customKeycode.shortName || keyInfo.keycodeInfo.name.short,
             },
-            keywords: [customKeycode.shortName],
+            keywords: customKeycode.shortName
+              ? [customKeycode.shortName]
+              : keyInfo.keycodeInfo.keywords,
           },
         };
       } else {
-        info = getKeyInfo(code);
+        info = keyInfo;
       }
       if (info) {
         const keymap: IKeymap = {

--- a/src/services/hid/Composition.ts
+++ b/src/services/hid/Composition.ts
@@ -1,4 +1,9 @@
-import { IKeycodeCategoryInfo, IKeycodeInfo, IKeymap } from './Hid';
+import {
+  ICustomKeycode,
+  IKeycodeCategoryInfo,
+  IKeycodeInfo,
+  IKeymap,
+} from './Hid';
 import { hexadecimal } from '../../utils/StringUtils';
 
 import {
@@ -38,6 +43,7 @@ import {
   KEY_SUB_CATEGORY_SPACE_CADET,
   KEY_SUB_CATEGORY_UNDERGLOW,
   KEY_SUB_CATEGORY_FNMO,
+  KEY_SUB_CATEGORY_VIA_USER_KEY,
 } from './KeyCategoryList';
 import { KeyInfo, keyInfoList } from './KeycodeInfoList';
 import { KeyLabel } from '../labellang/KeyLabel';
@@ -96,7 +102,10 @@ export const QK_UNICODE_MIN = 0b1000_0000_0000_0000;
 export const QK_UNICODE_MAX = 0b1111_1111_1111_1111;
 
 export const LOOSE_KEYCODE_MIN = 0b0101_1100_0000_0000;
-export const LOOSE_KEYCODE_MAX = 0b0101_1111_1111_1111;
+export const LOOSE_KEYCODE_MAX = 0b0101_1111_0111_1111;
+
+export const VIA_USER_KEY_MIN = 0b0101_1111_1000_0000;
+export const VIA_USER_KEY_MAX = 0b0101_1111_1000_1111;
 
 export const ASCII_MIN = 0b0000_0000_0000_0000;
 export const ASCII_MAX = 0b0000_0000_0111_1111;
@@ -120,7 +129,8 @@ export type IKeycodeCompositionKind =
   | 'mod_tap'
   | 'unicode'
   | 'loose_keycode'
-  | 'ascii';
+  | 'ascii'
+  | 'via_user_key';
 export const KeycodeCompositionKind: {
   // eslint-disable-next-line no-unused-vars
   [p in IKeycodeCompositionKind]: IKeycodeCompositionKind;
@@ -144,6 +154,7 @@ export const KeycodeCompositionKind: {
   unicode: 'unicode',
   loose_keycode: 'loose_keycode',
   ascii: 'ascii',
+  via_user_key: 'via_user_key',
 };
 
 const keycodeCompositionKindRangeMap: {
@@ -171,6 +182,7 @@ const keycodeCompositionKindRangeMap: {
   mod_tap: { min: QK_MOD_TAP_MIN, max: QK_MOD_TAP_MAX },
   unicode: { min: QK_UNICODE_MIN, max: QK_UNICODE_MAX },
   loose_keycode: { min: LOOSE_KEYCODE_MIN, max: LOOSE_KEYCODE_MAX },
+  via_user_key: { min: VIA_USER_KEY_MIN, max: VIA_USER_KEY_MAX },
   ascii: { min: Number.MIN_VALUE, max: Number.MIN_VALUE }, // never match
 };
 
@@ -343,6 +355,8 @@ export interface IUnicodeComposition extends IComposition {
 }
 
 export interface ILooseKeycodeComposition extends IComposition {}
+
+export interface IViaUserKeyComposition extends IComposition {}
 
 export class AsciiComposition implements IAsciiComposition {
   private static _keymaps: IKeymap[];
@@ -1537,6 +1551,75 @@ export class LooseKeycodeComposition implements ILooseKeycodeComposition {
   }
 }
 
+export class ViaUserKeyComposition implements IViaUserKeyComposition {
+  private readonly key: IKeymap;
+
+  constructor(keymap: IKeymap) {
+    this.key = keymap;
+  }
+
+  getCode(): number {
+    return VIA_USER_KEY_MIN | this.key.code;
+  }
+
+  genKeymap(): IKeymap {
+    return JSON.parse(JSON.stringify(this.key));
+  }
+
+  static genKeymaps(customKeycodes: ICustomKeycode[] | undefined): IKeymap[] {
+    // It is necessary to generate keymaps every time for custom keycodes.
+
+    const getKeyInfo = (code: number): KeyInfo | undefined => {
+      return keyInfoList.find((info) => info.keycodeInfo.code === code);
+    };
+
+    const viaUserKeymaps: IKeymap[] = [];
+    const kinds = KEY_SUB_CATEGORY_VIA_USER_KEY.kinds;
+    KEY_SUB_CATEGORY_VIA_USER_KEY.codes.forEach((code, index) => {
+      let info: KeyInfo | undefined;
+      if (customKeycodes && customKeycodes[index]) {
+        const customKeycode = customKeycodes[index];
+        info = {
+          desc: customKeycode.title,
+          keycodeInfo: {
+            code,
+            label: customKeycode.name,
+            name: {
+              long: customKeycode.name,
+              short: customKeycode.shortName,
+            },
+            keywords: [customKeycode.shortName],
+          },
+        };
+      } else {
+        info = getKeyInfo(code);
+      }
+      if (info) {
+        const keymap: IKeymap = {
+          code,
+          isAny: false,
+          direction: MOD_LEFT,
+          modifiers: [],
+          keycodeInfo: info.keycodeInfo,
+          kinds: kinds,
+          desc: info.desc,
+        };
+        viaUserKeymaps.push(keymap);
+      }
+    });
+
+    return viaUserKeymaps;
+  }
+
+  static findKeymap(
+    code: number,
+    customKeycodes: ICustomKeycode[] | undefined
+  ): IKeymap | undefined {
+    const list: IKeymap[] = ViaUserKeyComposition.genKeymaps(customKeycodes);
+    return list.find((km) => km.code === code);
+  }
+}
+
 export interface IKeycodeCompositionFactory {
   isBasic(): boolean;
   isMods(): boolean;
@@ -1558,6 +1641,7 @@ export interface IKeycodeCompositionFactory {
   isLooseKeycode(): boolean;
   isUnknown(): boolean;
   isAscii(): boolean;
+  isViaUserKey(): boolean;
   getKind(): IKeycodeCompositionKind | null;
   createBasicComposition(): IBasicComposition;
   createModsComposition(): IModsComposition;
@@ -1578,6 +1662,10 @@ export interface IKeycodeCompositionFactory {
   createUnicodeComposition(): IUnicodeComposition;
   createLooseKeycodeComposition(): ILooseKeycodeComposition;
   createAsciiKeycodeComposition(): IAsciiComposition;
+  createViaUserKeyComposition(
+    // eslint-disable-next-line no-unused-vars
+    customKeycodes: ICustomKeycode[] | undefined
+  ): IViaUserKeyComposition;
 }
 
 export class KeycodeCompositionFactory implements IKeycodeCompositionFactory {
@@ -1693,6 +1781,10 @@ export class KeycodeCompositionFactory implements IKeycodeCompositionFactory {
 
   isAscii(): boolean {
     return ASCII_MIN <= this.code && this.code <= ASCII_MAX;
+  }
+
+  isViaUserKey(): boolean {
+    return this.getKind() === KeycodeCompositionKind.via_user_key;
   }
 
   createBasicComposition(): IBasicComposition {
@@ -1961,5 +2053,18 @@ export class KeycodeCompositionFactory implements IKeycodeCompositionFactory {
       );
     }
     return new AsciiComposition(AsciiComposition.createKeymap(this.code));
+  }
+
+  createViaUserKeyComposition(
+    customKeycodes: ICustomKeycode[] | undefined
+  ): IViaUserKeyComposition {
+    if (!this.isViaUserKey()) {
+      throw new Error(
+        `This code is not a via user key: ${hexadecimal(this.code, 16)}`
+      );
+    }
+    return new ViaUserKeyComposition(
+      ViaUserKeyComposition.findKeymap(this.code, customKeycodes)!
+    );
   }
 }

--- a/src/services/hid/Hid.ts
+++ b/src/services/hid/Hid.ts
@@ -79,6 +79,13 @@ export type IKeymaps = {
   [pos: string]: IKeymap;
 };
 
+export type ICustomKeycode = {
+  name: string;
+  title: string;
+  shortName: string;
+  [k: string]: unknown;
+};
+
 export interface IFetchKeymapResult extends IResult {
   keymap?: IKeymaps;
 }
@@ -144,7 +151,8 @@ export interface IKeyboard {
     layer: number,
     rowCount: number,
     columnCount: number,
-    labelLang: KeyboardLabelLang
+    labelLang: KeyboardLabelLang,
+    customKeycodes: ICustomKeycode[] | undefined
   ): Promise<IFetchKeymapResult>;
   updateKeymap(
     layer: number,

--- a/src/services/hid/KeyCategoryList.ts
+++ b/src/services/hid/KeyCategoryList.ts
@@ -10,8 +10,9 @@ import {
   SwapHandsComposition,
   ToComposition,
   ToggleLayerComposition,
+  ViaUserKeyComposition,
 } from './Composition';
-import { IKeycodeCategoryInfo, IKeymap } from './Hid';
+import { ICustomKeycode, IKeycodeCategoryInfo, IKeymap } from './Hid';
 import { range } from '../../utils/ArrayUtils';
 import { encodeMacroText, IMacroBuffer } from '../macro/Macro';
 
@@ -74,27 +75,33 @@ export class KeyCategory {
     return KeyCategory._symbol[labelLang];
   }
 
-  static functions(labelLang: KeyboardLabelLang): IKeymap[] {
-    if (
-      Object.prototype.hasOwnProperty.call(KeyCategory._functions, labelLang)
-    ) {
-      return KeyCategory._functions[labelLang];
-    }
-
-    const basicCodes: number[] = [
+  static functions(
+    labelLang: KeyboardLabelLang,
+    customKeycodes: ICustomKeycode[] | undefined
+  ): IKeymap[] {
+    // It is necessary to build keymaps every time for custom keycodes.
+    const functionsCodes: number[] = [
       ...KEY_SUB_CATEGORY_F.codes,
       ...KEY_SUB_CATEGORY_INTERNATIONAL.codes,
       ...KEY_SUB_CATEGORY_LANGUAGE.codes,
       ...KEY_SUB_CATEGORY_LOCK.codes,
     ];
-    const looseCodes: number[] = [...KEY_SUB_CATEGORY_COMBO.codes];
-    const basicKeymaps: IKeymap[] = basicCodes.map(
+    const comboCodes: number[] = [...KEY_SUB_CATEGORY_COMBO.codes];
+    const viaUserCodes: number[] = [...KEY_SUB_CATEGORY_VIA_USER_KEY.codes];
+    const functionsKeymaps: IKeymap[] = functionsCodes.map(
       (code) => BasicComposition.findKeymap(code, labelLang)!
     );
-    const looseKeymaps: IKeymap[] = looseCodes.map(
+    const comboKeymaps: IKeymap[] = comboCodes.map(
       (code) => LooseKeycodeComposition.findKeymap(code)!
     );
-    KeyCategory._functions[labelLang] = [...basicKeymaps, ...looseKeymaps];
+    const viaUserKeymaps: IKeymap[] = viaUserCodes.map(
+      (code) => ViaUserKeyComposition.findKeymap(code, customKeycodes)!
+    );
+    KeyCategory._functions[labelLang] = [
+      ...functionsKeymaps,
+      ...comboKeymaps,
+      ...viaUserKeymaps,
+    ];
     return KeyCategory._functions[labelLang];
   }
 
@@ -453,4 +460,10 @@ export const KEY_CATEGORY_ASCII: IKeycodeCategoryInfo = {
 export const KEY_SUB_CATEGORY_FNMO: IKeycodeCategoryInfo = {
   kinds: ['fnmo'],
   codes: [24336, 24337],
+};
+
+// VIA USER
+export const KEY_SUB_CATEGORY_VIA_USER_KEY: IKeycodeCategoryInfo = {
+  kinds: ['via_user_key'],
+  codes: range(24448, 24463),
 };

--- a/src/services/hid/KeycodeInfoList.ts
+++ b/src/services/hid/KeycodeInfoList.ts
@@ -6943,4 +6943,212 @@ export const keyInfoList: KeyInfo[] = [
       keywords: ['macro15'],
     },
   },
+
+  {
+    desc: 'User 0',
+    keycodeInfo: {
+      code: 24448,
+      name: {
+        long: 'Custom Keycode 0',
+        short: 'USER 0',
+      },
+      label: 'USER 0',
+      keywords: ['user0'],
+    },
+  },
+
+  {
+    desc: 'User 1',
+    keycodeInfo: {
+      code: 24449,
+      name: {
+        long: 'Custom Keycode 1',
+        short: 'USER 1',
+      },
+      label: 'USER 1',
+      keywords: ['user1'],
+    },
+  },
+
+  {
+    desc: 'User 2',
+    keycodeInfo: {
+      code: 24450,
+      name: {
+        long: 'Custom Keycode 2',
+        short: 'USER 2',
+      },
+      label: 'USER 2',
+      keywords: ['user2'],
+    },
+  },
+
+  {
+    desc: 'User 3',
+    keycodeInfo: {
+      code: 24451,
+      name: {
+        long: 'Custom Keycode 3',
+        short: 'USER 3',
+      },
+      label: 'USER 3',
+      keywords: ['user3'],
+    },
+  },
+
+  {
+    desc: 'User 4',
+    keycodeInfo: {
+      code: 24452,
+      name: {
+        long: 'Custom Keycode 4',
+        short: 'USER 4',
+      },
+      label: 'USER 4',
+      keywords: ['user4'],
+    },
+  },
+
+  {
+    desc: 'User 5',
+    keycodeInfo: {
+      code: 24453,
+      name: {
+        long: 'Custom Keycode 5',
+        short: 'USER 5',
+      },
+      label: 'USER 5',
+      keywords: ['user5'],
+    },
+  },
+
+  {
+    desc: 'User 6',
+    keycodeInfo: {
+      code: 24454,
+      name: {
+        long: 'Custom Keycode 6',
+        short: 'USER 6',
+      },
+      label: 'USER 6',
+      keywords: ['user6'],
+    },
+  },
+
+  {
+    desc: 'User 7',
+    keycodeInfo: {
+      code: 24455,
+      name: {
+        long: 'Custom Keycode 7',
+        short: 'USER 7',
+      },
+      label: 'USER 7',
+      keywords: ['user7'],
+    },
+  },
+
+  {
+    desc: 'User 8',
+    keycodeInfo: {
+      code: 24456,
+      name: {
+        long: 'Custom Keycode 8',
+        short: 'USER 8',
+      },
+      label: 'USER 8',
+      keywords: ['user8'],
+    },
+  },
+
+  {
+    desc: 'User 9',
+    keycodeInfo: {
+      code: 24457,
+      name: {
+        long: 'Custom Keycode 9',
+        short: 'USER 9',
+      },
+      label: 'USER 9',
+      keywords: ['user9'],
+    },
+  },
+
+  {
+    desc: 'User 10',
+    keycodeInfo: {
+      code: 24458,
+      name: {
+        long: 'Custom Keycode 10',
+        short: 'USER 10',
+      },
+      label: 'USER 10',
+      keywords: ['user10'],
+    },
+  },
+
+  {
+    desc: 'User 11',
+    keycodeInfo: {
+      code: 24459,
+      name: {
+        long: 'Custom Keycode 11',
+        short: 'USER 11',
+      },
+      label: 'USER 11',
+      keywords: ['user11'],
+    },
+  },
+
+  {
+    desc: 'User 12',
+    keycodeInfo: {
+      code: 24460,
+      name: {
+        long: 'Custom Keycode 12',
+        short: 'USER 12',
+      },
+      label: 'USER 12',
+      keywords: ['user12'],
+    },
+  },
+
+  {
+    desc: 'User 13',
+    keycodeInfo: {
+      code: 24461,
+      name: {
+        long: 'Custom Keycode 13',
+        short: 'USER 13',
+      },
+      label: 'USER 13',
+      keywords: ['user13'],
+    },
+  },
+
+  {
+    desc: 'User 14',
+    keycodeInfo: {
+      code: 24462,
+      name: {
+        long: 'Custom Keycode 14',
+        short: 'USER 14',
+      },
+      label: 'USER 14',
+      keywords: ['user14'],
+    },
+  },
+
+  {
+    desc: 'User 15',
+    keycodeInfo: {
+      code: 24463,
+      name: {
+        long: 'Custom Keycode 15',
+        short: 'USER 15',
+      },
+      label: 'USER 15',
+      keywords: ['user15'],
+    },
+  },
 ];

--- a/src/services/hid/KeycodeList.ts
+++ b/src/services/hid/KeycodeList.ts
@@ -1,4 +1,4 @@
-import { IKeymap } from './Hid';
+import { ICustomKeycode, IKeymap } from './Hid';
 import {
   anyKeymap,
   IKeycodeCompositionKind,
@@ -74,7 +74,8 @@ function isDefinedKey(ret: {
 export class KeycodeList {
   static getKeymaps(
     hex: number,
-    langLabel: KeyboardLabelLang
+    langLabel: KeyboardLabelLang,
+    customKeycodes: ICustomKeycode[] | undefined
   ): {
     value: IKeymap | null;
     holdKey: IKeymap | null;
@@ -144,6 +145,9 @@ export class KeycodeList {
       const comp = factory.createLayerTapComposition();
       ret.holdKey = comp.genKeymap() || null;
       ret.tapKey = comp.genTapKey() || null;
+    } else if (factory.isViaUserKey()) {
+      const comp = factory.createViaUserKeyComposition(customKeycodes);
+      ret.value = comp.genKeymap() || null;
     }
 
     if (!isDefinedKey(ret)) {
@@ -153,8 +157,16 @@ export class KeycodeList {
     return ret;
   }
 
-  static getKeymap(code: number, labelLang: KeyboardLabelLang): IKeymap {
-    const { value, holdKey, tapKey } = KeycodeList.getKeymaps(code, labelLang);
+  static getKeymap(
+    code: number,
+    labelLang: KeyboardLabelLang,
+    customKeycodes: ICustomKeycode[] | undefined
+  ): IKeymap {
+    const { value, holdKey, tapKey } = KeycodeList.getKeymaps(
+      code,
+      labelLang,
+      customKeycodes
+    );
     if (value) {
       return value;
     }

--- a/src/services/hid/WebHid.ts
+++ b/src/services/hid/WebHid.ts
@@ -21,6 +21,7 @@ import {
   IGetMacroBufferSizeResult,
   IFetchMacroBufferResult,
   IFetchViaProtocolVersionResult,
+  ICustomKeycode,
 } from './Hid';
 import { KeycodeList } from './KeycodeList';
 import {
@@ -171,7 +172,8 @@ export class Keyboard implements IKeyboard {
     layer: number,
     rowCount: number,
     columnCount: number,
-    labelLang: KeyboardLabelLang
+    labelLang: KeyboardLabelLang,
+    customKeycodes: ICustomKeycode[] | undefined
   ): Promise<IFetchKeymapResult> {
     const totalSize = rowCount * columnCount * 2;
     let offset = layer * totalSize;
@@ -224,7 +226,7 @@ export class Keyboard implements IKeyboard {
         }
         for (let i = 0; i < buffer.length; i += 2) {
           const code = (buffer[i] << 8) | buffer[i + 1];
-          const keymap = KeycodeList.getKeymap(code, labelLang);
+          const keymap = KeycodeList.getKeymap(code, labelLang, customKeycodes);
           keymapMap[`${row},${column}`] = keymap;
           column = column + 1;
           if (columnCount === column) {

--- a/src/services/hid/ui/Hid.tsx
+++ b/src/services/hid/ui/Hid.tsx
@@ -235,7 +235,8 @@ const Hid = () => {
         layer2,
         rowCount,
         columnCount,
-        'en-us'
+        'en-us',
+        undefined
       );
       if (fetchKeymapResult.success) {
         console.log(fetchKeymapResult.keymap);


### PR DESCRIPTION
Fix #729  and #707

This pull request adds a new feature to support the "Custom Keycodes`. This custom keycodes are defined in the VIA JSON file, and it provides custom label, short name and description for each USER** keys.

When there is no custom keycodes in VIA JSON file, USER** keys are displayed with default names.

![Screenshot_20220912_144639](https://user-images.githubusercontent.com/261787/189582108-ba336d37-f693-4856-84f8-6fb8e89d9b9b.png)

In the other hand, if a VIA JSON file has a custom keycodes definition like the following:

```
"customKeycodes": [
    { "name": "A_CW", "title": "A_CW", "shortName": "A_CW" },
    { "name": "A_CCW", "title": "A_CCW", "shortName": "A_CC" },
    { "name": "B_CW", "title": "B_CW", "shortName": "B_CW" },
    { "name": "B_CCW", "title": "B_CCW", "shortName": "B_CC" },
    { "name": "C_CW", "title": "C_CW", "shortName": "C_CW" },
    { "name": "C_CCW", "title": "C_CCW", "shortName": "C_CC" },
    { "name": "D_CW", "title": "D_CW", "shortName": "D_CW" },
    { "name": "D_CCW", "title": "D_CCW", "shortName": "D_CC" },
    { "name": "E_CW", "title": "E_CW", "shortName": "E_CW" },
    { "name": "E_CCW", "title": "E_CCW", "shortName": "E_CC" },
    { "name": "F_CW", "title": "F_CW", "shortName": "F_CW" },
    { "name": "F_CCW", "title": "F_CCW", "shortName": "F_CC" },
    { "name": "A_X", "title": "A_X", "shortName": "A_X" },
    { "name": "B_X", "title": "B_X", "shortName": "B_X" },
    { "name": "C_X", "title": "C_X", "shortName": "C_X" },
    { "name": "D_X", "title": "D_X", "shortName": "D_X" }
]
```

Each USER** key label is changed with their definitions like the following:

![Screenshot_20220912_144709](https://user-images.githubusercontent.com/261787/189582384-3e43c015-fe72-4f7f-8f75-37836eab4ed6.png)
