### PR TITLE
Remove dependencies related to Jest

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -35,6 +35,7 @@
     "describe": "readonly",
     "test": "readonly",
     "expect": "readonly",
-    "fail": "readonly"
+    "fail": "readonly",
+    "assert": "readonly"
   }
 }

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -2,8 +2,6 @@
   "env": {
     "es6": true,
     "node": true,
-    "jest": true,
-    "jasmine": true,
     "browser": true
   },
   "parser": "@typescript-eslint/parser",
@@ -33,6 +31,10 @@
     "react/prop-types": "warn"
   },
   "globals": {
-    "HIDDevice": "readonly"
+    "HIDDevice": "readonly",
+    "describe": "readonly",
+    "test": "readonly",
+    "expect": "readonly",
+    "fail": "readonly"
   }
 }

--- a/package.json
+++ b/package.json
@@ -73,7 +73,6 @@
     "@storybook/node-logger": "^6.1.14",
     "@storybook/preset-create-react-app": "^3.1.5",
     "@storybook/react": "^6.1.14",
-    "@testing-library/jest-dom": "^5.11.4",
     "@testing-library/react": "^11.1.0",
     "@testing-library/user-event": "^12.1.10",
     "@types/ajv": "^1.0.0",

--- a/src/services/macro/Macro.test.ts
+++ b/src/services/macro/Macro.test.ts
@@ -341,7 +341,7 @@ describe('Macro', () => {
         ).toBeTruthy();
         expect(actual.macroKeys[0].keyDelayPair.key.keymap.isAny).toBeFalsy();
       } else {
-        fail('actual.macroKeys[0] is not Tap');
+        assert.fail('actual.macroKeys[0] is not Tap');
       }
       expect(actual.macroKeys[1].type).toEqual('tap');
       if (isTap(actual.macroKeys[1])) {
@@ -352,7 +352,7 @@ describe('Macro', () => {
         expect(actual.macroKeys[1].keyDelayPair.key.keymap.isAscii).toBeFalsy();
         expect(actual.macroKeys[1].keyDelayPair.key.keymap.isAny).toBeFalsy();
       } else {
-        fail('actual.macroKeys[1] is not Tap');
+        assert.fail('actual.macroKeys[1] is not Tap');
       }
       expect(actual.macroKeys[2].type).toEqual('hold');
       if (isHold(actual.macroKeys[2])) {
@@ -372,7 +372,7 @@ describe('Macro', () => {
           actual.macroKeys[2].keyDelayPairs[0].key.keymap.isAny
         ).toBeFalsy();
       } else {
-        fail('actual.macroKeys[2] is not Hold');
+        assert.fail('actual.macroKeys[2] is not Hold');
       }
     });
 
@@ -428,7 +428,7 @@ describe('Macro', () => {
         ).toBeTruthy();
         expect(actual.macroKeys[0].keyDelayPair.key.keymap.isAny).toBeFalsy();
       } else {
-        fail('actual.macroKeys[0] is not Tap');
+        assert.fail('actual.macroKeys[0] is not Tap');
       }
       expect(actual.macroKeys[1].type).toEqual('tap');
       if (isTap(actual.macroKeys[1])) {
@@ -440,7 +440,7 @@ describe('Macro', () => {
         expect(actual.macroKeys[1].keyDelayPair.key.keymap.isAny).toBeFalsy();
         expect(actual.macroKeys[1].keyDelayPair.delay).toEqual(456);
       } else {
-        fail('actual.macroKeys[1] is not Tap');
+        assert.fail('actual.macroKeys[1] is not Tap');
       }
       expect(actual.macroKeys[2].type).toEqual('hold');
       if (isHold(actual.macroKeys[2])) {
@@ -461,7 +461,7 @@ describe('Macro', () => {
         ).toBeFalsy();
         expect(actual.macroKeys[2].keyDelayPairs[0].delay).toEqual(789);
       } else {
-        fail('actual.macroKeys[2] is not Hold');
+        assert.fail('actual.macroKeys[2] is not Hold');
       }
     });
 
@@ -489,7 +489,7 @@ describe('Macro', () => {
         expect(actual.macroKeys[0].keyDelayPair.key.keymap.isAscii).toBeFalsy();
         expect(actual.macroKeys[0].keyDelayPair.key.keymap.isAny).toBeFalsy();
       } else {
-        fail('actual.macroKeys[0] is not Tap');
+        assert.fail('actual.macroKeys[0] is not Tap');
       }
       actual = subject.generateMacroKeys('ja-jp');
       expect(actual.success).toBeTruthy();
@@ -503,7 +503,7 @@ describe('Macro', () => {
         expect(actual.macroKeys[0].keyDelayPair.key.keymap.isAscii).toBeFalsy();
         expect(actual.macroKeys[0].keyDelayPair.key.keymap.isAny).toBeFalsy();
       } else {
-        fail('actual.macroKeys[0] is not Tap');
+        assert.fail('actual.macroKeys[0] is not Tap');
       }
     });
 
@@ -545,7 +545,7 @@ describe('Macro', () => {
         ).toBeTruthy();
         expect(actual.macroKeys[0].keyDelayPair.key.keymap.isAny).toBeFalsy();
       } else {
-        fail('actual.macroKeys[0] is not Tap');
+        assert.fail('actual.macroKeys[0] is not Tap');
       }
       expect(actual.macroKeys[1].type).toEqual('tap');
       if (isTap(actual.macroKeys[1])) {
@@ -558,7 +558,7 @@ describe('Macro', () => {
         ).toBeTruthy();
         expect(actual.macroKeys[1].keyDelayPair.key.keymap.isAny).toBeFalsy();
       } else {
-        fail('actual.macroKeys[1] is not Tap');
+        assert.fail('actual.macroKeys[1] is not Tap');
       }
       expect(actual.macroKeys[2].type).toEqual('tap');
       if (isTap(actual.macroKeys[2])) {
@@ -571,7 +571,7 @@ describe('Macro', () => {
         ).toBeTruthy();
         expect(actual.macroKeys[2].keyDelayPair.key.keymap.isAny).toBeTruthy();
       } else {
-        fail('actual.macroKeys[2] is not Tap');
+        assert.fail('actual.macroKeys[2] is not Tap');
       }
     });
 
@@ -620,7 +620,7 @@ describe('Macro', () => {
         expect(actual.macroKeys[0].keyDelayPair.key.keymap.isAny).toBeFalsy();
         expect(actual.macroKeys[0].keyDelayPair.delay).toEqual(123);
       } else {
-        fail('actual.macroKeys[0] is not Tap');
+        assert.fail('actual.macroKeys[0] is not Tap');
       }
       expect(actual.macroKeys[1].type).toEqual('tap');
       if (isTap(actual.macroKeys[1])) {
@@ -634,7 +634,7 @@ describe('Macro', () => {
         expect(actual.macroKeys[1].keyDelayPair.key.keymap.isAny).toBeFalsy();
         expect(actual.macroKeys[1].keyDelayPair.delay).toEqual(456);
       } else {
-        fail('actual.macroKeys[1] is not Tap');
+        assert.fail('actual.macroKeys[1] is not Tap');
       }
       expect(actual.macroKeys[2].type).toEqual('tap');
       if (isTap(actual.macroKeys[2])) {
@@ -648,7 +648,7 @@ describe('Macro', () => {
         expect(actual.macroKeys[2].keyDelayPair.key.keymap.isAny).toBeTruthy();
         expect(actual.macroKeys[2].keyDelayPair.delay).toEqual(789);
       } else {
-        fail('actual.macroKeys[2] is not Tap');
+        assert.fail('actual.macroKeys[2] is not Tap');
       }
     });
 
@@ -682,7 +682,7 @@ describe('Macro', () => {
         expect(actual.macroKeys[0].keyDelayPair.key.keymap.isAscii).toBeFalsy();
         expect(actual.macroKeys[0].keyDelayPair.key.keymap.isAny).toBeFalsy();
       } else {
-        fail('actual.macroKeys[0] is not Tap');
+        assert.fail('actual.macroKeys[0] is not Tap');
       }
       expect(actual.macroKeys[1].type).toEqual('tap');
       if (isTap(actual.macroKeys[1])) {
@@ -693,7 +693,7 @@ describe('Macro', () => {
         expect(actual.macroKeys[1].keyDelayPair.key.keymap.isAscii).toBeFalsy();
         expect(actual.macroKeys[1].keyDelayPair.key.keymap.isAny).toBeFalsy();
       } else {
-        fail('actual.macroKeys[1] is not Tap');
+        assert.fail('actual.macroKeys[1] is not Tap');
       }
       expect(actual.macroKeys[2].type).toEqual('tap');
       if (isTap(actual.macroKeys[2])) {
@@ -704,7 +704,7 @@ describe('Macro', () => {
         expect(actual.macroKeys[2].keyDelayPair.key.keymap.isAscii).toBeFalsy();
         expect(actual.macroKeys[2].keyDelayPair.key.keymap.isAny).toBeFalsy();
       } else {
-        fail('actual.macroKeys[2] is not Tap');
+        assert.fail('actual.macroKeys[2] is not Tap');
       }
     });
 
@@ -757,7 +757,7 @@ describe('Macro', () => {
         expect(actual.macroKeys[0].keyDelayPair.key.keymap.isAny).toBeFalsy();
         expect(actual.macroKeys[0].keyDelayPair.delay).toEqual(123);
       } else {
-        fail('actual.macroKeys[0] is not Tap');
+        assert.fail('actual.macroKeys[0] is not Tap');
       }
       expect(actual.macroKeys[1].type).toEqual('tap');
       if (isTap(actual.macroKeys[1])) {
@@ -769,7 +769,7 @@ describe('Macro', () => {
         expect(actual.macroKeys[1].keyDelayPair.key.keymap.isAny).toBeFalsy();
         expect(actual.macroKeys[1].keyDelayPair.delay).toEqual(456);
       } else {
-        fail('actual.macroKeys[1] is not Tap');
+        assert.fail('actual.macroKeys[1] is not Tap');
       }
       expect(actual.macroKeys[2].type).toEqual('tap');
       if (isTap(actual.macroKeys[2])) {
@@ -781,7 +781,7 @@ describe('Macro', () => {
         expect(actual.macroKeys[2].keyDelayPair.key.keymap.isAny).toBeFalsy();
         expect(actual.macroKeys[2].keyDelayPair.delay).toEqual(789);
       } else {
-        fail('actual.macroKeys[2] is not Tap');
+        assert.fail('actual.macroKeys[2] is not Tap');
       }
     });
 
@@ -847,7 +847,7 @@ describe('Macro', () => {
           actual.macroKeys[0].keyDelayPairs[1].key.keymap.isAny
         ).toBeFalsy();
       } else {
-        fail('actual.macroKeys[0] is not Hold');
+        assert.fail('actual.macroKeys[0] is not Hold');
       }
       expect(actual.macroKeys[1].type).toEqual('hold');
       if (isHold(actual.macroKeys[1])) {
@@ -867,7 +867,7 @@ describe('Macro', () => {
           actual.macroKeys[1].keyDelayPairs[0].key.keymap.isAny
         ).toBeFalsy();
       } else {
-        fail('actual.macroKeys[1] is not Hold');
+        assert.fail('actual.macroKeys[1] is not Hold');
       }
     });
 
@@ -953,7 +953,7 @@ describe('Macro', () => {
         ).toBeFalsy();
         expect(actual.macroKeys[0].keyDelayPairs[1].delay).toEqual(456);
       } else {
-        fail('actual.macroKeys[0] is not Hold');
+        assert.fail('actual.macroKeys[0] is not Hold');
       }
       expect(actual.macroKeys[1].type).toEqual('hold');
       if (isHold(actual.macroKeys[1])) {
@@ -974,7 +974,7 @@ describe('Macro', () => {
         ).toBeFalsy();
         expect(actual.macroKeys[1].keyDelayPairs[0].delay).toEqual(789);
       } else {
-        fail('actual.macroKeys[1] is not Hold');
+        assert.fail('actual.macroKeys[1] is not Hold');
       }
     });
 

--- a/src/setupTests.ts
+++ b/src/setupTests.ts
@@ -1,5 +1,0 @@
-// jest-dom adds custom jest matchers for asserting on DOM nodes.
-// allows you to do things like:
-// expect(element).toHaveTextContent(/react/i)
-// learn more: https://github.com/testing-library/jest-dom
-import '@testing-library/jest-dom';

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,7 +1,8 @@
 /// <reference types="vitest" />
 import react from '@vitejs/plugin-react-swc';
-import { defineConfig, Plugin, loadEnv } from 'vite';
+import { Plugin, loadEnv } from 'vite';
 import { nodePolyfills } from 'vite-plugin-node-polyfills';
+import { defineConfig } from 'vitest/config';
 
 export default defineConfig(({ mode }) => {
   return {
@@ -19,7 +20,6 @@ export default defineConfig(({ mode }) => {
     test: {
       globals: true,
       environment: 'happy-dom',
-      setupFiles: 'setupTests.ts',
     },
   };
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -5,13 +5,6 @@ __metadata:
   version: 8
   cacheKey: 10c0
 
-"@adobe/css-tools@npm:^4.0.1":
-  version: 4.3.3
-  resolution: "@adobe/css-tools@npm:4.3.3"
-  checksum: 10c0/e76e712df713964b87cdf2aca1f0477f19bebd845484d5fcba726d3ec7782366e2f26ec8cb2dcfaf47081a5c891987d8a9f5c3f30d11e1eb3c1848adc27fcb24
-  languageName: node
-  linkType: hard
-
 "@ampproject/remapping@npm:^2.2.0":
   version: 2.3.0
   resolution: "@ampproject/remapping@npm:2.3.0"
@@ -34,7 +27,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/code-frame@npm:^7.0.0, @babel/code-frame@npm:^7.10.4, @babel/code-frame@npm:^7.12.13, @babel/code-frame@npm:^7.24.6, @babel/code-frame@npm:^7.5.5, @babel/code-frame@npm:^7.8.3":
+"@babel/code-frame@npm:^7.0.0, @babel/code-frame@npm:^7.10.4, @babel/code-frame@npm:^7.24.6, @babel/code-frame@npm:^7.5.5, @babel/code-frame@npm:^7.8.3":
   version: 7.24.6
   resolution: "@babel/code-frame@npm:7.24.6"
   dependencies:
@@ -2612,15 +2605,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@jest/expect-utils@npm:^29.7.0":
-  version: 29.7.0
-  resolution: "@jest/expect-utils@npm:29.7.0"
-  dependencies:
-    jest-get-type: "npm:^29.6.3"
-  checksum: 10c0/60b79d23a5358dc50d9510d726443316253ecda3a7fb8072e1526b3e0d3b14f066ee112db95699b7a43ad3f0b61b750c72e28a5a1cac361d7a2bb34747fa938a
-  languageName: node
-  linkType: hard
-
 "@jest/schemas@npm:^29.6.3":
   version: 29.6.3
   resolution: "@jest/schemas@npm:29.6.3"
@@ -2663,20 +2647,6 @@ __metadata:
     "@types/yargs": "npm:^15.0.0"
     chalk: "npm:^4.0.0"
   checksum: 10c0/5b9b957f38a002895eb04bbb8c3dda6fccce8e2551f3f44b02f1f43063a78e8bedce73cd4330b53ede00ae005de5cd805982fbb2ec6ab9feacf96344240d5db2
-  languageName: node
-  linkType: hard
-
-"@jest/types@npm:^29.6.3":
-  version: 29.6.3
-  resolution: "@jest/types@npm:29.6.3"
-  dependencies:
-    "@jest/schemas": "npm:^29.6.3"
-    "@types/istanbul-lib-coverage": "npm:^2.0.0"
-    "@types/istanbul-reports": "npm:^3.0.0"
-    "@types/node": "npm:*"
-    "@types/yargs": "npm:^17.0.8"
-    chalk: "npm:^4.0.0"
-  checksum: 10c0/ea4e493dd3fb47933b8ccab201ae573dcc451f951dc44ed2a86123cd8541b82aa9d2b1031caf9b1080d6673c517e2dcc25a44b2dc4f3fbc37bfc965d444888c0
   languageName: node
   linkType: hard
 
@@ -4769,23 +4739,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@testing-library/jest-dom@npm:^5.11.4":
-  version: 5.17.0
-  resolution: "@testing-library/jest-dom@npm:5.17.0"
-  dependencies:
-    "@adobe/css-tools": "npm:^4.0.1"
-    "@babel/runtime": "npm:^7.9.2"
-    "@types/testing-library__jest-dom": "npm:^5.9.1"
-    aria-query: "npm:^5.0.0"
-    chalk: "npm:^3.0.0"
-    css.escape: "npm:^1.5.1"
-    dom-accessibility-api: "npm:^0.5.6"
-    lodash: "npm:^4.17.15"
-    redent: "npm:^3.0.0"
-  checksum: 10c0/24e09c5779ea44644945ec26f2e4e5f48aecfe57d469decf2317a3253a5db28d865c55ad0ea4818d8d1df7572a6486c45daa06fa09644a833a7dd84563881939
-  languageName: node
-  linkType: hard
-
 "@testing-library/react@npm:^11.1.0":
   version: 11.2.7
   resolution: "@testing-library/react@npm:11.2.7"
@@ -5001,16 +4954,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/jest@npm:*":
-  version: 29.5.12
-  resolution: "@types/jest@npm:29.5.12"
-  dependencies:
-    expect: "npm:^29.0.0"
-    pretty-format: "npm:^29.0.0"
-  checksum: 10c0/25fc8e4c611fa6c4421e631432e9f0a6865a8cb07c9815ec9ac90d630271cad773b2ee5fe08066f7b95bebd18bb967f8ce05d018ee9ab0430f9dfd1d84665b6f
-  languageName: node
-  linkType: hard
-
 "@types/json-schema@npm:*, @types/json-schema@npm:^7.0.4, @types/json-schema@npm:^7.0.5, @types/json-schema@npm:^7.0.6, @types/json-schema@npm:^7.0.7, @types/json-schema@npm:^7.0.8, @types/json-schema@npm:^7.0.9":
   version: 7.0.15
   resolution: "@types/json-schema@npm:7.0.15"
@@ -5220,26 +5163,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/stack-utils@npm:^2.0.0":
-  version: 2.0.3
-  resolution: "@types/stack-utils@npm:2.0.3"
-  checksum: 10c0/1f4658385ae936330581bcb8aa3a066df03867d90281cdf89cc356d404bd6579be0f11902304e1f775d92df22c6dd761d4451c804b0a4fba973e06211e9bd77c
-  languageName: node
-  linkType: hard
-
 "@types/tapable@npm:^1, @types/tapable@npm:^1.0.5":
   version: 1.0.12
   resolution: "@types/tapable@npm:1.0.12"
   checksum: 10c0/d6a080f5839b323eb96dd5b65a6c3161c1297d8c2433eb52437912d1c3df54e38fce12ce7a57650f6453d96942298bd0935436e2501d09e407b7f41634483131
-  languageName: node
-  linkType: hard
-
-"@types/testing-library__jest-dom@npm:^5.9.1":
-  version: 5.14.9
-  resolution: "@types/testing-library__jest-dom@npm:5.14.9"
-  dependencies:
-    "@types/jest": "npm:*"
-  checksum: 10c0/91f7b15e8813b515912c54da44464fb60ecf21162b7cae2272fcb3918074f4e1387dc2beca1f5041667e77b76b34253c39675ea4e0b3f28f102d8cc87fdba9fa
   languageName: node
   linkType: hard
 
@@ -5339,15 +5266,6 @@ __metadata:
   dependencies:
     "@types/yargs-parser": "npm:*"
   checksum: 10c0/9fe9b8645304a628006cbba2d1990fb015e2727274d0e3853f321a379a1242d1da2c15d2f56cff0d4313ae94f0383ccf834c3bded9fb3589608aefb3432fcf00
-  languageName: node
-  linkType: hard
-
-"@types/yargs@npm:^17.0.8":
-  version: 17.0.32
-  resolution: "@types/yargs@npm:17.0.32"
-  dependencies:
-    "@types/yargs-parser": "npm:*"
-  checksum: 10c0/2095e8aad8a4e66b86147415364266b8d607a3b95b4239623423efd7e29df93ba81bb862784a6e08664f645cc1981b25fd598f532019174cd3e5e1e689e1cccf
   languageName: node
   linkType: hard
 
@@ -5932,7 +5850,6 @@ __metadata:
     "@storybook/node-logger": "npm:^6.1.14"
     "@storybook/preset-create-react-app": "npm:^3.1.5"
     "@storybook/react": "npm:^6.1.14"
-    "@testing-library/jest-dom": "npm:^5.11.4"
     "@testing-library/react": "npm:^11.1.0"
     "@testing-library/user-event": "npm:^12.1.10"
     "@types/ajv": "npm:^1.0.0"
@@ -6407,15 +6324,6 @@ __metadata:
     "@babel/runtime": "npm:^7.10.2"
     "@babel/runtime-corejs3": "npm:^7.10.2"
   checksum: 10c0/7e224fbbb4de8210c5d8cbaf0e1a22caa78f2068bf231f4c75302bd77eeba1c3e3b97912080535140be60174720d2ac817e5d6fec18592951b4b6488d4da7cdc
-  languageName: node
-  linkType: hard
-
-"aria-query@npm:^5.0.0":
-  version: 5.3.0
-  resolution: "aria-query@npm:5.3.0"
-  dependencies:
-    dequal: "npm:^2.0.3"
-  checksum: 10c0/2bff0d4eba5852a9dd578ecf47eaef0e82cc52569b48469b0aac2db5145db0b17b7a58d9e01237706d1e14b7a1b0ac9b78e9c97027ad97679dd8f91b85da1469
   languageName: node
   linkType: hard
 
@@ -7521,16 +7429,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"chalk@npm:^3.0.0":
-  version: 3.0.0
-  resolution: "chalk@npm:3.0.0"
-  dependencies:
-    ansi-styles: "npm:^4.1.0"
-    supports-color: "npm:^7.1.0"
-  checksum: 10c0/ee650b0a065b3d7a6fda258e75d3a86fc8e4effa55871da730a9e42ccb035bf5fd203525e5a1ef45ec2582ecc4f65b47eb11357c526b84dd29a14fb162c414d2
-  languageName: node
-  linkType: hard
-
 "chalk@npm:^4.0.0, chalk@npm:^4.1.0":
   version: 4.1.2
   resolution: "chalk@npm:4.1.2"
@@ -7638,13 +7536,6 @@ __metadata:
   version: 2.0.0
   resolution: "ci-info@npm:2.0.0"
   checksum: 10c0/8c5fa3830a2bcee2b53c2e5018226f0141db9ec9f7b1e27a5c57db5512332cde8a0beb769bcbaf0d8775a78afbf2bb841928feca4ea6219638a5b088f9884b46
-  languageName: node
-  linkType: hard
-
-"ci-info@npm:^3.2.0":
-  version: 3.9.0
-  resolution: "ci-info@npm:3.9.0"
-  checksum: 10c0/6f0109e36e111684291d46123d491bc4e7b7a1934c3a20dea28cba89f1d4a03acd892f5f6a81ed3855c38647e285a150e3c9ba062e38943bef57fee6c1554c3a
   languageName: node
   linkType: hard
 
@@ -8276,13 +8167,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"css.escape@npm:^1.5.1":
-  version: 1.5.1
-  resolution: "css.escape@npm:1.5.1"
-  checksum: 10c0/5e09035e5bf6c2c422b40c6df2eb1529657a17df37fda5d0433d722609527ab98090baf25b13970ca754079a0f3161dd3dfc0e743563ded8cfa0749d861c1525
-  languageName: node
-  linkType: hard
-
 "cssesc@npm:^3.0.0":
   version: 3.0.0
   resolution: "cssesc@npm:3.0.0"
@@ -8527,13 +8411,6 @@ __metadata:
   version: 2.0.0
   resolution: "depd@npm:2.0.0"
   checksum: 10c0/58bd06ec20e19529b06f7ad07ddab60e504d9e0faca4bd23079fac2d279c3594334d736508dc350e06e510aba5e22e4594483b3a6562ce7c17dd797f4cc4ad2c
-  languageName: node
-  linkType: hard
-
-"dequal@npm:^2.0.3":
-  version: 2.0.3
-  resolution: "dequal@npm:2.0.3"
-  checksum: 10c0/f98860cdf58b64991ae10205137c0e97d384c3a4edc7f807603887b7c4b850af1224a33d88012009f150861cbee4fa2d322c4cc04b9313bee312e47f6ecaa888
   languageName: node
   linkType: hard
 
@@ -9285,13 +9162,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"escape-string-regexp@npm:^2.0.0":
-  version: 2.0.0
-  resolution: "escape-string-regexp@npm:2.0.0"
-  checksum: 10c0/2530479fe8db57eace5e8646c9c2a9c80fa279614986d16dcc6bcaceb63ae77f05a851ba6c43756d816c61d7f4534baf56e3c705e3e0d884818a46808811c507
-  languageName: node
-  linkType: hard
-
 "escape-string-regexp@npm:^4.0.0":
   version: 4.0.0
   resolution: "escape-string-regexp@npm:4.0.0"
@@ -9705,19 +9575,6 @@ __metadata:
     snapdragon: "npm:^0.8.1"
     to-regex: "npm:^3.0.1"
   checksum: 10c0/3e2fb95d2d7d7231486493fd65db913927b656b6fcdfcce41e139c0991a72204af619ad4acb1be75ed994ca49edb7995ef241dbf8cf44dc3c03d211328428a87
-  languageName: node
-  linkType: hard
-
-"expect@npm:^29.0.0":
-  version: 29.7.0
-  resolution: "expect@npm:29.7.0"
-  dependencies:
-    "@jest/expect-utils": "npm:^29.7.0"
-    jest-get-type: "npm:^29.6.3"
-    jest-matcher-utils: "npm:^29.7.0"
-    jest-message-util: "npm:^29.7.0"
-    jest-util: "npm:^29.7.0"
-  checksum: 10c0/2eddeace66e68b8d8ee5f7be57f3014b19770caaf6815c7a08d131821da527fb8c8cb7b3dcd7c883d2d3d8d184206a4268984618032d1e4b16dc8d6596475d41
   languageName: node
   linkType: hard
 
@@ -10692,7 +10549,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"graceful-fs@npm:^4.1.11, graceful-fs@npm:^4.1.15, graceful-fs@npm:^4.1.2, graceful-fs@npm:^4.1.6, graceful-fs@npm:^4.2.0, graceful-fs@npm:^4.2.11, graceful-fs@npm:^4.2.4, graceful-fs@npm:^4.2.6, graceful-fs@npm:^4.2.9":
+"graceful-fs@npm:^4.1.11, graceful-fs@npm:^4.1.15, graceful-fs@npm:^4.1.2, graceful-fs@npm:^4.1.6, graceful-fs@npm:^4.2.0, graceful-fs@npm:^4.2.11, graceful-fs@npm:^4.2.4, graceful-fs@npm:^4.2.6":
   version: 4.2.11
   resolution: "graceful-fs@npm:4.2.11"
   checksum: 10c0/386d011a553e02bc594ac2ca0bd6d9e4c22d7fa8cfbfc448a6d148c59ea881b092db9dbe3547ae4b88e55f1b01f7c4a2ecc53b310c042793e63aa44cf6c257f2
@@ -12135,25 +11992,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"jest-diff@npm:^29.7.0":
-  version: 29.7.0
-  resolution: "jest-diff@npm:29.7.0"
-  dependencies:
-    chalk: "npm:^4.0.0"
-    diff-sequences: "npm:^29.6.3"
-    jest-get-type: "npm:^29.6.3"
-    pretty-format: "npm:^29.7.0"
-  checksum: 10c0/89a4a7f182590f56f526443dde69acefb1f2f0c9e59253c61d319569856c4931eae66b8a3790c443f529267a0ddba5ba80431c585deed81827032b2b2a1fc999
-  languageName: node
-  linkType: hard
-
-"jest-get-type@npm:^29.6.3":
-  version: 29.6.3
-  resolution: "jest-get-type@npm:29.6.3"
-  checksum: 10c0/552e7a97a983d3c2d4e412a44eb7de0430ff773dd99f7500962c268d6dfbfa431d7d08f919c9d960530e5f7f78eb47f267ad9b318265e5092b3ff9ede0db7c2b
-  languageName: node
-  linkType: hard
-
 "jest-haste-map@npm:^26.6.2":
   version: 26.6.2
   resolution: "jest-haste-map@npm:26.6.2"
@@ -12176,35 +12014,6 @@ __metadata:
     fsevents:
       optional: true
   checksum: 10c0/85a40d8ecf4bfb659613f107c963c7366cdf6dcceb0ca73dc8ca09fbe0e2a63b976940f573db6260c43011993cb804275f447f268c3bc4b680c08baed300701d
-  languageName: node
-  linkType: hard
-
-"jest-matcher-utils@npm:^29.7.0":
-  version: 29.7.0
-  resolution: "jest-matcher-utils@npm:29.7.0"
-  dependencies:
-    chalk: "npm:^4.0.0"
-    jest-diff: "npm:^29.7.0"
-    jest-get-type: "npm:^29.6.3"
-    pretty-format: "npm:^29.7.0"
-  checksum: 10c0/0d0e70b28fa5c7d4dce701dc1f46ae0922102aadc24ed45d594dd9b7ae0a8a6ef8b216718d1ab79e451291217e05d4d49a82666e1a3cc2b428b75cd9c933244e
-  languageName: node
-  linkType: hard
-
-"jest-message-util@npm:^29.7.0":
-  version: 29.7.0
-  resolution: "jest-message-util@npm:29.7.0"
-  dependencies:
-    "@babel/code-frame": "npm:^7.12.13"
-    "@jest/types": "npm:^29.6.3"
-    "@types/stack-utils": "npm:^2.0.0"
-    chalk: "npm:^4.0.0"
-    graceful-fs: "npm:^4.2.9"
-    micromatch: "npm:^4.0.4"
-    pretty-format: "npm:^29.7.0"
-    slash: "npm:^3.0.0"
-    stack-utils: "npm:^2.0.3"
-  checksum: 10c0/850ae35477f59f3e6f27efac5215f706296e2104af39232bb14e5403e067992afb5c015e87a9243ec4d9df38525ef1ca663af9f2f4766aa116f127247008bd22
   languageName: node
   linkType: hard
 
@@ -12236,20 +12045,6 @@ __metadata:
     is-ci: "npm:^2.0.0"
     micromatch: "npm:^4.0.2"
   checksum: 10c0/ab93709840f87bdf478d082f5465467c27a20a422cbe456cc2a56961d8c950ea52511995fb6063f62a113737f3dd714b836a1fbde51abef96642a5975e835a01
-  languageName: node
-  linkType: hard
-
-"jest-util@npm:^29.7.0":
-  version: 29.7.0
-  resolution: "jest-util@npm:29.7.0"
-  dependencies:
-    "@jest/types": "npm:^29.6.3"
-    "@types/node": "npm:*"
-    chalk: "npm:^4.0.0"
-    ci-info: "npm:^3.2.0"
-    graceful-fs: "npm:^4.2.9"
-    picomatch: "npm:^2.2.3"
-  checksum: 10c0/bc55a8f49fdbb8f51baf31d2a4f312fb66c9db1483b82f602c9c990e659cdd7ec529c8e916d5a89452ecbcfae4949b21b40a7a59d4ffc0cd813a973ab08c8150
   languageName: node
   linkType: hard
 
@@ -14610,7 +14405,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"picomatch@npm:^2.0.4, picomatch@npm:^2.2.1, picomatch@npm:^2.2.3, picomatch@npm:^2.3.0, picomatch@npm:^2.3.1":
+"picomatch@npm:^2.0.4, picomatch@npm:^2.2.1, picomatch@npm:^2.3.0, picomatch@npm:^2.3.1":
   version: 2.3.1
   resolution: "picomatch@npm:2.3.1"
   checksum: 10c0/26c02b8d06f03206fc2ab8d16f19960f2ff9e81a658f831ecb656d8f17d9edc799e8364b1f4a7873e89d9702dff96204be0fa26fe4181f6843f040f819dac4be
@@ -14918,7 +14713,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"pretty-format@npm:^29.0.0, pretty-format@npm:^29.7.0":
+"pretty-format@npm:^29.7.0":
   version: 29.7.0
   resolution: "pretty-format@npm:29.7.0"
   dependencies:
@@ -15605,16 +15400,6 @@ __metadata:
     indent-string: "npm:^2.1.0"
     strip-indent: "npm:^1.0.1"
   checksum: 10c0/9fa48d250d4e645acac9de57cb82dc29cd7f5f27257ec367461e3dd0c9f14c55f1c40fd3d9cf7f9a3ed337f209ad4e0370abfcf5cf75569ebd31c97a7949b8a2
-  languageName: node
-  linkType: hard
-
-"redent@npm:^3.0.0":
-  version: 3.0.0
-  resolution: "redent@npm:3.0.0"
-  dependencies:
-    indent-string: "npm:^4.0.0"
-    strip-indent: "npm:^3.0.0"
-  checksum: 10c0/d64a6b5c0b50eb3ddce3ab770f866658a2b9998c678f797919ceb1b586bab9259b311407280bd80b804e2a7c7539b19238ae6a2a20c843f1a7fcff21d48c2eae
   languageName: node
   linkType: hard
 
@@ -16850,15 +16635,6 @@ __metadata:
   version: 0.1.8
   resolution: "stable@npm:0.1.8"
   checksum: 10c0/df74b5883075076e78f8e365e4068ecd977af6c09da510cfc3148a303d4b87bc9aa8f7c48feb67ed4ef970b6140bd9eabba2129e28024aa88df5ea0114cba39d
-  languageName: node
-  linkType: hard
-
-"stack-utils@npm:^2.0.3":
-  version: 2.0.6
-  resolution: "stack-utils@npm:2.0.6"
-  dependencies:
-    escape-string-regexp: "npm:^2.0.0"
-  checksum: 10c0/651c9f87667e077584bbe848acaecc6049bc71979f1e9a46c7b920cad4431c388df0f51b8ad7cfd6eed3db97a2878d0fc8b3122979439ea8bac29c61c95eec8a
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
This pull request removes dependencies related to Jest testing library. It is necessary to do because of upgrading ESLint version and migrating the ESLint configuration file.