### PR TITLE
Upgrade the NodeJS from 18 to 20 which is used by GitHub Actions.

### DIFF
--- a/.github/workflows/production.yaml
+++ b/.github/workflows/production.yaml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [18.x]
+        node-version: [20.x]
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v3

--- a/.github/workflows/pullrequest.yaml
+++ b/.github/workflows/pullrequest.yaml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [18.x]
+        node-version: [20.x]
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v2


### PR DESCRIPTION
As the title. This pull request upgrades the NodeJS 18 to 20 which is used by GitHub Actions.