### PR TITLE
Add `corepack enable` for yarn v4 to GitHub Actions for production

### DIFF
--- a/.github/workflows/production.yaml
+++ b/.github/workflows/production.yaml
@@ -30,6 +30,8 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node-version }}
+      - name: use Yarn v4
+        run: corepack enable; yarn set version 4.2.2
       - name: Get yarn cache directory path
         id: yarn-cache-dir-path
         run: echo "::set-output name=dir::$(yarn cache dir)"


### PR DESCRIPTION
This pull request adds `corepack enable` for yarn v4 to GitHub Actions workflow for production.