### PR TITLE
Store/Restore keymap information with encoders

### DIFF
--- a/src/actions/catalog.action.ts
+++ b/src/actions/catalog.action.ts
@@ -4,7 +4,7 @@ import {
   IKeyboardFeatures,
   RootState,
 } from '../store/state';
-import { IKeymap } from '../services/hid/Hid';
+import { IEncoderKeymaps, IKeymap } from '../services/hid/Hid';
 import { KeyboardLabelLang } from '../services/labellang/KeyLabelLangs';
 import { AbstractKeymapData } from '../services/storage/Storage';
 import { KeycodeList } from '../services/hid/KeycodeList';
@@ -14,6 +14,8 @@ import {
   NotificationActions,
 } from './actions';
 import { ThunkAction, ThunkDispatch } from 'redux-thunk';
+import { getEncoderIdList } from './utils';
+import { KC_NO } from '../services/hid/KeycodeInfoList';
 
 export const CATALOG_APP_ACTIONS = `@CatalogApp`;
 export const CATALOG_APP_UPDATE_PHASE = `${CATALOG_APP_ACTIONS}/UpdatePhase`;
@@ -72,6 +74,7 @@ export const CatalogSearchActions = {
 
 export const CATALOG_KEYBOARD_ACTIONS = `@CatalogKeyboard`;
 export const CATALOG_KEYBOARD_UPDATE_KEYMAPS = `${CATALOG_KEYBOARD_ACTIONS}/UpdateKeymaps`;
+export const CATALOG_KEYBOARD_UPDATE_ENCODERS_KEYMAPS = `${CATALOG_KEYBOARD_ACTIONS}/UpdateEncodersKeymaps`;
 export const CATALOG_KEYBOARD_UPDATE_SELECTED_LAYER = `${CATALOG_KEYBOARD_ACTIONS}/UpdateSelectedLayer`;
 export const CATALOG_KEYBOARD_UPDATE_LANG_LABEL = `${CATALOG_KEYBOARD_ACTIONS}/UpdateLangLabel`;
 export const CATALOG_KEYBOARD_CLEAR_KEYMAP = `${CATALOG_KEYBOARD_ACTIONS}/ClearKeymap`;
@@ -85,6 +88,12 @@ export const CatalogKeyboardActions = {
     return {
       type: CATALOG_KEYBOARD_UPDATE_KEYMAPS,
       value: keymaps,
+    };
+  },
+  updateEncodersKeymaps: (encodersKeymaps: IEncoderKeymaps[]) => {
+    return {
+      type: CATALOG_KEYBOARD_UPDATE_ENCODERS_KEYMAPS,
+      value: encodersKeymaps,
     };
   },
   updateSelectedLayer: (selectedLayer: number) => {
@@ -136,30 +145,86 @@ export const catalogActionsThunk = {
       const { entities } = getState();
       const labelLang = savedKeymapData.label_lang;
       const layoutOptions = savedKeymapData.layout_options;
-      let keycodes: { [pos: string]: IKeymap }[] = [];
+
+      const keycodes: { [pos: string]: IKeymap }[] = [];
       const savedKeycodes: { [pos: string]: number }[] =
         savedKeymapData.keycodes;
       for (let i = 0; i < savedKeycodes.length; i++) {
         const savedCode = savedKeycodes[i];
-        const changes: { [pos: string]: IKeymap } = {};
+        const keymaps: { [pos: string]: IKeymap } = {};
         // When the savedKeycodes was stored for BMP MCU, the length may be 11.
         // Therefore, the target layer must be checked to ensure that the value
         // is less than the savedKeycodes length.
         // See: https://github.com/remap-keys/remap/issues/454
         if (i < savedKeycodes.length) {
           Object.keys(savedCode).forEach((pos) => {
-            changes[pos] = KeycodeList.getKeymap(
+            keymaps[pos] = KeycodeList.getKeymap(
               savedCode[pos],
               labelLang,
               entities.keyboardDefinition!.customKeycodes
             );
           });
         }
-        keycodes.push(changes);
+        keycodes.push(keymaps);
       }
+
+      const encoderIdList = getEncoderIdList(
+        entities.keyboardDefinition!.layouts.keymap
+      );
+      const encodersKeycodes: IEncoderKeymaps[] = [];
+      const savedEncodersKeycodes: {
+        [id: number]: { clockwise: number; counterclockwise: number };
+      }[] =
+        savedKeymapData.encoderKeycodes ||
+        // Shared keymaps don't have any encoder's key codes before supporting encoders in Remap.
+        // Therefore, set initial key codes (KC_NO) for encoders here.
+        (
+          new Array(savedKeycodes.length) as {
+            [id: number]: { clockwise: number; counterclockwise: number };
+          }[]
+        ).fill(
+          encoderIdList.reduce<{
+            [id: number]: { clockwise: number; counterclockwise: number };
+          }>(
+            (result, encoderId) => {
+              result[encoderId] = { clockwise: KC_NO, counterclockwise: KC_NO };
+              return result;
+            },
+            {} as {
+              [id: number]: { clockwise: number; counterclockwise: number };
+            }
+          )
+        );
+      for (let i = 0; i < savedEncodersKeycodes.length; i++) {
+        const savedEncodersCode = savedEncodersKeycodes[i];
+        const encodersKeymaps: IEncoderKeymaps = {};
+        // When the savedKeycodes was stored for BMP MCU, the length may be 11.
+        // Therefore, the target layer must be checked to ensure that the value
+        // is less than the savedKeycodes length.
+        // See: https://github.com/remap-keys/remap/issues/454
+        if (i < savedEncodersKeycodes.length) {
+          Object.keys(savedEncodersCode).forEach((id) => {
+            encodersKeymaps[Number(id)] = {
+              clockwise: KeycodeList.getKeymap(
+                savedEncodersCode[Number(id)].clockwise,
+                labelLang,
+                entities.keyboardDefinition!.customKeycodes
+              ),
+              counterclockwise: KeycodeList.getKeymap(
+                savedEncodersCode[Number(id)].counterclockwise,
+                labelLang,
+                entities.keyboardDefinition!.customKeycodes
+              ),
+            };
+          });
+        }
+        encodersKeycodes.push(encodersKeymaps);
+      }
+
       dispatch(CatalogKeyboardActions.updateLangLabel(labelLang));
       dispatch(AppActions.updateLangLabel(labelLang));
       dispatch(CatalogKeyboardActions.updateKeymaps(keycodes));
+      dispatch(CatalogKeyboardActions.updateEncodersKeymaps(encodersKeycodes));
       dispatch(LayoutOptionsActions.restoreLayoutOptions(layoutOptions));
       dispatch(CatalogKeyboardActions.updateSelectedLayer(0));
       dispatch(

--- a/src/actions/hid.action.ts
+++ b/src/actions/hid.action.ts
@@ -24,7 +24,7 @@ import { sendEventToGoogleAnalytics } from '../utils/GoogleAnalytics';
 import { LayoutOption } from '../components/configure/keymap/Keymap';
 import { maxValueByBitLength } from '../utils/NumberUtils';
 import { KeyOp } from '../gen/types/KeyboardDefinition';
-import KeyboardModel from '../models/KeyboardModel';
+import { getEncoderIdList } from './utils';
 
 const PRODUCT_PREFIX_FOR_BLE_MICRO_PRO = '(BMP)';
 
@@ -807,19 +807,6 @@ const loadEncodersKeymap = async (
     }
   }
   return keymaps;
-};
-
-const getEncoderIdList = (
-  keymapDefinition: ((string | KeyOp)[] | { name: string })[]
-): number[] => {
-  const keyboardModel = new KeyboardModel(keymapDefinition);
-  const keyModels = keyboardModel.keyModels;
-  return keyModels.reduce<number[]>((result, keyModel) => {
-    if (keyModel.isEncoder) {
-      result.push(keyModel.encoderId!);
-    }
-    return result;
-  }, []);
 };
 
 const createLayoutValueBitLengths = (

--- a/src/actions/utils.test.ts
+++ b/src/actions/utils.test.ts
@@ -1,0 +1,31 @@
+import { KeyOp } from '../gen/types/KeyboardDefinition';
+import { getEncoderIdList } from './utils';
+
+describe('getEncoderIdList', () => {
+  test('no encoder', () => {
+    const keymapDefinition: ((string | KeyOp)[] | { name: string })[] = [];
+    const actual = getEncoderIdList(keymapDefinition);
+    expect(actual.length).toEqual(0);
+  });
+
+  test('normal', () => {
+    const keymapDefinition: ((string | KeyOp)[] | { name: string })[] = [
+      [
+        '0,0',
+        { a: 7 },
+        'e0',
+        { a: 4 },
+        '0,1\n\n\n\n\n\n\n\n\ne1',
+        '0,2\n\n\n0,0\n\n\n\n\n\ne2',
+        '\n\n\n0,1\n\n\n\n\n\ne4',
+        '0,3',
+      ],
+    ];
+    const actual = getEncoderIdList(keymapDefinition);
+    expect(actual.length).toEqual(4);
+    expect(actual[0]).toEqual(0);
+    expect(actual[1]).toEqual(1);
+    expect(actual[2]).toEqual(2);
+    expect(actual[3]).toEqual(4);
+  });
+});

--- a/src/actions/utils.ts
+++ b/src/actions/utils.ts
@@ -1,0 +1,15 @@
+import { KeyOp } from '../gen/types/KeyboardDefinition';
+import KeyboardModel from '../models/KeyboardModel';
+
+export const getEncoderIdList = (
+  keymapDefinition: ((string | KeyOp)[] | { name: string })[]
+): number[] => {
+  const keyboardModel = new KeyboardModel(keymapDefinition);
+  const keyModels = keyboardModel.keyModels;
+  return keyModels.reduce<number[]>((result, keyModel) => {
+    if (keyModel.isEncoder) {
+      result.push(keyModel.encoderId!);
+    }
+    return result;
+  }, []);
+};

--- a/src/components/configure/keymaplist/KeymapListPopover.container.ts
+++ b/src/components/configure/keymaplist/KeymapListPopover.container.ts
@@ -7,7 +7,7 @@ import {
   LayoutOptionsActions,
 } from '../../../actions/actions';
 import { KeyboardLabelLang } from '../../../services/labellang/KeyLabelLangs';
-import { IKeymap } from '../../../services/hid/Hid';
+import { IEncoderKeymaps, IKeymap } from '../../../services/hid/Hid';
 import { LayoutOption } from '../keymap/Keymap';
 import { AbstractKeymapData } from '../../../services/storage/Storage';
 import { storageActionsThunk } from '../../../actions/storage.action';
@@ -17,6 +17,7 @@ const mapStateToProps = (state: RootState) => {
   return {
     savedKeymaps: state.entities.savedKeymaps,
     keymaps: state.entities.device.keymaps,
+    encodersKeymaps: state.entities.device.encodersKeymaps,
     auth: state.auth.instance,
     signedIn: state.app.signedIn,
     sharedKeymaps: state.entities.sharedKeymaps,
@@ -32,12 +33,14 @@ const mapDispatchToProps = (_dispatch: any) => {
   return {
     applySavedKeymapData: (
       keymaps: { [pos: string]: IKeymap }[],
+      encodersKeymaps: IEncoderKeymaps[],
       layoutOptions: LayoutOption[],
       labelLang: KeyboardLabelLang
     ) => {
       _dispatch(AppActions.updateLangLabel(labelLang));
       _dispatch(KeydiffActions.clearKeydiff());
       _dispatch(AppActions.remapsSetKeys(keymaps));
+      _dispatch(AppActions.encodersRemapsSetKeys(encodersKeymaps));
       _dispatch(LayoutOptionsActions.restoreLayoutOptions(layoutOptions));
     },
     createOrUpdateAppliedKeymap: (savedKeymapData: AbstractKeymapData) => {

--- a/src/components/configure/keymaplist/KeymapSaveDialog.container.ts
+++ b/src/components/configure/keymaplist/KeymapSaveDialog.container.ts
@@ -8,6 +8,7 @@ const mapStateToProps = (state: RootState) => {
   return {
     keyboard: state.entities.keyboard,
     keymaps: state.entities.device.keymaps,
+    encodersKeymaps: state.entities.device.encodersKeymaps,
     labelLang: state.app.labelLang,
     layerCount: state.entities.device.layerCount,
     layoutLabels: state.entities.keyboardDefinition?.layouts.labels,

--- a/src/services/hid/KeycodeInfoList.ts
+++ b/src/services/hid/KeycodeInfoList.ts
@@ -1,5 +1,7 @@
 import { IKeycodeInfo } from './Hid';
 
+export const KC_NO = 0;
+
 export type KeyInfo = {
   desc: string;
   keycodeInfo: IKeycodeInfo;
@@ -8,7 +10,7 @@ export const keyInfoList: KeyInfo[] = [
   {
     desc: 'Ignore this key (NOOP)',
     keycodeInfo: {
-      code: 0,
+      code: KC_NO,
       name: {
         long: 'KC_NO',
         short: 'KC_NO',

--- a/src/services/provider/Firebase.ts
+++ b/src/services/provider/Firebase.ts
@@ -853,6 +853,7 @@ export class FirebaseProvider implements IStorage, IAuth {
           label_lang: keymapData.label_lang,
           layout_options: keymapData.layout_options,
           keycodes: keymapData.keycodes,
+          encoderKeycodes: keymapData.encoderKeycodes,
           created_at: now,
           updated_at: now,
         };
@@ -879,6 +880,7 @@ export class FirebaseProvider implements IStorage, IAuth {
             label_lang: keymapData.label_lang,
             layout_options: keymapData.layout_options,
             keycodes: keymapData.keycodes,
+            encoderKeycodes: keymapData.encoderKeycodes,
             updated_at: new Date(),
           });
         return {

--- a/src/services/storage/Storage.ts
+++ b/src/services/storage/Storage.ts
@@ -133,6 +133,9 @@ export interface AbstractKeymapData {
   label_lang: KeyboardLabelLang;
   layout_options: LayoutOption[];
   keycodes: { [pos: string]: number }[];
+  encoderKeycodes: {
+    [id: number]: { clockwise: number; counterclockwise: number };
+  }[];
   created_at?: Date;
   updated_at?: Date;
 }

--- a/src/store/reducers.ts
+++ b/src/store/reducers.ts
@@ -158,6 +158,7 @@ import {
   CATALOG_APP_UPDATE_PHASE,
   CATALOG_KEYBOARD_ACTIONS,
   CATALOG_KEYBOARD_CLEAR_KEYMAP,
+  CATALOG_KEYBOARD_UPDATE_ENCODERS_KEYMAPS,
   CATALOG_KEYBOARD_UPDATE_KEYMAPS,
   CATALOG_KEYBOARD_UPDATE_LANG_LABEL,
   CATALOG_KEYBOARD_UPDATE_SELECTED_KEYMAP_DATA,
@@ -1040,6 +1041,9 @@ const catalogKeyboardReducer = (
   switch (action.type) {
     case CATALOG_KEYBOARD_UPDATE_KEYMAPS:
       draft.catalog.keyboard.keymaps = action.value;
+      break;
+    case CATALOG_KEYBOARD_UPDATE_ENCODERS_KEYMAPS:
+      draft.catalog.keyboard.encodersKeymaps = action.value;
       break;
     case CATALOG_KEYBOARD_UPDATE_SELECTED_LAYER:
       draft.catalog.keyboard.selectedLayer = action.value;

--- a/src/store/state.ts
+++ b/src/store/state.ts
@@ -360,6 +360,7 @@ export type RootState = {
       keymaps: {
         [pos: string]: IKeymap;
       }[];
+      encodersKeymaps: IEncoderKeymaps[];
       selectedLayer: number;
       langLabel: KeyboardLabelLang;
       selectedKeymapData: AbstractKeymapData | null;
@@ -587,6 +588,7 @@ export const INIT_STATE: RootState = {
     },
     keyboard: {
       keymaps: [],
+      encodersKeymaps: [],
       selectedLayer: 0,
       langLabel: 'en-us',
       selectedKeymapData: null,


### PR DESCRIPTION
This pull request changes codes to store/restore keymaps. For instance, this adds keymap information (which consists of clockwise and counterclockwise) for encoders.

* If a stored key mapping information does not have any encoder's key codes, nothing is updated for encoders at applying.
* If there are one or some key codes for encoders in a stored key mapping information at applying it, and they are different from key codes loaded from MCU, they are set to the app.encodersRemaps in the state.

![Screenshot_20221015_062449](https://user-images.githubusercontent.com/261787/195946412-48b04f85-6ce8-407e-a1c0-c0599888ce38.png)
