### PR TITLE
Support encoders in the KeyboardModel with alignment.

### DIFF
--- a/src/gen/types/KeyboardDefinition.ts
+++ b/src/gen/types/KeyboardDefinition.ts
@@ -70,5 +70,6 @@ export interface KeyOp {
   y2?: number;
   w2?: number;
   h2?: number;
+  a?: number;
   [k: string]: unknown;
 }

--- a/src/models/KeyModel.test.ts
+++ b/src/models/KeyModel.test.ts
@@ -14,4 +14,17 @@ describe('KeyModel', () => {
     subject = new KeyModel(null, '0,1', 0, 0, '', 0, 0, 0, null);
     expect(subject.encoderId).toBeNull();
   });
+
+  test('isDecal', () => {
+    let subject = new KeyModel(null, '', 0, 0, '', 0, 0, 0, null);
+    expect(subject.isDecal).toBeTruthy();
+    subject = new KeyModel(null, '0,1', 0, 0, '', 0, 0, 0, null);
+    expect(subject.isDecal).toBeFalsy();
+    subject = new KeyModel(null, '0,1', 0, 0, '', 0, 0, 0, 1);
+    expect(subject.isDecal).toBeFalsy();
+    // This key model is not decal, because this has an encoder ID.
+    subject = new KeyModel(null, '', 0, 0, '', 0, 0, 0, 1);
+    expect(subject.isDecal).toBeFalsy();
+    expect(subject.isEncoder).toBeTruthy();
+  });
 });

--- a/src/models/KeyModel.ts
+++ b/src/models/KeyModel.ts
@@ -55,9 +55,10 @@ export default class KeyModel {
     this.encoderId = encoderId;
     this.location = location;
     const locs = location.split('\n');
-    this.pos = locs[0]; // 0 < locs[0].length ? locs[0] : locs[3];
-    if (!this.includePosition(this.pos)) {
-      // If there is no position label, this Key should be "Decal".
+    this.pos = locs[0];
+    if (!this.includePosition(this.pos) && this.encoderId === null) {
+      // If there is no position label and this is not an encoder,
+      // this Key should be "Decal".
       this.keyOp = { ...(this.keyOp || {}), ...{ d: true } };
     }
     this.optionLabel =

--- a/src/models/KeyboardModel.test.ts
+++ b/src/models/KeyboardModel.test.ts
@@ -1,26 +1,119 @@
-import { Current, KeymapItem } from './KeyboardModel';
+import KeyboardModel, { Current, KeymapItem } from './KeyboardModel';
 import { OPTION_DEFAULT } from './KeyModel';
+
+describe('KeyboardModel', () => {
+  describe('keyModels', () => {
+    test('default layout', () => {
+      const subject = new KeyboardModel([
+        [
+          '0,0',
+          { a: 7 },
+          'e0',
+          { a: 4 },
+          '0,1\n\n\n\n\n\n\n\n\ne1',
+          '0,2\n\n\n0,0\n\n\n\n\n\ne2',
+          '\n\n\n0,1\n\n\n\n\n\ne3',
+          '0,3',
+        ],
+      ]);
+      const actual = subject.keyModels;
+      expect(actual.length).toEqual(6);
+      expect(actual[0].location).toEqual('0,0');
+      expect(actual[0].pos).toEqual('0,0');
+      expect(actual[0].optionLabel).toEqual('-,-');
+      expect(actual[0].option).toEqual('-');
+      expect(actual[0].optionChoice).toEqual('-');
+      expect(actual[0].encoderId).toBeNull();
+      expect(actual[0].x).toEqual(0);
+      expect(actual[0].y).toEqual(0);
+      expect(actual[1].location).toEqual('e0');
+      expect(actual[1].pos).toEqual('e0');
+      expect(actual[1].optionLabel).toEqual('-,-');
+      expect(actual[1].option).toEqual('-');
+      expect(actual[1].optionChoice).toEqual('-');
+      expect(actual[1].encoderId).toEqual(0);
+      expect(actual[1].x).toEqual(1);
+      expect(actual[1].y).toEqual(0);
+      expect(actual[2].location).toEqual('0,1\n\n\n\n\n\n\n\n\ne1');
+      expect(actual[2].pos).toEqual('0,1');
+      expect(actual[2].optionLabel).toEqual('');
+      expect(actual[2].option).toEqual('');
+      expect(actual[2].optionChoice).toBeUndefined();
+      expect(actual[2].encoderId).toEqual(1);
+      expect(actual[2].x).toEqual(2);
+      expect(actual[2].y).toEqual(0);
+      expect(actual[3].location).toEqual('0,2\n\n\n0,0\n\n\n\n\n\ne2');
+      expect(actual[3].pos).toEqual('0,2');
+      expect(actual[3].optionLabel).toEqual('0,0');
+      expect(actual[3].option).toEqual('0');
+      expect(actual[3].optionChoice).toEqual('0');
+      expect(actual[3].encoderId).toEqual(2);
+      expect(actual[3].x).toEqual(3);
+      expect(actual[3].y).toEqual(0);
+      expect(actual[4].location).toEqual('\n\n\n0,1\n\n\n\n\n\ne3');
+      expect(actual[4].pos).toEqual('');
+      expect(actual[4].optionLabel).toEqual('0,1');
+      expect(actual[4].option).toEqual('0');
+      expect(actual[4].optionChoice).toEqual('1');
+      expect(actual[4].encoderId).toEqual(3);
+      expect(actual[4].x).toEqual(3);
+      expect(actual[4].y).toEqual(0);
+      expect(actual[5].location).toEqual('0,3');
+      expect(actual[5].pos).toEqual('0,3');
+      expect(actual[5].optionLabel).toEqual('-,-');
+      expect(actual[5].option).toEqual('-');
+      expect(actual[5].optionChoice).toEqual('-');
+      expect(actual[5].encoderId).toBeNull();
+      expect(actual[5].x).toEqual(5);
+      expect(actual[5].y).toEqual(0);
+    });
+  });
+});
 
 describe('KeymapItem', () => {
   describe('encoderId', () => {
     test('encoder exists - 1', () => {
       const current = new Current();
-      const subject = new KeymapItem(current, '0,0\n\n\n\n\n\n\n\n\ne0');
-      expect(subject.encoderId).toEqual(0);
+      const subject = new KeymapItem(current, '0,0\n\n\n\n\n\n\n\n\ne3');
+      expect(subject.encoderId).toEqual(3);
     });
 
     test('encoder exists - 2', () => {
       const current = new Current();
-      const subject = new KeymapItem(
-        current,
-        '0,0\n0,6\n0,2\n0,8\n0.9\n1,1\n0,3\n0,5\n0,1\ne1\n0,7\n1,0'
-      );
-      expect(subject.encoderId).toEqual(1);
+      const subject = new KeymapItem(current, '\n\n\n0,1\n\n\n\n\n\ne3');
+      expect(subject.encoderId).toEqual(3);
     });
 
-    test('encoder not exists', () => {
+    test('encoder exists - 3', () => {
+      const current = new Current();
+      const subject = new KeymapItem(current, '0,1\n\n\n0,2\n\n\n\n\n\ne3');
+      expect(subject.encoderId).toEqual(3);
+    });
+
+    test('encoder exists - 4', () => {
+      const current = new Current();
+      current.a = 7;
+      const subject = new KeymapItem(current, 'e3');
+      expect(subject.encoderId).toEqual(3);
+    });
+
+    test('encoder exists - 5', () => {
+      const current = new Current();
+      current.a = 3;
+      const subject = new KeymapItem(current, 'e3');
+      expect(subject.encoderId).toEqual(3);
+    });
+
+    test('encoder not exists - 1', () => {
       const current = new Current();
       const subject = new KeymapItem(current, '0,0');
+      expect(subject.encoderId).toBeNull();
+    });
+
+    test('encoder not exists - 2', () => {
+      const current = new Current();
+      current.a = 4;
+      const subject = new KeymapItem(current, 'e0');
       expect(subject.encoderId).toBeNull();
     });
   });

--- a/src/models/KeyboardModel.ts
+++ b/src/models/KeyboardModel.ts
@@ -84,12 +84,6 @@ export class Current {
   }
 }
 
-// For an encoder: There are following patterns:
-//   (Left Top) (Center) (Right Bottom) -> (Label)
-//              e0                      -> "{a:3},"e0",{a:4}" or "{a:7},"e0",{a:4}"
-//   0,1        e0                      -> "0,1\n\n\n\n\n\n\n\n\ne0"
-//              e0        0,1           -> "\n\n\n0,1\n\n\n\n\n\ne0"
-//   0,1        e0        0,2           -> "0,1\n\n\n0,2\n\n\n\n\n\ne0"
 export class KeymapItem {
   private _curr: Current;
   readonly op: KeyOp;
@@ -110,6 +104,13 @@ export class KeymapItem {
         : [OPTION_DEFAULT, OPTION_DEFAULT];
     this.option = options[0];
     this.choice = options[1];
+
+    // For an encoder: There are following patterns:
+    //   (Left Top) (Center) (Right Bottom) -> (Label)
+    //              e0                      -> "{a:3},"e0",{a:4}" or "{a:7},"e0",{a:4}"
+    //   0,1        e0                      -> "0,1\n\n\n\n\n\n\n\n\ne0"
+    //              e0        0,1           -> "\n\n\n0,1\n\n\n\n\n\ne0"
+    //   0,1        e0        0,2           -> "0,1\n\n\n0,2\n\n\n\n\n\ne0"
     if (10 <= locs.length && locs[9].match(/^e[0-9]+$/i)) {
       this._encoderId = Number(locs[9].substring(1));
     } else if (
@@ -121,6 +122,7 @@ export class KeymapItem {
     } else {
       this._encoderId = null;
     }
+
     this._toBeDelete = false;
   }
 

--- a/src/models/KeyboardModel.ts
+++ b/src/models/KeyboardModel.ts
@@ -20,6 +20,7 @@ export class Current {
   ry = 0;
   x2 = 0;
   y2 = 0;
+  a = 4;
 
   constructor(curr?: Current) {
     if (curr) {
@@ -31,6 +32,7 @@ export class Current {
       this.ry = curr.ry;
       this.x2 = curr.x2;
       this.y2 = curr.y2;
+      this.a = curr.a;
     }
   }
 
@@ -72,6 +74,7 @@ export class Current {
     this.x2 = op.x2 != undefined ? op.x2 : this.x2;
     this.y2 = op.y2 != undefined ? op.y2 : this.y2;
     this.c = op.c != undefined ? op.c : this.c;
+    this.a = op.a != undefined ? op.a : this.a;
   }
 
   next(w: number) {
@@ -81,6 +84,12 @@ export class Current {
   }
 }
 
+// For an encoder: There are following patterns:
+//   (Left Top) (Center) (Right Bottom) -> (Label)
+//              e0                      -> "{a:3},"e0",{a:4}" or "{a:7},"e0",{a:4}"
+//   0,1        e0                      -> "0,1\n\n\n\n\n\n\n\n\ne0"
+//              e0        0,1           -> "\n\n\n0,1\n\n\n\n\n\ne0"
+//   0,1        e0        0,2           -> "0,1\n\n\n0,2\n\n\n\n\n\ne0"
 export class KeymapItem {
   private _curr: Current;
   readonly op: KeyOp;
@@ -101,10 +110,17 @@ export class KeymapItem {
         : [OPTION_DEFAULT, OPTION_DEFAULT];
     this.option = options[0];
     this.choice = options[1];
-    this._encoderId =
-      10 <= locs.length && locs[9].match(/^e[0-9]+$/i)
-        ? Number(locs[9].substring(1))
-        : null;
+    if (10 <= locs.length && locs[9].match(/^e[0-9]+$/i)) {
+      this._encoderId = Number(locs[9].substring(1));
+    } else if (
+      locs.length === 1 &&
+      (this._curr.a === 3 || this._curr.a === 7) &&
+      locs[0].match(/e[0-9]+$/i)
+    ) {
+      this._encoderId = Number(locs[0].substring(1));
+    } else {
+      this._encoderId = null;
+    }
     this._toBeDelete = false;
   }
 
@@ -157,6 +173,10 @@ export class KeymapItem {
       return this.op.w;
     }
     return 1;
+  }
+
+  get a(): number {
+    return this._curr.a;
   }
 
   get toBeDeleted(): boolean {

--- a/src/services/storage/assets/keyboard-definition-schema.json
+++ b/src/services/storage/assets/keyboard-definition-schema.json
@@ -192,7 +192,8 @@
         "x2": { "type": "number" },
         "y2": { "type": "number" },
         "w2": { "type": "number" },
-        "h2": { "type": "number" }
+        "h2": { "type": "number" },
+        "a": { "type": "number" }
       }
     }
   }


### PR DESCRIPTION
This pull request adds a new logic to determine whether the key is an encoder or not with alighment.

There is the following pattern to specify an encoder:

```
(Left Top) (Center) (Right Bottom) -> (Label)
           e0                      -> "{a:3},"e0",{a:4}" or "{a:7},"e0",{a:4}"
0,1        e0                      -> "0,1\n\n\n\n\n\n\n\n\ne0"
           e0        0,1           -> "\n\n\n0,1\n\n\n\n\n\ne0"
0,1        e0        0,2           -> "0,1\n\n\n0,2\n\n\n\n\n\ne0"
```

I would like to add the new logic to support the specification above so that each key model can have an encoder ID.

Also, if some key has an encode ID and there is no position, I think that the key is not "Decal", but is "Encoder". That is, all encoders should be displayed on the keyboard layout, and the "Decal" is not applied for encoders because the meaning of "Decal" is what the key is not displayed on the keyboard layout.