### PR TITLE
Add the new link to navigate to the GitHub repository of Remap.

### DIFF
--- a/src/components/common/footer/Footer.tsx
+++ b/src/components/common/footer/Footer.tsx
@@ -52,6 +52,15 @@ export default class Footer extends React.Component<
           </div>
           <div className="footer-content">
             <a
+              href="https://github.com/remap-keys/remap"
+              target={'_blank'}
+              rel={'noreferrer'}
+            >
+              GitHub
+            </a>
+          </div>
+          <div className="footer-content">
+            <a
               href="https://github.com/sponsors/yoichiro"
               target={'_blank'}
               rel={'noreferrer'}


### PR DESCRIPTION
This pull request fixes the issue #808.

![スクリーンショット 2024-06-01 174803](https://github.com/remap-keys/remap/assets/261787/86d5711e-9ff7-44cf-980a-9fb5a237e04c)
