### PR TITLE
Show the message for keyboards which firmware files are not registered yet.

### DIFF
--- a/src/components/catalog/keyboard/build/CatalogBuild.tsx
+++ b/src/components/catalog/keyboard/build/CatalogBuild.tsx
@@ -4,7 +4,14 @@ import {
   CatalogBuildActionsType,
   CatalogBuildStateType,
 } from './CatalogBuild.container';
-import { Box, Button, FormControlLabel, Paper, Switch } from '@mui/material';
+import {
+  Alert,
+  Box,
+  Button,
+  FormControlLabel,
+  Paper,
+  Switch,
+} from '@mui/material';
 import {
   IBuildableFirmwareFile,
   IFirmwareBuildingTask,
@@ -268,6 +275,13 @@ export default function CatalogBuild(props: CatalogBuildProps) {
     <div className="catalog-build-container">
       <React.Fragment>
         <Paper sx={{ p: '16px', mb: '32px' }}>
+          {props.buildableFirmware == null ||
+          !props.buildableFirmware.enabled ? (
+            <Alert severity="info" sx={{ mb: 2 }}>
+              The firmware building feature can&quot;t be used because firmware
+              files for this keyboard are not registered by the owner yet.
+            </Alert>
+          ) : null}
           <Box sx={{ display: 'flex', justifyContent: 'flex-end' }}>
             <FormControlLabel
               control={


### PR DESCRIPTION
This pull request adds a logic to show the message for keyboards which firmware files are not registered yet.