### PR TITLE
Save keyLabelLang to keep selection of user language in localstorage

### DIFF
--- a/src/store/reducers.ts
+++ b/src/store/reducers.ts
@@ -610,7 +610,7 @@ const appReducer = (action: Action, draft: WritableDraft<RootState>) => {
     case APP_UPDATE_LANG_LABEL: {
       draft.app.labelLang = action.value;
       // Save the value to storage
-      localStorage.setItem("LabelLang", action.value)
+      localStorage.setItem('LabelLang', action.value);
       break;
     }
     case APP_UPDATE_SIGNED_IN: {

--- a/src/store/reducers.ts
+++ b/src/store/reducers.ts
@@ -609,6 +609,8 @@ const appReducer = (action: Action, draft: WritableDraft<RootState>) => {
     }
     case APP_UPDATE_LANG_LABEL: {
       draft.app.labelLang = action.value;
+      // Save the value to storage
+      localStorage.setItem("LabelLang", action.value)
       break;
     }
     case APP_UPDATE_SIGNED_IN: {

--- a/src/store/state.ts
+++ b/src/store/state.ts
@@ -20,7 +20,10 @@ import { IAuth } from '../services/auth/Auth';
 import { KeyboardDefinitionSchema } from '../gen/types/KeyboardDefinition';
 import { GitHub, IGitHub } from '../services/github/GitHub';
 import buildInfo from '../assets/files/build-info.json';
-import { KeyboardLabelLang, KEY_LABEL_LANGS } from '../services/labellang/KeyLabelLangs';
+import {
+  KeyboardLabelLang,
+  KEY_LABEL_LANGS,
+} from '../services/labellang/KeyLabelLangs';
 import { LayoutOption } from '../components/configure/keymap/Keymap';
 import { IMacro, IMacroBuffer, MacroKey } from '../services/macro/Macro';
 import { IFirmwareWriter } from '../services/firmware/FirmwareWriter';
@@ -417,17 +420,17 @@ const gitHub = new GitHub();
 const firmwareWriter = new FirmwareWriterWebApiImpl();
 
 const getKeyLabel = () => {
-  const defaultKeyLabel = 'en-us'
-  const storageValue = localStorage.getItem("LabelLang")
+  const defaultKeyLabel = 'en-us';
+  const storageValue = localStorage.getItem('LabelLang');
   if (storageValue === null) {
-    return defaultKeyLabel
+    return defaultKeyLabel;
   }
-  const keyLabelLang = KEY_LABEL_LANGS.find(v => v.labelLang == storageValue)
+  const keyLabelLang = KEY_LABEL_LANGS.find((v) => v.labelLang == storageValue);
   if (keyLabelLang == undefined) {
-    return defaultKeyLabel
+    return defaultKeyLabel;
   }
-  return keyLabelLang.labelLang
-}
+  return keyLabelLang.labelLang;
+};
 
 export const INIT_STATE: RootState = {
   entities: {
@@ -474,16 +477,18 @@ export const INIT_STATE: RootState = {
     keyboardHeight: 0,
     keyboardWidth: 0,
     labelLang: (() => {
-      const defaultKeyLabel = 'en-us'
-      const storageValue = localStorage.getItem("LabelLang")
+      const defaultKeyLabel = 'en-us';
+      const storageValue = localStorage.getItem('LabelLang');
       if (storageValue === null) {
-        return defaultKeyLabel
+        return defaultKeyLabel;
       }
-      const keyLabelLang = KEY_LABEL_LANGS.find(v => v.labelLang == storageValue)
+      const keyLabelLang = KEY_LABEL_LANGS.find(
+        (v) => v.labelLang == storageValue
+      );
       if (keyLabelLang == undefined) {
-        return defaultKeyLabel
+        return defaultKeyLabel;
       }
-      return keyLabelLang.labelLang
+      return keyLabelLang.labelLang;
     })(),
     signedIn: false,
     meta: {

--- a/src/store/state.ts
+++ b/src/store/state.ts
@@ -20,7 +20,7 @@ import { IAuth } from '../services/auth/Auth';
 import { KeyboardDefinitionSchema } from '../gen/types/KeyboardDefinition';
 import { GitHub, IGitHub } from '../services/github/GitHub';
 import buildInfo from '../assets/files/build-info.json';
-import { KeyboardLabelLang } from '../services/labellang/KeyLabelLangs';
+import { KeyboardLabelLang, KEY_LABEL_LANGS } from '../services/labellang/KeyLabelLangs';
 import { LayoutOption } from '../components/configure/keymap/Keymap';
 import { IMacro, IMacroBuffer, MacroKey } from '../services/macro/Macro';
 import { IFirmwareWriter } from '../services/firmware/FirmwareWriter';
@@ -416,6 +416,19 @@ const gitHub = new GitHub();
 
 const firmwareWriter = new FirmwareWriterWebApiImpl();
 
+const getKeyLabel = () => {
+  const defaultKeyLabel = 'en-us'
+  const storageValue = localStorage.getItem("LabelLang")
+  if (storageValue === null) {
+    return defaultKeyLabel
+  }
+  const keyLabelLang = KEY_LABEL_LANGS.find(v => v.labelLang == storageValue)
+  if (keyLabelLang == undefined) {
+    return defaultKeyLabel
+  }
+  return keyLabelLang.labelLang
+}
+
 export const INIT_STATE: RootState = {
   entities: {
     device: {
@@ -460,7 +473,18 @@ export const INIT_STATE: RootState = {
     notifications: [],
     keyboardHeight: 0,
     keyboardWidth: 0,
-    labelLang: 'en-us',
+    labelLang: (() => {
+      const defaultKeyLabel = 'en-us'
+      const storageValue = localStorage.getItem("LabelLang")
+      if (storageValue === null) {
+        return defaultKeyLabel
+      }
+      const keyLabelLang = KEY_LABEL_LANGS.find(v => v.labelLang == storageValue)
+      if (keyLabelLang == undefined) {
+        return defaultKeyLabel
+      }
+      return keyLabelLang.labelLang
+    })(),
     signedIn: false,
     meta: {
       title: '',

--- a/src/store/state.ts
+++ b/src/store/state.ts
@@ -419,19 +419,6 @@ const gitHub = new GitHub();
 
 const firmwareWriter = new FirmwareWriterWebApiImpl();
 
-const getKeyLabel = () => {
-  const defaultKeyLabel = 'en-us';
-  const storageValue = localStorage.getItem('LabelLang');
-  if (storageValue === null) {
-    return defaultKeyLabel;
-  }
-  const keyLabelLang = KEY_LABEL_LANGS.find((v) => v.labelLang == storageValue);
-  if (keyLabelLang == undefined) {
-    return defaultKeyLabel;
-  }
-  return keyLabelLang.labelLang;
-};
-
 export const INIT_STATE: RootState = {
   entities: {
     device: {


### PR DESCRIPTION
This PR is related with #451

## What I did

- Add logic to save/fetch lang data to localStorage

## What I have not done yet

- Gather logic of save/fetch lang data to localStorage.

## What I want to consult

- The storage to save the language data
  - localStorage
  - Firestore
- The architecture
  - Current code does not encapsulate storage access logic.
  - I want to gather them like `/src/services/provider/Firebase.ts`.
  - I don't have enough knowledge and understanding this project. I would like you to tell me your best way or thinking.
