### PR TITLE
Store a local authentication user ID to the local storage in the Web browser.

### DIFF
--- a/src/store/state.ts
+++ b/src/store/state.ts
@@ -33,6 +33,7 @@ import { IMacro, IMacroBuffer, MacroKey } from '../services/macro/Macro';
 import { IFirmwareWriter } from '../services/firmware/FirmwareWriter';
 import { FirmwareWriterWebApiImpl } from '../services/firmware/FirmwareWriterWebApiImpl';
 import { IBootloaderType } from '../services/firmware/Types';
+import { getLocalAuthenticationUid } from '../utils/AuthUtils';
 
 export type ISetupPhase =
   | 'init'
@@ -311,6 +312,9 @@ export type RootState = {
         image: string;
       };
     };
+    localAuthenticationInfo: {
+      uid: string;
+    };
   };
   configure: {
     header: {
@@ -491,6 +495,8 @@ const gitHub = new GitHub();
 
 const firmwareWriter = new FirmwareWriterWebApiImpl();
 
+const localAuthenticationUid = getLocalAuthenticationUid();
+
 export const INIT_STATE: RootState = {
   entities: {
     device: {
@@ -565,6 +571,9 @@ export const INIT_STATE: RootState = {
         description: '',
         image: '',
       },
+    },
+    localAuthenticationInfo: {
+      uid: localAuthenticationUid,
     },
   },
   configure: {

--- a/src/utils/AuthUtils.ts
+++ b/src/utils/AuthUtils.ts
@@ -1,0 +1,17 @@
+export const getLocalAuthenticationUid = (): string => {
+  const uid = window.localStorage.getItem('localAuthenticationUid');
+  if (uid === null) {
+    const newUid = createRandomString(32);
+    window.localStorage.setItem('localAuthenticationUid', newUid);
+    return newUid;
+  }
+  return uid;
+};
+
+const createRandomString = (length: number): string => {
+  const chars =
+    'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789';
+  const randomValues = new Uint32Array(length);
+  window.crypto.getRandomValues(randomValues);
+  return Array.from(randomValues, (x) => chars[x % chars.length]).join('');
+};


### PR DESCRIPTION
This pull request adds a logic to store a local authentication user ID to the local storage in the Web browser. The local authentication user ID will be used for a operation log feature to calculate unique user counts and to limit to show the counts.