### PR TITLE
Update ble micro pro custom keycodes

### DIFF
--- a/src/actions/hid.action.ts
+++ b/src/actions/hid.action.ts
@@ -25,6 +25,7 @@ import { LayoutOption } from '../components/configure/keymap/Keymap';
 import { maxValueByBitLength } from '../utils/NumberUtils';
 import { KeyOp } from '../gen/types/KeyboardDefinition';
 import { getEncoderIdList } from './utils';
+import { bmpKeyInfoList } from '../services/hid/KeycodeInfoListBmp';
 
 const PRODUCT_PREFIX_FOR_BLE_MICRO_PRO = '(BMP)';
 
@@ -290,13 +291,32 @@ export const hidActionsThunk = {
         product_id: keyboard.getInformation().productId,
         product_name: keyboard.getInformation().productName,
       });
-      dispatch(
-        HidActions.updateBleMicroPro(
-          keyboard
-            .getInformation()
-            .productName.includes(PRODUCT_PREFIX_FOR_BLE_MICRO_PRO)
-        )
-      );
+
+      const isBleMicroPro = keyboard
+        .getInformation()
+        .productName.includes(PRODUCT_PREFIX_FOR_BLE_MICRO_PRO);
+
+      // Override custom keycode list if the keyboard uses BLE Micro Pro
+      const customKeycodes = !isBleMicroPro
+        ? entities.keyboardDefinition?.customKeycodes
+        : bmpKeyInfoList.map((k) => {
+            return {
+              name: k.keycodeInfo.name.long,
+              title: k.desc,
+              shortName: k.keycodeInfo.name.short,
+            };
+          });
+
+      if (isBleMicroPro) {
+        dispatch(HidActions.updateBleMicroPro(isBleMicroPro));
+        dispatch(
+          StorageActions.updateKeyboardDefinition({
+            ...entities.keyboardDefinition,
+            customKeycodes: customKeycodes,
+          })
+        );
+      }
+
       const viaProtocolVersionResult = await keyboard.fetchViaProtocolVersion();
       if (!viaProtocolVersionResult.success) {
         dispatch(
@@ -338,7 +358,7 @@ export const hidActionsThunk = {
         entities.keyboardDefinition!.matrix.rows,
         entities.keyboardDefinition!.matrix.cols,
         app.labelLang,
-        entities.keyboardDefinition!.customKeycodes
+        customKeycodes
       );
       dispatch(HidActions.updateKeymaps(keymaps));
       const encodersKeymaps: IEncoderKeymaps[] = await loadEncodersKeymap(
@@ -346,7 +366,7 @@ export const hidActionsThunk = {
         keyboard,
         layerCount,
         app.labelLang,
-        entities.keyboardDefinition!.customKeycodes,
+        customKeycodes,
         entities.keyboardDefinition!.layouts.keymap,
         viaProtocolVersion
       );

--- a/src/actions/hid.action.ts
+++ b/src/actions/hid.action.ts
@@ -308,7 +308,6 @@ export const hidActionsThunk = {
           });
 
       if (isBleMicroPro) {
-        dispatch(HidActions.updateBleMicroPro(isBleMicroPro));
         dispatch(
           StorageActions.updateKeyboardDefinition({
             ...entities.keyboardDefinition,
@@ -316,6 +315,7 @@ export const hidActionsThunk = {
           })
         );
       }
+      dispatch(HidActions.updateBleMicroPro(isBleMicroPro));
 
       const viaProtocolVersionResult = await keyboard.fetchViaProtocolVersion();
       if (!viaProtocolVersionResult.success) {

--- a/src/actions/hid.action.ts
+++ b/src/actions/hid.action.ts
@@ -301,7 +301,7 @@ export const hidActionsThunk = {
         ? entities.keyboardDefinition?.customKeycodes
         : bmpKeyInfoList.map((k) => {
             return {
-              name: k.keycodeInfo.name.long,
+              name: k.keycodeInfo.label,
               title: k.desc,
               shortName: k.keycodeInfo.name.short,
             };

--- a/src/services/hid/KeycodeInfoListBmp.ts
+++ b/src/services/hid/KeycodeInfoListBmp.ts
@@ -267,4 +267,40 @@ export const bmpKeyInfoList: KeyInfo[] = [
       keywords: ['ent_slp'],
     },
   },
+  {
+    desc: 'Disable key override for US/JP keyboard on JP/US OS',
+    keycodeInfo: {
+      code: 0x7e15,
+      name: {
+        long: 'DISABLE_KEY_OS_OVERRIDE',
+        short: 'D_OVR',
+      },
+      label: 'D OVR',
+      keywords: ['Disable keyboard os override'],
+    },
+  },
+  {
+    desc: 'Enable US keyboard on JP OS override',
+    keycodeInfo: {
+      code: 0x7e16,
+      name: {
+        long: 'ENABLE_US_KEY_ON_JP_OS_OVERRIDE',
+        short: 'UJ_OVR',
+      },
+      label: 'UJ OVR',
+      keywords: ['Enable US keyboard on JP OS override'],
+    },
+  },
+  {
+    desc: 'Enable JP keyboard on US OS override',
+    keycodeInfo: {
+      code: 0x7e17,
+      name: {
+        long: 'ENABLE_JP_KEY_ON_US_OS_OVERRIDE',
+        short: 'JU_OVR',
+      },
+      label: 'JU OVR',
+      keywords: ['Enable JP keyboard on US OS override'],
+    },
+  },
 ];

--- a/src/services/hid/KeycodeInfoListBmp.ts
+++ b/src/services/hid/KeycodeInfoListBmp.ts
@@ -4,57 +4,9 @@ export const CATEGORY_LABEL_BMP = 'BMP';
 
 export const bmpKeyInfoList: KeyInfo[] = [
   {
-    desc: 'Disable BLE HID sending',
-    keycodeInfo: {
-      code: 0x5e00, // 24064 0b101111000000000
-      name: {
-        long: 'BLE_DIS',
-        short: 'BLE_DIS',
-      },
-      label: 'BLE DIS',
-      keywords: ['ble_dis'],
-    },
-  },
-  {
-    desc: 'Enable BLE HID sending',
-    keycodeInfo: {
-      code: 0x5e01, // 24065 0b101111000000001
-      name: {
-        long: 'BLE_EN',
-        short: 'BLE_EN',
-      },
-      label: 'BLE EN',
-      keywords: ['ble_en'],
-    },
-  },
-  {
-    desc: 'Disable USB HID sending',
-    keycodeInfo: {
-      code: 0x5e02, // 24066 0b101111000000010
-      name: {
-        long: 'USB_DIS',
-        short: 'USB_DIS',
-      },
-      label: 'USB DIS',
-      keywords: ['usb_dis'],
-    },
-  },
-  {
-    desc: 'Enable USB HID sending',
-    keycodeInfo: {
-      code: 0x5e03, // 24067 0b101111000000011
-      name: {
-        long: 'USB_EN',
-        short: 'USB_EN',
-      },
-      label: 'USB EN',
-      keywords: ['usb_en'],
-    },
-  },
-  {
     desc: 'Enable BLE and disable USB',
     keycodeInfo: {
-      code: 0x5e04, // 24068 0b101111000000100
+      code: 0x7e00,
       name: {
         long: 'SEL_BLE',
         short: 'SEL_BLE',
@@ -66,7 +18,7 @@ export const bmpKeyInfoList: KeyInfo[] = [
   {
     desc: 'Enable USB and disable BLE',
     keycodeInfo: {
-      code: 0x5e05, // 24069 0b101111000000101
+      code: 0x7e01,
       name: {
         long: 'SEL_USB',
         short: 'SEL_USB',
@@ -78,7 +30,7 @@ export const bmpKeyInfoList: KeyInfo[] = [
   {
     desc: 'Start advertising to PeerID 0',
     keycodeInfo: {
-      code: 0x5e06, // 24070 0b101111000000110
+      code: 0x7e02,
       name: {
         long: 'ADV_ID0',
         short: 'ADV_ID0',
@@ -90,7 +42,7 @@ export const bmpKeyInfoList: KeyInfo[] = [
   {
     desc: 'Start advertising to PeerID 1',
     keycodeInfo: {
-      code: 0x5e07, // 24071 0b101111000000111
+      code: 0x7e03,
       name: {
         long: 'ADV_ID1',
         short: 'ADV_ID1',
@@ -102,7 +54,7 @@ export const bmpKeyInfoList: KeyInfo[] = [
   {
     desc: 'Start advertising to PeerID 2',
     keycodeInfo: {
-      code: 0x5e08, // 24072 0b101111000001000
+      code: 0x7e04,
       name: {
         long: 'ADV_ID2',
         short: 'ADV_ID2',
@@ -114,7 +66,7 @@ export const bmpKeyInfoList: KeyInfo[] = [
   {
     desc: 'Start advertising to PeerID 3',
     keycodeInfo: {
-      code: 0x5e09, // 24073 0b101111000001001
+      code: 0x7e05,
       name: {
         long: 'ADV_ID3',
         short: 'ADV_ID3',
@@ -126,7 +78,7 @@ export const bmpKeyInfoList: KeyInfo[] = [
   {
     desc: 'Start advertising to PeerID 4',
     keycodeInfo: {
-      code: 0x5e0a, // 24074 0b101111000001010
+      code: 0x7e06,
       name: {
         long: 'ADV_ID4',
         short: 'ADV_ID4',
@@ -138,7 +90,7 @@ export const bmpKeyInfoList: KeyInfo[] = [
   {
     desc: 'Start advertising to PeerID 5',
     keycodeInfo: {
-      code: 0x5e0b, // 24075 0b101111000001011
+      code: 0x7e07,
       name: {
         long: 'ADV_ID5',
         short: 'ADV_ID5',
@@ -150,7 +102,7 @@ export const bmpKeyInfoList: KeyInfo[] = [
   {
     desc: 'Start advertising to PeerID 6',
     keycodeInfo: {
-      code: 0x5e0c, // 24076 0b101111000001100
+      code: 0x7e08,
       name: {
         long: 'ADV_ID6',
         short: 'ADV_ID6',
@@ -162,7 +114,7 @@ export const bmpKeyInfoList: KeyInfo[] = [
   {
     desc: 'Start advertising to PeerID 7',
     keycodeInfo: {
-      code: 0x5e0d, // 24077 0b101111000001101
+      code: 0x7e09,
       name: {
         long: 'ADV_ID7',
         short: 'ADV_ID7',
@@ -174,7 +126,7 @@ export const bmpKeyInfoList: KeyInfo[] = [
   {
     desc: 'Start advertising without whitelist',
     keycodeInfo: {
-      code: 0x5e0e, // 24078 0b101111000001110
+      code: 0x7e0a,
       name: {
         long: 'AD_WO_L',
         short: 'AD_WO_L',
@@ -186,7 +138,7 @@ export const bmpKeyInfoList: KeyInfo[] = [
   {
     desc: 'Delete bonding of PeerID 0',
     keycodeInfo: {
-      code: 0x5e0f, // 24079 0b101111000001111
+      code: 0x7e0b,
       name: {
         long: 'DEL_ID0',
         short: 'DEL_ID0',
@@ -198,7 +150,7 @@ export const bmpKeyInfoList: KeyInfo[] = [
   {
     desc: 'Delete bonding of PeerID 1',
     keycodeInfo: {
-      code: 0x5e10, // 24080 0b101111000010000
+      code: 0x7e0c,
       name: {
         long: 'DEL_ID1',
         short: 'DEL_ID1',
@@ -210,7 +162,7 @@ export const bmpKeyInfoList: KeyInfo[] = [
   {
     desc: 'Delete bonding of PeerID 2',
     keycodeInfo: {
-      code: 0x5e11, // 24081 0b101111000010001
+      code: 0x7e0d,
       name: {
         long: 'DEL_ID2',
         short: 'DEL_ID2',
@@ -222,7 +174,7 @@ export const bmpKeyInfoList: KeyInfo[] = [
   {
     desc: 'Delete bonding of PeerID 3',
     keycodeInfo: {
-      code: 0x5e12, // 24082 0b101111000010010
+      code: 0x7e0e,
       name: {
         long: 'DEL_ID3',
         short: 'DEL_ID3',
@@ -234,7 +186,7 @@ export const bmpKeyInfoList: KeyInfo[] = [
   {
     desc: 'Delete bonding of PeerID 4',
     keycodeInfo: {
-      code: 0x5e13, // 24083 0b101111000010011
+      code: 24083,
       name: {
         long: 'DEL_ID4',
         short: 'DEL_ID4',
@@ -246,7 +198,7 @@ export const bmpKeyInfoList: KeyInfo[] = [
   {
     desc: 'Delete bonding of PeerID 5',
     keycodeInfo: {
-      code: 0x5e14, // 24084 0b101111000010100
+      code: 0x7e0f,
       name: {
         long: 'DEL_ID5',
         short: 'DEL_ID5',
@@ -258,7 +210,7 @@ export const bmpKeyInfoList: KeyInfo[] = [
   {
     desc: 'Delete bonding of PeerID 6',
     keycodeInfo: {
-      code: 0x5e15, // 24085 0b101111000010101
+      code: 0x7e10,
       name: {
         long: 'DEL_ID6',
         short: 'DEL_ID6',
@@ -270,7 +222,7 @@ export const bmpKeyInfoList: KeyInfo[] = [
   {
     desc: 'Delete bonding of PeerID 7',
     keycodeInfo: {
-      code: 0x5e16, // 24086 0b101111000010110
+      code: 0x7e11,
       name: {
         long: 'DEL_ID7',
         short: 'DEL_ID7',
@@ -282,7 +234,7 @@ export const bmpKeyInfoList: KeyInfo[] = [
   {
     desc: 'Delete all bonding',
     keycodeInfo: {
-      code: 0x5e17, // 24087 0b101111000010111
+      code: 0x7e12,
       name: {
         long: 'DELBNDS',
         short: 'DELBNDS',
@@ -292,45 +244,9 @@ export const bmpKeyInfoList: KeyInfo[] = [
     },
   },
   {
-    desc: 'Start bootloader',
-    keycodeInfo: {
-      code: 0x5e18, // 24088 0b101111000011000
-      name: {
-        long: 'ENT_DFU',
-        short: 'ENT_DFU',
-      },
-      label: 'ENT DFU',
-      keywords: ['ent_dfu'],
-    },
-  },
-  {
-    desc: 'Start web configurator',
-    keycodeInfo: {
-      code: 0x5e19, // 24089 0b101111000011001
-      name: {
-        long: 'ENT_WEB',
-        short: 'ENT_WEB',
-      },
-      label: 'ENT WEB',
-      keywords: ['ent_web'],
-    },
-  },
-  {
-    desc: 'Deep sleep mode',
-    keycodeInfo: {
-      code: 0x5e1a, // 24090 0b101111000011010
-      name: {
-        long: 'ENT_SLP',
-        short: 'ENT_SLP',
-      },
-      label: 'ENT SLP',
-      keywords: ['ent_slp'],
-    },
-  },
-  {
     desc: 'Display battery level in milli volts',
     keycodeInfo: {
-      code: 0x5e1b, // 24091 0b101111000011011
+      code: 0x7e13,
       name: {
         long: 'BATT_LV',
         short: 'BATT_LV',
@@ -340,51 +256,15 @@ export const bmpKeyInfoList: KeyInfo[] = [
     },
   },
   {
-    desc: 'Save EEPROM emulation',
+    desc: 'Deep sleep mode',
     keycodeInfo: {
-      code: 0x5e1c, // 24092 0b101111000011100
+      code: 0x7e14,
       name: {
-        long: 'SAVE_EE',
-        short: 'SAVE_EE',
+        long: 'ENT_SLP',
+        short: 'ENT_SLP',
       },
-      label: 'SAVE_EE',
-      keywords: ['save_ee'],
-    },
-  },
-  {
-    desc: 'Delete EEPROM emulation',
-    keycodeInfo: {
-      code: 0x5e1d, // 24093 0b101111000011101
-      name: {
-        long: 'DEL_EE',
-        short: 'DEL_EE',
-      },
-      label: 'DEL_EE',
-      keywords: ['del_ee'],
-    },
-  },
-  {
-    desc: 'Send Alt+` or LANG1',
-    keycodeInfo: {
-      code: 0x5e1e, // 24094 0b101111000011110
-      name: {
-        long: 'xEISU',
-        short: 'xEISU',
-      },
-      label: 'xEISU',
-      keywords: [],
-    },
-  },
-  {
-    desc: 'Send Alt+` or LANG2',
-    keycodeInfo: {
-      code: 0x5e1f, // 24095 0b101111000011111
-      name: {
-        long: 'xKANA',
-        short: 'xKANA',
-      },
-      label: 'xKANA',
-      keywords: [],
+      label: 'ENT SLP',
+      keywords: ['ent_slp'],
     },
   },
 ];


### PR DESCRIPTION
This pull request includes two main updates: a keycode update for BLE Micro Pro and a revision to the user custom keycode composition logic. I am preparing to release a new firmware for BLE Micro Pro that will support the latest REMAP feature. In this upcoming version, the values of custom keycodes for BLE Micro Pro will be replaced, starting from QK_KB_0. Furthermore, the custom keycode definition will also be overridden.

Please note that BMP keycodes are only enabled when a connected keyboard utilizes BMP. This means that this modification won't have any adverse effects on keyboards operating on different platforms.