### PR TITLE
Quit using lodash

### DIFF
--- a/package.json
+++ b/package.json
@@ -79,7 +79,6 @@
     "@types/ajv": "^1.0.0",
     "@types/axios": "^0.14.0",
     "@types/downloadjs": "^1.4.2",
-    "@types/lodash": "^4.14.167",
     "@types/node": "^14.14.22",
     "@types/prop-types": "^15.7.4",
     "@types/qs": "^6.9.6",

--- a/src/components/configure/keycodekey/KeyGen.ts
+++ b/src/components/configure/keycodekey/KeyGen.ts
@@ -8,7 +8,6 @@ import {
   KeyLabelLangs,
 } from '../../../services/labellang/KeyLabelLangs';
 import { mods2Number } from '../customkey/Modifiers';
-import _ from 'lodash';
 import { MOD_LEFT, MOD_RIGHT } from '../../../services/hid/Constraints';
 
 export type Key = {
@@ -98,7 +97,7 @@ export const genKey = (keymap: IKeymap, lang?: KeyboardLabelLang): Key => {
 
     let newKeymap: IKeymap = keymap;
     if (0 < keytop.keywords.length) {
-      newKeymap = _.cloneDeep(keymap) as IKeymap;
+      newKeymap = structuredClone(keymap) as IKeymap;
       newKeymap.keycodeInfo.keywords = newKeymap.keycodeInfo.keywords.concat(
         keytop.keywords
       );

--- a/src/components/configure/macroeditor/MacroEditor.tsx
+++ b/src/components/configure/macroeditor/MacroEditor.tsx
@@ -60,7 +60,7 @@ export default class MacroEditor extends React.Component<
     indexInHold: number,
     newKeyDelayPair: KeyDelayPair
   ) {
-    const macroKeys: MacroKey[] = lodash.cloneDeep(this.props.macroKeys!);
+    const macroKeys: MacroKey[] = structuredClone(this.props.macroKeys!);
     if (Number.isNaN(indexInHold)) {
       // TODO: Set delay.
       const tap: Tap = {
@@ -85,7 +85,7 @@ export default class MacroEditor extends React.Component<
   }
 
   private addTapKeys(index: number, newKeyDelayPairs: KeyDelayPair[]) {
-    const macroKeys: MacroKey[] = lodash.cloneDeep(this.props.macroKeys!);
+    const macroKeys: MacroKey[] = structuredClone(this.props.macroKeys!);
     const taps: Tap[] = newKeyDelayPairs.map((v) => {
       // TODO: Set delay.
       return { keyDelayPair: v, type: MacroTap };
@@ -95,7 +95,7 @@ export default class MacroEditor extends React.Component<
   }
 
   private popKey() {
-    const macroKeys: MacroKey[] = lodash.cloneDeep(this.props.macroKeys!);
+    const macroKeys: MacroKey[] = structuredClone(this.props.macroKeys!);
     this.props.updateMacroKeys!(macroKeys.slice(0, -1));
   }
 
@@ -129,7 +129,7 @@ export default class MacroEditor extends React.Component<
     if (fromIndex === toIndex && fromIndexInHold === toIndexInHold) {
       return;
     }
-    const macroKeys: MacroKey[] = lodash.cloneDeep(this.props.macroKeys!);
+    const macroKeys: MacroKey[] = structuredClone(this.props.macroKeys!);
     const srcMacroKey: MacroKey = macroKeys[fromIndex];
     const dstMacroKey: MacroKey = macroKeys[toIndex];
     if (fromIndex === toIndex && isHold(srcMacroKey)) {

--- a/src/components/configure/macroeditor/MacroEditor.tsx
+++ b/src/components/configure/macroeditor/MacroEditor.tsx
@@ -18,7 +18,6 @@ import {
   Tap,
   KeyDelayPair,
 } from '../../../services/macro/Macro';
-import lodash from 'lodash';
 import FlashButton, { FlashButtonState } from '../../common/flash/FlashButton';
 import { KeycodeCompositionFactory } from '../../../services/hid/Composition';
 import { MacroDropSpacer } from './MacroDropSpacer';

--- a/yarn.lock
+++ b/yarn.lock
@@ -5938,7 +5938,6 @@ __metadata:
     "@types/ajv": "npm:^1.0.0"
     "@types/axios": "npm:^0.14.0"
     "@types/downloadjs": "npm:^1.4.2"
-    "@types/lodash": "npm:^4.14.167"
     "@types/node": "npm:^14.14.22"
     "@types/prop-types": "npm:^15.7.4"
     "@types/qs": "npm:^6.9.6"


### PR DESCRIPTION
1. lodashからimportしている`cloneDeep()`を[`structuredClone()`](https://developer.mozilla.org/ja/docs/Web/API/structuredClone)に置き換える
2. `@types/lodash`を削除する