### PR TITLE
SCSSから`@import`を廃止する

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "redux-devtools-extension": "^2.13.8",
     "redux-thunk": "^2.3.0",
     "reinvented-color-wheel": "^0.2.10",
-    "sass": "^1.49.8",
+    "sass": "^1.77.4",
     "tss-react": "^3.3.1",
     "typescript": "^5.4.5",
     "web-vitals": "^1.1.0"

--- a/src/_variables.scss
+++ b/src/_variables.scss
@@ -1,3 +1,4 @@
+@use 'sass:map';
 :root {
   --header-height: 42px;
   --key-height: 56px;
@@ -43,7 +44,7 @@ $breakpoints: (
   'xl': 'screen and (min-width: 1001px)',
 ) !default;
 @mixin mq($breakpoint: md) {
-  @media #{map-get($breakpoints, $breakpoint)} {
+  @media #{map.get($breakpoints, $breakpoint)} {
     @content;
   }
 }

--- a/src/components/catalog/content/Content.scss
+++ b/src/components/catalog/content/Content.scss
@@ -1,4 +1,4 @@
-@import '../../../variables';
+@use '../../../variables';
 .catalog-content {
   display: flex;
   position: relative;
@@ -29,14 +29,14 @@
   flex-direction: column;
   align-items: center;
   justify-content: center;
-  padding-top: $space-xl;
+  padding-top: variables.$space-xl;
   background-color: white;
   flex: 1 1;
   width: 100%;
   height: 100vh;
 }
 
-@include mq(sm) {
+@include variables.mq(sm) {
   .catalog-content {
     padding-top: calc(var(--key-height));
   }

--- a/src/components/catalog/header/Header.scss
+++ b/src/components/catalog/header/Header.scss
@@ -1,4 +1,4 @@
-@import '../../../_variables.scss';
+@use '../../../_variables.scss';
 
 .catalog-header {
   display: flex;
@@ -8,7 +8,7 @@
   flex-direction: row;
   align-items: center;
   margin: 0;
-  padding: 0 $space-m;
+  padding: 0 variables.$space-m;
   background: white;
   border-bottom: 1px solid rgba(0, 0, 0, 0.2);
   z-index: 2;

--- a/src/components/catalog/keyboard/CatalogKeyboard.scss
+++ b/src/components/catalog/keyboard/CatalogKeyboard.scss
@@ -1,4 +1,4 @@
-@import '../../../variables';
+@use '../../../variables';
 
 .catalog-keyboard {
   &-wrapper {
@@ -30,7 +30,7 @@
     width: 100%;
   }
 
-  @include mq(sm) {
+  @include variables.mq(sm) {
     &-header {
       padding: 8px;
     }

--- a/src/components/catalog/keyboard/CatalogKeyboardHeader.scss
+++ b/src/components/catalog/keyboard/CatalogKeyboardHeader.scss
@@ -1,4 +1,4 @@
-@import '../../../variables';
+@use '../../../variables';
 
 .catalog-keyboard-header {
   color: white;
@@ -16,7 +16,7 @@
     flex-direction: row;
     width: 100%;
     padding: 16px 16px 16px 8px;
-    background-color: $primary;
+    background-color: variables.$primary;
     align-items: center;
     justify-content: space-between;
     flex-wrap: wrap;
@@ -43,7 +43,7 @@
     & h6 {
       font-size: 0.9rem;
     }
-    @include mq(lg) {
+    @include variables.mq(lg) {
       & h1 {
         font-size: 24px;
         font-weight: bold;
@@ -72,7 +72,7 @@
     &-stores {
       margin-left: 16px;
     }
-    @include mq(lg) {
+    @include variables.mq(lg) {
       &-github {
         margin-left: 8px;
         div {
@@ -99,7 +99,7 @@
   }
 }
 
-@include mq(sm) {
+@include variables.mq(sm) {
   .catalog-keyboard-header {
     margin-top: 0;
     margin-bottom: 8px;

--- a/src/components/catalog/keyboard/build/BuildParametersDialog.scss
+++ b/src/components/catalog/keyboard/build/BuildParametersDialog.scss
@@ -1,4 +1,4 @@
-@import '../../../../variables';
+@use '../../../../variables';
 
 .build-parameters-dialog {
   &-content {

--- a/src/components/catalog/keyboard/build/CatalogBuild.scss
+++ b/src/components/catalog/keyboard/build/CatalogBuild.scss
@@ -1,4 +1,4 @@
-@import 'src/variables';
+@use '../../../../variables';
 
 .catalog-build {
   &-container {

--- a/src/components/catalog/keyboard/firmware/CatalogFirmware.scss
+++ b/src/components/catalog/keyboard/firmware/CatalogFirmware.scss
@@ -1,4 +1,4 @@
-@import 'src/variables';
+@use '../../../../variables';
 
 .catalog-firmware {
   &-wrapper {
@@ -32,7 +32,7 @@
 
   &-total-download-count {
     width: 100%;
-    margin-bottom: $space-m;
+    margin-bottom: variables.$space-m;
   }
 
   &-card {

--- a/src/components/catalog/keyboard/introduction/CatalogIntroduction.scss
+++ b/src/components/catalog/keyboard/introduction/CatalogIntroduction.scss
@@ -1,4 +1,4 @@
-@import 'src/variables';
+@use '../../../../variables';
 
 .catalog-introduction {
   &-wrapper {
@@ -19,7 +19,7 @@
     margin-bottom: 32px;
   }
 
-  @include mq(sm) {
+  @include variables.mq(sm) {
     &-container {
       padding-top: 0;
     }
@@ -45,7 +45,7 @@
       width: 438px;
       align-items: center;
     }
-    @include mq(lg) {
+    @include variables.mq(lg) {
       .image-gallery-slides {
         width: 100%;
       }
@@ -57,11 +57,11 @@
       &.active,
       &:focus {
         outline: none;
-        border: 2px solid $primary;
+        border: 2px solid variables.$primary;
       }
     }
 
-    @include mq(lg) {
+    @include variables.mq(lg) {
       .image-gallery-thumbnail {
         width: 80px;
       }
@@ -72,13 +72,13 @@
       flex-direction: column;
       justify-content: center;
       align-items: center;
-      color: $color-gray-600;
+      color: variables.$color-gray-600;
       width: 438px;
       height: 328px;
-      background-color: $color-gray-300;
+      background-color: variables.$color-gray-300;
     }
   }
-  @include mq(sm) {
+  @include variables.mq(sm) {
     &-image {
       padding: 0;
       &-nothing {
@@ -131,7 +131,7 @@
     cursor: pointer;
 
     &:hover {
-      border: 1px solid $color-gray-300;
+      border: 1px solid variables.$color-gray-300;
     }
 
     &-image {
@@ -145,13 +145,13 @@
     &-no-image {
       width: 100px;
       height: 75px;
-      border: 1px dotted $color-gray-300;
+      border: 1px dotted variables.$color-gray-300;
       display: flex;
       flex-direction: column;
       justify-content: center;
       align-items: center;
-      color: $color-gray-600;
-      background-color: $color-gray-300;
+      color: variables.$color-gray-600;
+      background-color: variables.$color-gray-300;
       font-size: 0.8rem;
     }
 

--- a/src/components/catalog/keyboard/keymap/CatalogKeymap.scss
+++ b/src/components/catalog/keyboard/keymap/CatalogKeymap.scss
@@ -1,4 +1,4 @@
-@import 'src/variables';
+@use '../../../../variables';
 
 .catalog-keymap {
   &-container {
@@ -85,7 +85,7 @@
       justify-content: center;
       align-items: center;
       flex-wrap: wrap;
-      padding: $space-l $space-l 0 $space-l;
+      padding: variables.$space-l variables.$space-l 0 variables.$space-l;
       z-index: 2;
     }
 

--- a/src/components/catalog/keyboard/keymap/CatalogKeymapList.scss
+++ b/src/components/catalog/keyboard/keymap/CatalogKeymapList.scss
@@ -1,4 +1,4 @@
-@import 'src/variables';
+@use '../../../../variables';
 
 .catalog-keymap-list {
   &-wrapper {
@@ -12,6 +12,6 @@
   }
 
   &-row-selected {
-    background-color: $primary !important;
+    background-color: variables.$primary !important;
   }
 }

--- a/src/components/catalog/search/CatalogSearch.scss
+++ b/src/components/catalog/search/CatalogSearch.scss
@@ -1,4 +1,4 @@
-@import '../../../variables';
+@use '../../../variables';
 
 .catalog-search-wrapper {
   position: relative;
@@ -107,8 +107,8 @@
     flex-direction: column;
     justify-content: center;
     align-items: center;
-    color: $color-gray-600;
-    background-color: $color-gray-300;
+    color: variables.$color-gray-600;
+    background-color: variables.$color-gray-300;
   }
 
   &-content {
@@ -167,7 +167,7 @@
   }
 }
 
-@include mq(sm) {
+@include variables.mq(sm) {
   .catalog-search-result-card {
     flex-direction: column;
     height: 210px;

--- a/src/components/catalog/search/CatalogSearchForm.scss
+++ b/src/components/catalog/search/CatalogSearchForm.scss
@@ -1,4 +1,4 @@
-@import '../../../variables';
+@use '../../../variables';
 .catalog-search-condition-container {
   display: flex;
   flex-direction: column;

--- a/src/components/common/anchortypography/AnchorTypography.scss
+++ b/src/components/common/anchortypography/AnchorTypography.scss
@@ -1,4 +1,4 @@
-@import '../../../variables';
+@use '../../../variables';
 
 .anchor-typography {
   &-link {

--- a/src/components/common/auth/AuthProviderDialog.scss
+++ b/src/components/common/auth/AuthProviderDialog.scss
@@ -1,4 +1,4 @@
-@import 'src/variables';
+@use '../../../variables';
 
 .auth-provider-dialog {
   .close-dialog {
@@ -7,7 +7,7 @@
     right: 20px;
 
     &:hover {
-      color: $primary-light;
+      color: variables.$primary-light;
       cursor: pointer;
     }
   }
@@ -18,7 +18,7 @@
 
     &-provider {
       display: inline-block;
-      margin-left: $space-m;
+      margin-left: variables.$space-m;
     }
   }
 }

--- a/src/components/common/auth/ProfileIcon.scss
+++ b/src/components/common/auth/ProfileIcon.scss
@@ -1,4 +1,4 @@
-@import 'src/variables';
+@use '../../../variables';
 
 .profile-icon {
   &-avatar {

--- a/src/components/common/firmware/FlashFirmwareDialog.scss
+++ b/src/components/common/firmware/FlashFirmwareDialog.scss
@@ -1,4 +1,4 @@
-@import '../../../variables';
+@use '../../../variables';
 
 .flash-firmware-dialog {
   &-info {
@@ -26,7 +26,7 @@
     justify-content: center;
     margin: 8px;
     padding: 8px;
-    border: 1px solid $color-gray-300;
+    border: 1px solid variables.$color-gray-300;
 
     &-items {
       display: flex;

--- a/src/components/common/firmware/UploadFirmwareDialog.scss
+++ b/src/components/common/firmware/UploadFirmwareDialog.scss
@@ -1,4 +1,4 @@
-@import '../../../variables';
+@use '../../../variables';
 
 .upload-firmware-dialog {
   &-upload-file-form {
@@ -24,7 +24,7 @@
     }
 
     &-message {
-      color: $color-gray-500;
+      color: variables.$color-gray-500;
     }
   }
 }

--- a/src/components/common/flash/FlashButton.scss
+++ b/src/components/common/flash/FlashButton.scss
@@ -1,4 +1,4 @@
-@import '../../../_variables.scss';
+@use '../../../_variables.scss';
 
 .flash-button-wrapper {
   width: 7rem;
@@ -20,8 +20,8 @@
     opacity: 0.5;
   }
   100% {
-    border-color: $primary;
-    background-color: $primary;
+    border-color: variables.$primary;
+    background-color: variables.$primary;
     opacity: 1;
   }
 }
@@ -37,7 +37,7 @@
   }
 
   40% {
-    border-color: $primary;
+    border-color: variables.$primary;
     background-color: transparent;
 
     transform: scale(1, 1);
@@ -49,8 +49,8 @@
     width: 2.5rem;
     text-indent: -0.6125rem;
     color: transparent;
-    border-color: $primary;
-    background-color: $primary;
+    border-color: variables.$primary;
+    background-color: variables.$primary;
   }
 
   80% {
@@ -60,8 +60,8 @@
   100% {
     margin-left: 1.25rem;
     width: 2.5rem;
-    background-color: $primary;
-    border-color: $primary;
+    background-color: variables.$primary;
+    border-color: variables.$primary;
     color: transparent;
   }
 }
@@ -115,7 +115,7 @@
   }
 
   10% {
-    border-color: $primary;
+    border-color: variables.$primary;
   }
 
   20% {
@@ -128,11 +128,11 @@
   80% {
     opacity: 1;
     width: 7rem;
-    border-color: $primary;
+    border-color: variables.$primary;
   }
 
   100% {
-    border-color: $primary-pale;
+    border-color: variables.$primary-pale;
     opacity: 0;
   }
 }
@@ -151,8 +151,8 @@
   position: relative;
   overflow: hidden;
   width: 7rem;
-  color: $primary-pale;
-  border: 3px solid $primary-pale;
+  color: variables.$primary-pale;
+  border: 3px solid variables.$primary-pale;
   background-color: transparent;
   cursor: pointer;
   line-height: 2;
@@ -234,7 +234,7 @@
     height: auto;
     border-radius: 0;
     background-color: transparent;
-    color: $primary;
+    color: variables.$primary;
     content: 'success';
     opacity: 0;
     z-index: 2;

--- a/src/components/common/footer/Footer.scss
+++ b/src/components/common/footer/Footer.scss
@@ -1,11 +1,11 @@
-@import 'src/variables';
+@use '../../../variables';
 
 .footer {
   display: grid;
   grid-template-columns: 0.8fr 1.4fr 0.8fr;
   position: fixed;
   background-color: white;
-  padding: $space-s $space-m;
+  padding: variables.$space-s variables.$space-m;
   bottom: 0;
   left: 0;
   width: 100%;
@@ -14,7 +14,7 @@
   z-index: 1;
 
   a {
-    color: $primary-light;
+    color: variables.$primary-light;
   }
   &-dev-team {
     text-align: start;
@@ -52,10 +52,10 @@
 
   .app-version {
     text-align: end;
-    color: $color-gray-400;
+    color: variables.$color-gray-400;
   }
 
-  @include mq(sm) {
+  @include variables.mq(sm) {
     &-dev-team {
       &-years {
         display: none;

--- a/src/components/common/keyboarddefformpart/KeyboardDefinitionFormPart.scss
+++ b/src/components/common/keyboarddefformpart/KeyboardDefinitionFormPart.scss
@@ -1,4 +1,4 @@
-@import '../../../variables';
+@use '../../../variables';
 
 .keyboarddefinitionform-wrapper {
   position: relative;
@@ -10,7 +10,7 @@
 
   .message {
     margin: 0 auto;
-    padding: $space-l 0;
+    padding: variables.$space-l 0;
     font-size: 1rem;
     overflow-wrap: anywhere;
     &.message-small {
@@ -81,7 +81,7 @@
   .validation-errors {
     width: 100%;
     max-width: 853px;
-    margin: $space-m auto;
+    margin: variables.$space-m auto;
     #other-possibilities {
       .MuiAccordionDetails-root {
         flex-direction: column;
@@ -89,7 +89,7 @@
     }
   }
   .invalid-item {
-    margin-top: $space-m;
+    margin-top: variables.$space-m;
     overflow-wrap: anywhere;
   }
 }

--- a/src/components/configure/Configure.scss
+++ b/src/components/configure/Configure.scss
@@ -1,10 +1,10 @@
-@import '../../_variables.scss';
+@use '../../_variables.scss';
 
 .configure-root {
   display: flex;
   flex-direction: column;
   height: 100vh;
-  background-color: $background-color-gray;
+  background-color: variables.$background-color-gray;
 }
 
 .message-box-wrapper {

--- a/src/components/configure/content/Content.scss
+++ b/src/components/configure/content/Content.scss
@@ -1,4 +1,4 @@
-@import '../../../variables';
+@use '../../../variables';
 .content {
   display: flex;
   position: relative;
@@ -14,7 +14,7 @@
     flex-direction: column;
     align-items: center;
     justify-content: center;
-    padding-top: $space-xl;
+    padding-top: variables.$space-xl;
     background-color: white;
     flex: 1 1;
     width: 100%;

--- a/src/components/configure/customkey/AutocompleteKeys.scss
+++ b/src/components/configure/customkey/AutocompleteKeys.scss
@@ -1,10 +1,10 @@
-@import '../../../variables';
+@use '../../../variables';
 
 .customkey-auto-select-item {
   position: relative;
   display: flex;
   flex-direction: column;
-  padding: $space-s 0;
+  padding: variables.$space-s 0;
   font-size: 0.87rem;
   width: 100%;
   .keycode-auto-label-wrapper {
@@ -14,11 +14,11 @@
       flex-grow: 1;
     }
     .keycode-auto-category {
-      color: $color-gray-600;
+      color: variables.$color-gray-600;
     }
   }
   .keycode-auto-desc {
     font-size: 0.8rem;
-    color: $color-gray-600;
+    color: variables.$color-gray-600;
   }
 }

--- a/src/components/configure/customkey/CustomKey.scss
+++ b/src/components/configure/customkey/CustomKey.scss
@@ -1,4 +1,4 @@
-@import '../../../variables';
+@use '../../../variables';
 
 .customkey-popover {
   .MuiTab-root {
@@ -25,18 +25,18 @@
     }
     .customkey-tabpanel {
       position: relative;
-      padding: $space-l;
+      padding: variables.$space-l;
     }
     .customkey-body {
       width: 400px;
       height: 254px;
 
       .customkey-field {
-        margin-bottom: $space-l;
+        margin-bottom: variables.$space-l;
       }
 
       .customkey-field-hex {
-        margin-top: $space-m;
+        margin-top: variables.$space-m;
       }
 
       .customkey-label {
@@ -44,21 +44,21 @@
       }
 
       .customkey-description {
-        margin-bottom: $space-l;
+        margin-bottom: variables.$space-l;
         font-size: 0.9rem;
       }
       .customkey-code {
         div::before {
           content: '0x';
-          margin-left: $space-l;
-          color: $color-gray-500;
+          margin-left: variables.$space-l;
+          color: variables.$color-gray-500;
         }
         input {
-          padding-left: $space-xs;
+          padding-left: variables.$space-xs;
         }
       }
       .customkey-meta {
-        color: $color-gray-400;
+        color: variables.$color-gray-400;
         font-size: 0.7rem;
         align-items: flex-end;
         display: flex;
@@ -71,7 +71,7 @@
         }
       }
       .customkey-bcode {
-        color: $color-gray-400;
+        color: variables.$color-gray-400;
         font-size: 0.7rem;
         justify-content: flex-end;
         display: flex;

--- a/src/components/configure/customkey/Modifiers.scss
+++ b/src/components/configure/customkey/Modifiers.scss
@@ -1,9 +1,9 @@
-@import '../../../variables';
+@use '../../../variables';
 
 .modifiers-label {
   font-weight: 700;
 }
 
 .modifiers-label-disabled {
-  color: $color-gray-500;
+  color: variables.$color-gray-500;
 }

--- a/src/components/configure/customkey/TabHoldTapKey.scss
+++ b/src/components/configure/customkey/TabHoldTapKey.scss
@@ -1,7 +1,7 @@
-@import '../../../variables';
+@use '../../../variables';
 
 .holdkey-desc {
   font-size: 0.8rem;
-  margin-bottom: $space-m;
-  color: $color-gray-600;
+  margin-bottom: variables.$space-m;
+  color: variables.$color-gray-600;
 }

--- a/src/components/configure/customkey/TabKey.scss
+++ b/src/components/configure/customkey/TabKey.scss
@@ -1,8 +1,8 @@
-@import '../../../variables';
+@use '../../../variables';
 
 .customkey-desc {
   font-size: 0.8rem;
-  color: $color-gray-600;
+  color: variables.$color-gray-600;
   height: 30px;
-  padding-top: $space-s;
+  padding-top: variables.$space-s;
 }

--- a/src/components/configure/header/Header.scss
+++ b/src/components/configure/header/Header.scss
@@ -1,4 +1,4 @@
-@import '../../../_variables.scss';
+@use '../../../_variables.scss';
 
 .header {
   display: grid;
@@ -8,7 +8,7 @@
   grid-template-columns: 1fr 1fr 1fr;
   align-items: center;
   margin: 0;
-  padding: 0 $space-m;
+  padding: 0 variables.$space-m;
   background: white;
   border-bottom: 1px solid rgba(0, 0, 0, 0.2);
   z-index: 2;
@@ -33,17 +33,17 @@
           text-overflow: ellipsis;
         }
         .ids {
-          font-size: $font-xs;
-          color: $color-gray;
+          font-size: variables.$font-xs;
+          color: variables.$color-gray;
           margin-top: -4px;
         }
       }
 
       &:hover {
-        color: $primary;
+        color: variables.$primary;
         .kbd-name {
           .ids {
-            color: $primary;
+            color: variables.$primary;
           }
         }
       }
@@ -106,10 +106,10 @@
   width: 100%;
 
   .link-icon {
-    margin-right: $space-m;
+    margin-right: variables.$space-m;
   }
   .link-on {
-    color: $primary;
+    color: variables.$primary;
     font-weight: 700;
   }
   .link-off {
@@ -124,7 +124,7 @@
     .device-ids {
       font-weight: 400;
       font-size: 40%;
-      margin-left: $space-m;
+      margin-left: variables.$space-m;
     }
   }
 }
@@ -152,8 +152,8 @@
     opacity: 0.5;
   }
   100% {
-    border-color: $primary;
-    background-color: $primary;
+    border-color: variables.$primary;
+    background-color: variables.$primary;
     opacity: 1;
   }
 }
@@ -167,7 +167,7 @@
   }
 
   40% {
-    border-color: $primary;
+    border-color: variables.$primary;
     background-color: transparent;
     transform: scale(1, 1);
   }
@@ -178,8 +178,8 @@
     width: 2.5rem;
     text-indent: -0.6125rem;
     color: transparent;
-    border-color: $primary;
-    background-color: $primary;
+    border-color: variables.$primary;
+    background-color: variables.$primary;
   }
 
   80% {
@@ -189,8 +189,8 @@
   100% {
     margin-left: 1.25rem;
     width: 2.5rem;
-    background-color: $primary;
-    border-color: $primary;
+    background-color: variables.$primary;
+    border-color: variables.$primary;
     color: transparent;
   }
 }
@@ -241,7 +241,7 @@
   }
 
   10% {
-    border-color: $primary;
+    border-color: variables.$primary;
   }
 
   20% {
@@ -255,11 +255,11 @@
     opacity: 1;
     width: 7rem;
     transform: scale(1, 1);
-    border-color: $primary;
+    border-color: variables.$primary;
   }
 
   100% {
-    border-color: $primary-pale;
+    border-color: variables.$primary-pale;
     opacity: 0;
   }
 }
@@ -278,8 +278,8 @@
   position: relative;
   overflow: hidden;
   width: 7rem;
-  color: $primary-pale;
-  border: 3px solid $primary-pale;
+  color: variables.$primary-pale;
+  border: 3px solid variables.$primary-pale;
   background-color: transparent;
   cursor: pointer;
   line-height: 2;
@@ -353,7 +353,7 @@
     height: auto;
     border-radius: 0;
     background-color: transparent;
-    color: $primary;
+    color: variables.$primary;
     content: 'success';
     opacity: 0;
     z-index: 2;

--- a/src/components/configure/importDef/ImportDefDialog.scss
+++ b/src/components/configure/importDef/ImportDefDialog.scss
@@ -1,4 +1,4 @@
-@import '../../../variables';
+@use '../../../variables';
 
 .import-file-dialog {
   .close-dialog {
@@ -7,7 +7,7 @@
     right: 20px;
 
     &:hover {
-      color: $primary-light;
+      color: variables.$primary-light;
       cursor: pointer;
     }
   }
@@ -17,13 +17,13 @@
     height: 440px;
 
     .import-success {
-      margin-top: $space-l;
+      margin-top: variables.$space-l;
       .apply-definition {
-        padding: $space-m 0;
+        padding: variables.$space-m 0;
         display: flex;
         justify-content: flex-end;
         button {
-          margin-left: $space-m;
+          margin-left: variables.$space-m;
         }
       }
     }
@@ -33,6 +33,6 @@
 .option-warning-message {
   font-size: 90%;
   line-height: 0.95rem;
-  color: $color-gray;
-  margin-bottom: $space-m;
+  color: variables.$color-gray;
+  margin-bottom: variables.$space-m;
 }

--- a/src/components/configure/info/InfoDialog.scss
+++ b/src/components/configure/info/InfoDialog.scss
@@ -1,4 +1,4 @@
-@import '../../../variables';
+@use '../../../variables';
 
 .info-dialog {
   .close-dialog {
@@ -7,7 +7,7 @@
     right: 20px;
 
     &:hover {
-      color: $primary-light;
+      color: variables.$primary-light;
       cursor: pointer;
     }
   }
@@ -15,14 +15,14 @@
   &-information-message {
     font-size: 90%;
     line-height: 0.95rem;
-    color: $color-gray;
-    margin-bottom: $space-m;
+    color: variables.$color-gray;
+    margin-bottom: variables.$space-m;
   }
 
   &-warning-message {
     font-size: 90%;
     line-height: 0.95rem;
-    color: $error;
-    margin-bottom: $space-m;
+    color: variables.$error;
+    margin-bottom: variables.$space-m;
   }
 }

--- a/src/components/configure/keyboarddefform/KeyboardDefinitionForm.scss
+++ b/src/components/configure/keyboarddefform/KeyboardDefinitionForm.scss
@@ -1,4 +1,4 @@
-@import '../../../variables';
+@use '../../../variables';
 
 .keyboarddefinitionform-wrapper {
   position: relative;

--- a/src/components/configure/keyboardlist/KeyboardList.scss
+++ b/src/components/configure/keyboardlist/KeyboardList.scss
@@ -1,4 +1,4 @@
-@import '../../../variables';
+@use '../../../variables';
 
 .keyboardlist-wrapper {
   position: relative;
@@ -6,12 +6,12 @@
   flex-direction: column;
   align-items: center;
   justify-content: center;
-  padding-top: $space-xl;
+  padding-top: variables.$space-xl;
   background: white;
   flex: 1 1;
   .message {
-    padding: $space-m 0;
-    margin-bottom: $space-m;
+    padding: variables.$space-m 0;
+    margin-bottom: variables.$space-m;
     font-size: 1rem;
     text-align: center;
 
@@ -56,11 +56,11 @@
     .keyboard-item {
       border-bottom: 1px solid rgba(0, 0, 0, 0.2);
       border-left: 3px solid white;
-      padding: $space-m;
+      padding: variables.$space-m;
       cursor: pointer;
       &:hover {
-        border-left: 3px solid $primary;
-        background-color: $primary-pale;
+        border-left: 3px solid variables.$primary;
+        background-color: variables.$primary-pale;
       }
       h3 {
         font-weight: 700;

--- a/src/components/configure/keycap/Keycap.scss
+++ b/src/components/configure/keycap/Keycap.scss
@@ -1,11 +1,11 @@
-@import '../../../variables';
+@use '../../../variables';
 
 @keyframes blink-primary {
   0% {
-    background-color: $primary-pale;
+    background-color: variables.$primary-pale;
   }
   100% {
-    background-color: $primary-light;
+    background-color: variables.$primary-light;
   }
 }
 @keyframes blink-border {
@@ -39,30 +39,30 @@
 
 .keycap-base {
   &.drag-over {
-    border-color: $primary-pale;
+    border-color: variables.$primary-pale;
     .keycap {
-      background-color: $primary-pale !important;
-      border-color: $primary !important;
+      background-color: variables.$primary-pale !important;
+      border-color: variables.$primary !important;
     }
     .keyroof-base {
-      border-color: $primary-pale !important;
-      background-color: $primary-pale !important;
+      border-color: variables.$primary-pale !important;
+      background-color: variables.$primary-pale !important;
     }
     .keyroof {
-      background-color: $primary-pale !important;
+      background-color: variables.$primary-pale !important;
     }
   }
   &.keycap-selected {
     .keycap {
-      background: $primary-light !important;
-      border-color: $primary-pale !important;
+      background: variables.$primary-light !important;
+      border-color: variables.$primary-pale !important;
     }
     .keyroof-base {
-      border-color: $primary-thin !important;
-      background-color: $primary-pale !important;
+      border-color: variables.$primary-thin !important;
+      background-color: variables.$primary-pale !important;
     }
     .keyroof {
-      background-color: $primary-pale !important;
+      background-color: variables.$primary-pale !important;
     }
   }
   .keycap {
@@ -182,24 +182,24 @@
       }
       .keycode-label {
         font-weight: 500;
-        color: $color-gray-600;
+        color: variables.$color-gray-600;
       }
       .modifier {
-        color: $color-gray-600;
+        color: variables.$color-gray-600;
         font-size: 0.6rem;
         width: 124%;
       }
       .left {
         text-align: left;
-        padding-left: $space-xs;
+        padding-left: variables.$space-xs;
       }
       .center {
         text-align: center;
       }
       .right {
         text-align: right;
-        padding-right: $space-m;
-        color: $color-gray-500;
+        padding-right: variables.$space-m;
+        color: variables.$color-gray-500;
       }
     }
     .color-modifier {

--- a/src/components/configure/keycodekey/KeycodeKey.scss
+++ b/src/components/configure/keycodekey/KeycodeKey.scss
@@ -1,4 +1,4 @@
-@import '../../../variables';
+@use '../../../variables';
 
 .keycodekey {
   width: calc(var(--key-width));
@@ -14,7 +14,7 @@
   z-index: 1;
   position: relative;
   &:hover {
-    background-color: $primary-pale !important;
+    background-color: variables.$primary-pale !important;
   }
 
   &.grabbable {
@@ -32,7 +32,7 @@
   &.addkey {
     border: 1px dashed #ccc;
     &:hover {
-      background-color: $primary-pale;
+      background-color: variables.$primary-pale;
       transition: background-color 0.5s;
     }
   }
@@ -57,7 +57,7 @@
     font-size: 0.72rem;
     overflow-wrap: anywhere;
     overflow: hidden;
-    padding: $space-xs;
+    padding: variables.$space-xs;
     height: 40%;
     .code-row {
       display: flex;
@@ -83,7 +83,7 @@
 
   .modifier-label {
     height: 30%;
-    color: $color-gray-600;
+    color: variables.$color-gray-600;
     font-size: 0.6rem;
   }
 }

--- a/src/components/configure/keycodekey/any/AnyKeyEditDialog.scss
+++ b/src/components/configure/keycodekey/any/AnyKeyEditDialog.scss
@@ -1,4 +1,4 @@
-@import '../../../../variables';
+@use '../../../../variables';
 
 .anykey-dialog {
   input {
@@ -7,12 +7,12 @@
   .hex-code-wrapper {
     display: flex;
     position: relative;
-    margin-top: $space-l;
+    margin-top: variables.$space-l;
     .hex-code {
       position: absolute;
       top: 21px;
       font-size: 1rem;
-      color: $color-gray-500;
+      color: variables.$color-gray-500;
     }
     input {
       padding-left: 18px;

--- a/src/components/configure/keycodes/Keycodes.scss
+++ b/src/components/configure/keycodes/Keycodes.scss
@@ -1,4 +1,4 @@
-@import '../../../variables';
+@use '../../../variables';
 
 :root {
   --switch-width: 140px;
@@ -15,11 +15,11 @@
     flex-direction: row;
     &:hover {
       .keycodekey {
-        border-color: $primary-light;
+        border-color: variables.$primary-light;
       }
       .sub-category {
         span {
-          color: $primary-light;
+          color: variables.$primary-light;
         }
       }
     }
@@ -55,15 +55,15 @@
   flex-direction: row;
   justify-content: center;
   align-items: flex-end;
-  padding: $space-m 0;
+  padding: variables.$space-m 0;
   .blank-category {
     width: var(--switch-width);
   }
   .key-category {
-    margin: 0 $space-m;
+    margin: 0 variables.$space-m;
     &.key-category-empty-keys {
       button:disabled {
-        color: $color-gray-400;
+        color: variables.$color-gray-400;
         background-color: #ffffff00;
       }
     }
@@ -72,7 +72,7 @@
       background-color: #ffffff00;
       &:disabled,
       &:hover {
-        background-color: $primary-pale;
+        background-color: variables.$primary-pale;
       }
       &:disabled {
         color: white;

--- a/src/components/configure/keycodes/Keycodes.stories.scss
+++ b/src/components/configure/keycodes/Keycodes.stories.scss
@@ -1,4 +1,4 @@
-@import '../../../variables';
+@use '../../../variables';
 
 :root {
   --switch-width: 140px;
@@ -22,7 +22,7 @@
       padding: 0 2px;
       &:hover {
         color: white;
-        background-color: $primary-pale;
+        background-color: variables.$primary-pale;
       }
     }
   }

--- a/src/components/configure/keydiff/Keydiff.scss
+++ b/src/components/configure/keydiff/Keydiff.scss
@@ -1,11 +1,11 @@
-@import '../../../variables';
+@use '../../../variables';
 
 .diff-frame {
   display: flex;
   flex-direction: row;
   justify-content: center;
   align-items: center;
-  padding-top: $space-m;
+  padding-top: variables.$space-m;
   .spacer {
     width: 94px;
   }

--- a/src/components/configure/keymap/Keymap.scss
+++ b/src/components/configure/keymap/Keymap.scss
@@ -1,4 +1,4 @@
-@import '../../../variables';
+@use '../../../variables';
 
 .keydiff-wrapper {
   display: flex;
@@ -10,7 +10,7 @@
     display: flex;
     flex-direction: row;
     justify-content: center;
-    margin-bottom: $space-m;
+    margin-bottom: variables.$space-m;
     .test-matrix-message {
       z-index: 2;
       color: white;
@@ -35,7 +35,7 @@
     display: flex;
     justify-content: flex-start;
     align-items: center;
-    padding: $space-l;
+    padding: variables.$space-l;
   }
 
   .label-lang,
@@ -54,7 +54,7 @@
     justify-content: center;
     align-items: flex-start;
     min-width: 80px;
-    padding-left: $space-l;
+    padding-left: variables.$space-l;
     z-index: 2;
 
     .MuiPagination-ul {
@@ -89,9 +89,9 @@
     }
     .app-info {
       position: absolute;
-      right: $space-l;
-      bottom: $space-s;
-      color: $primary-pale;
+      right: variables.$space-l;
+      bottom: variables.$space-s;
+      color: variables.$primary-pale;
     }
   }
 }

--- a/src/components/configure/keymapToolbar/KeymapToolbar.scss
+++ b/src/components/configure/keymapToolbar/KeymapToolbar.scss
@@ -1,4 +1,4 @@
-@import '../../../variables';
+@use '../../../variables';
 
 .keymap-menu {
   display: flex;
@@ -10,7 +10,7 @@
   z-index: 2;
 
   .keymap-menu-item {
-    margin-bottom: $space-m;
+    margin-bottom: variables.$space-m;
 
     &:first-child,
     &:last-child {

--- a/src/components/configure/keymaplist/KeymapListPopover.scss
+++ b/src/components/configure/keymaplist/KeymapListPopover.scss
@@ -1,8 +1,8 @@
-@import '../../../variables';
+@use '../../../variables';
 
 .keymaplist-root {
   .keymaplist {
-    padding: 0 $space-l $space-m $space-l;
+    padding: 0 variables.$space-l variables.$space-m variables.$space-l;
   }
   .keymaplist-popover {
     width: 400px;
@@ -30,9 +30,9 @@
         display: none;
       }
       .no-saved-keymap {
-        padding-bottom: $space-l;
+        padding-bottom: variables.$space-l;
         .keymaplist-warning {
-          color: $warning;
+          color: variables.$warning;
         }
       }
       .my-keymaplist-header {
@@ -74,17 +74,17 @@
     }
 
     .request-signin {
-      padding: $space-l;
+      padding: variables.$space-l;
       display: flex;
       flex-direction: column;
 
       .request-signin-message {
-        color: $warning;
+        color: variables.$warning;
       }
       .request-signin-actions {
         display: flex;
         justify-content: center;
-        padding-top: $space-l;
+        padding-top: variables.$space-l;
       }
     }
   }

--- a/src/components/configure/keymaplist/KeymapSaveDialog.scss
+++ b/src/components/configure/keymaplist/KeymapSaveDialog.scss
@@ -1,4 +1,4 @@
-@import '../../../variables';
+@use '../../../variables';
 
 .keymap-save-dialog {
   .close-dialog {
@@ -7,7 +7,7 @@
     right: 20px;
 
     &:hover {
-      color: $primary-light;
+      color: variables.$primary-light;
       cursor: pointer;
     }
   }
@@ -20,9 +20,9 @@
     }
     .keymap-save-text-counter {
       text-align: right;
-      color: $color-gray-600;
+      color: variables.$color-gray-600;
       margin-right: 8px;
-      margin-bottom: $space-m;
+      margin-bottom: variables.$space-m;
       top: -20px;
       position: relative;
     }

--- a/src/components/configure/layoutoption/LayoutOptionComponentList.scss
+++ b/src/components/configure/layoutoption/LayoutOptionComponentList.scss
@@ -1,8 +1,8 @@
-@import '../../../variables';
+@use '../../../variables';
 
 .layout-option-component-list {
   &-content {
-    padding: $space-l !important;
+    padding: variables.$space-l !important;
   }
 
   &-option-label,

--- a/src/components/configure/layoutoption/LayoutOptionPopover.scss
+++ b/src/components/configure/layoutoption/LayoutOptionPopover.scss
@@ -1,4 +1,4 @@
-@import '../../../variables';
+@use '../../../variables';
 
 .layout-option-root {
   .MuiPopover-paper {
@@ -11,7 +11,7 @@
     font-size: 0.9rem;
 
     .layout-option-header {
-      padding: $space-l !important;
+      padding: variables.$space-l !important;
     }
 
     .layout-option-header {

--- a/src/components/configure/lighting/Lighting.scss
+++ b/src/components/configure/lighting/Lighting.scss
@@ -1,4 +1,4 @@
-@import '../../../variables';
+@use '../../../variables';
 
 .lighting-settings {
   h4 {
@@ -7,7 +7,7 @@
   }
 
   .lighting-label-disabled {
-    color: $color-gray;
+    color: variables.$color-gray;
   }
 
   .lighting-label {
@@ -41,7 +41,7 @@
       display: flex;
     }
     .underglow-color-value:not(:last-child) {
-      margin-right: $space-s;
+      margin-right: variables.$space-s;
     }
     .color-rgb {
       flex-grow: 4;

--- a/src/components/configure/lighting/LightingDialog.scss
+++ b/src/components/configure/lighting/LightingDialog.scss
@@ -1,4 +1,4 @@
-@import '../../../variables';
+@use '../../../variables';
 
 .lighting-dialog {
   .close-dialog {
@@ -7,7 +7,7 @@
     right: 20px;
 
     &:hover {
-      color: $primary-light;
+      color: variables.$primary-light;
       cursor: pointer;
     }
   }

--- a/src/components/configure/macroeditor/MacroEditor.scss
+++ b/src/components/configure/macroeditor/MacroEditor.scss
@@ -1,4 +1,4 @@
-@import '../../../variables';
+@use '../../../variables';
 
 .macro-editor-wrapper {
   display: flex;
@@ -45,7 +45,7 @@
         background-color: white;
       }
       .macro-drop-spacer-over {
-        background-color: $primary;
+        background-color: variables.$primary;
       }
     }
   }
@@ -63,7 +63,7 @@
 }
 
 .macro-hold {
-  border: 1px solid $primary-light !important;
+  border: 1px solid variables.$primary-light !important;
 
   &:hover {
     cursor: grab;
@@ -159,14 +159,14 @@
             display: inline-block;
             font-size: 0.6rem;
             font-weight: 600;
-            color: $primary;
+            color: variables.$primary;
           }
         }
 
         a {
           font-size: 0.7rem;
           cursor: pointer;
-          color: $primary-light;
+          color: variables.$primary-light;
           margin-right: 2px;
         }
       }
@@ -188,15 +188,15 @@
     }
 
     .macro-key-tap {
-      border-color: $primary-light;
-      color: $primary;
-      box-shadow: 0px 0px 4px $primary-light;
+      border-color: variables.$primary-light;
+      color: variables.$primary;
+      box-shadow: 0px 0px 4px variables.$primary-light;
     }
 
     .macro-key-hold {
-      border-color: $primary-pale;
-      color: $primary;
-      box-shadow: 0px 0px 2px $primary-pale;
+      border-color: variables.$primary-pale;
+      color: variables.$primary;
+      box-shadow: 0px 0px 2px variables.$primary-pale;
     }
   }
 
@@ -206,7 +206,7 @@
     align-items: center;
     display: flex;
     .macro-key-toggle-tap-hold-btn {
-      color: $primary;
+      color: variables.$primary;
       font-weight: 600;
       font-size: 0.6rem !important;
     }
@@ -214,10 +214,10 @@
 }
 
 .drag-over-left {
-  border-left: 2px solid $primary !important;
+  border-left: 2px solid variables.$primary !important;
 }
 .drag-over-right {
-  border-right: 2px solid $primary !important;
+  border-right: 2px solid variables.$primary !important;
 }
 
 .macro-drop-key-area {
@@ -236,6 +236,6 @@
     font-size: medium;
     border: 1px dashed rgba(0, 0, 0, 0.2);
     border-radius: 4px;
-    color: $color-gray-600;
+    color: variables.$color-gray-600;
   }
 }

--- a/src/components/configure/modals/connection/ConnectionModal.scss
+++ b/src/components/configure/modals/connection/ConnectionModal.scss
@@ -1,4 +1,4 @@
-@import '../../../../variables';
+@use '../../../../variables';
 
 .connection-modal {
   display: flex;
@@ -9,5 +9,5 @@
   background-color: white;
   border: '2px solid #000';
   box-shadow: 5px;
-  padding: $space-m;
+  padding: variables.$space-m;
 }

--- a/src/components/configure/remap/Remap.scss
+++ b/src/components/configure/remap/Remap.scss
@@ -1,4 +1,4 @@
-@import '../../../variables';
+@use '../../../variables';
 
 .keyboard-wrapper {
   position: relative;
@@ -9,7 +9,7 @@
   .controller {
     display: flex;
     flex-direction: row;
-    padding: $space-l;
+    padding: variables.$space-l;
     background-color: white;
     .switch {
       display: flex;
@@ -33,8 +33,9 @@
   display: flex;
   position: relative;
   flex-direction: column;
-  padding: $space-m $space-m $space-xl $space-m;
-  background-color: $background-color-gray;
+  padding: variables.$space-m variables.$space-m variables.$space-xl
+    variables.$space-m;
+  background-color: variables.$background-color-gray;
   overflow-y: auto;
 
   .disable {
@@ -50,7 +51,7 @@
 .keycode-desc {
   display: flex;
   width: 100%;
-  padding: $space-s $space-l;
+  padding: variables.$space-s variables.$space-l;
 
   background-color: rgba(0, 0, 0, 0.6);
   position: fixed;

--- a/src/components/documents/Documents.scss
+++ b/src/components/documents/Documents.scss
@@ -1,4 +1,4 @@
-@import '../../variables';
+@use '../../variables';
 
 .documents {
   &-wrapper {
@@ -42,7 +42,7 @@
       }
 
       & code {
-        background-color: $color-gray-200;
+        background-color: variables.$color-gray-200;
       }
     }
 

--- a/src/components/documents/header/Header.scss
+++ b/src/components/documents/header/Header.scss
@@ -1,4 +1,4 @@
-@import '../../../_variables.scss';
+@use '../../../_variables.scss';
 
 .docs-header {
   display: flex;
@@ -8,7 +8,7 @@
   flex-direction: row;
   align-items: center;
   margin: 0;
-  padding: 0 $space-m;
+  padding: 0 variables.$space-m;
   background: white;
   border-bottom: 1px solid rgba(0, 0, 0, 0.2);
   z-index: 2;

--- a/src/components/keyboards/content/Content.scss
+++ b/src/components/keyboards/content/Content.scss
@@ -1,4 +1,4 @@
-@import '../../../variables';
+@use '../../../variables';
 .keyboards-content {
   display: flex;
   position: relative;
@@ -13,7 +13,7 @@
     flex-direction: column;
     align-items: center;
     justify-content: center;
-    padding-top: $space-xl;
+    padding-top: variables.$space-xl;
     background-color: white;
     flex: 1 1;
     width: 100%;

--- a/src/components/keyboards/createdefinition/CreateDefinition.scss
+++ b/src/components/keyboards/createdefinition/CreateDefinition.scss
@@ -1,4 +1,4 @@
-@import '../../../variables';
+@use '../../../variables';
 
 .create-definition-wrapper {
   position: fixed;
@@ -20,8 +20,8 @@
 }
 
 .create-definition-stepper {
-  margin-top: $space-l;
-  margin-bottom: $space-l !important;
+  margin-top: variables.$space-l;
+  margin-bottom: variables.$space-l !important;
 }
 
 .create-definition-card {
@@ -72,13 +72,13 @@
     justify-content: flex-end;
 
     button {
-      margin-left: $space-l;
+      margin-left: variables.$space-l;
     }
   }
 
   &-notice {
     font-size: 80%;
-    color: $color-gray;
-    margin-top: $space-m;
+    color: variables.$color-gray;
+    margin-top: variables.$space-m;
   }
 }

--- a/src/components/keyboards/definitionlist/DefinitionList.scss
+++ b/src/components/keyboards/definitionlist/DefinitionList.scss
@@ -1,4 +1,4 @@
-@import '../../../variables';
+@use '../../../variables';
 
 .definition-list-wrapper {
   position: fixed;
@@ -60,7 +60,7 @@
   flex-direction: row;
   align-items: center;
   .status-badge-in-review {
-    background-color: $primary-pale;
+    background-color: variables.$primary-pale;
   }
 }
 

--- a/src/components/keyboards/editdefinition/EditDefinition.scss
+++ b/src/components/keyboards/editdefinition/EditDefinition.scss
@@ -1,4 +1,4 @@
-@import '../../../variables';
+@use '../../../variables';
 
 .edit-definition-wrapper {
   position: fixed;
@@ -42,6 +42,6 @@
 }
 
 .edit-keyboard-stepper {
-  margin-top: $space-l;
-  margin-bottom: $space-l !important;
+  margin-top: variables.$space-l;
+  margin-bottom: variables.$space-l !important;
 }

--- a/src/components/keyboards/editdefinition/buildform/BuildForm.scss
+++ b/src/components/keyboards/editdefinition/buildform/BuildForm.scss
@@ -1,4 +1,4 @@
-@import 'src/variables';
+@use '../../../../variables';
 
 .edit-definition-build-form {
   &-container {

--- a/src/components/keyboards/editdefinition/catalogform/CatalogForm.scss
+++ b/src/components/keyboards/editdefinition/catalogform/CatalogForm.scss
@@ -1,4 +1,4 @@
-@import 'src/variables';
+@use '../../../../variables';
 
 .edit-definition-catalog-form-container {
   display: flex;
@@ -26,8 +26,8 @@
   }
 
   &-additional-description {
-    padding: $space-m;
-    margin-bottom: $space-xl;
+    padding: variables.$space-m;
+    margin-bottom: variables.$space-xl;
 
     &-entry {
       display: flex;
@@ -36,7 +36,7 @@
 
       &-field {
         flex: auto;
-        margin-right: $space-m !important;
+        margin-right: variables.$space-m !important;
       }
     }
 
@@ -44,10 +44,10 @@
       width: 100%;
       display: flex;
       flex-direction: column;
-      margin-top: $space-m;
+      margin-top: variables.$space-m;
 
       &:last-child {
-        margin-top: $space-l;
+        margin-top: variables.$space-l;
       }
 
       &-buttons {
@@ -55,10 +55,10 @@
         display: flex;
         flex-direction: row;
         justify-content: flex-end;
-        margin-top: $space-m;
+        margin-top: variables.$space-m;
 
         button {
-          margin-right: $space-s;
+          margin-right: variables.$space-s;
         }
       }
     }
@@ -71,7 +71,7 @@
     justify-content: flex-end;
 
     button {
-      margin-left: $space-s;
+      margin-left: variables.$space-s;
     }
   }
 
@@ -109,19 +109,19 @@
     }
 
     &-message {
-      color: $color-gray-500;
+      color: variables.$color-gray-500;
     }
 
     &-thumbnail {
       margin-left: 8px;
       width: 200px;
       height: 150px;
-      border: 1px solid $color-gray-300;
+      border: 1px solid variables.$color-gray-300;
     }
 
     &-image {
       margin-left: 8px;
-      border: 1px solid $color-gray-300;
+      border: 1px solid variables.$color-gray-300;
       width: 200px;
       height: 150px;
       background-size: contain;
@@ -131,7 +131,7 @@
 
     &-sub-image {
       margin-left: 8px;
-      border: 1px solid $color-gray-300;
+      border: 1px solid variables.$color-gray-300;
       width: 200px;
       height: 150px;
       background-size: contain;

--- a/src/components/keyboards/editdefinition/definitionform/DefinitionForm.scss
+++ b/src/components/keyboards/editdefinition/definitionform/DefinitionForm.scss
@@ -1,4 +1,4 @@
-@import 'src/variables';
+@use '../../../../variables';
 
 .edit-definition-form-container {
   display: flex;
@@ -25,14 +25,14 @@
     justify-content: flex-end;
 
     button {
-      margin-left: $space-s;
+      margin-left: variables.$space-s;
     }
   }
 
   &-notice {
     font-size: 80%;
-    color: $color-gray;
-    margin-top: $space-m;
+    color: variables.$color-gray;
+    margin-top: variables.$space-m;
   }
 }
 

--- a/src/components/keyboards/editdefinition/firmwareform/FirmwareForm.scss
+++ b/src/components/keyboards/editdefinition/firmwareform/FirmwareForm.scss
@@ -1,4 +1,4 @@
-@import 'src/variables';
+@use '../../../../variables';
 
 .edit-definition-firmware-form {
   &-container {
@@ -30,7 +30,7 @@
     justify-content: flex-end;
 
     button {
-      margin-left: $space-s;
+      margin-left: variables.$space-s;
     }
   }
 
@@ -52,7 +52,7 @@
     }
 
     &-message {
-      color: $color-gray-500;
+      color: variables.$color-gray-500;
     }
   }
 

--- a/src/components/keyboards/editdefinition/statistics/Statistics.scss
+++ b/src/components/keyboards/editdefinition/statistics/Statistics.scss
@@ -1,4 +1,4 @@
-@import 'src/variables';
+@use '../../../../variables';
 
 .edit-definition-statistics {
   &-container {

--- a/src/components/keyboards/header/Header.scss
+++ b/src/components/keyboards/header/Header.scss
@@ -1,4 +1,4 @@
-@import '../../../_variables.scss';
+@use '../../../_variables.scss';
 
 .keyboards-header {
   display: flex;
@@ -8,7 +8,7 @@
   flex-direction: row;
   align-items: center;
   margin: 0;
-  padding: 0 $space-m;
+  padding: 0 variables.$space-m;
   background: white;
   border-bottom: 1px solid rgba(0, 0, 0, 0.2);
   z-index: 2;

--- a/src/components/organizations/content/Content.scss
+++ b/src/components/organizations/content/Content.scss
@@ -1,4 +1,4 @@
-@import '../../../variables';
+@use '../../../variables';
 
 .organizations-content {
   display: flex;
@@ -14,7 +14,7 @@
     flex-direction: column;
     align-items: center;
     justify-content: center;
-    padding-top: $space-xl;
+    padding-top: variables.$space-xl;
     background-color: white;
     flex: 1 1;
     width: 100%;

--- a/src/components/organizations/editorganization/EditOrganization.scss
+++ b/src/components/organizations/editorganization/EditOrganization.scss
@@ -1,4 +1,4 @@
-@import '../../../variables';
+@use '../../../variables';
 
 .edit-organization-wrapper {
   position: fixed;

--- a/src/components/organizations/header/Header.scss
+++ b/src/components/organizations/header/Header.scss
@@ -1,4 +1,4 @@
-@import '../../../_variables.scss';
+@use '../../../_variables.scss';
 
 .organizations-header {
   display: flex;
@@ -8,7 +8,7 @@
   flex-direction: row;
   align-items: center;
   margin: 0;
-  padding: 0 $space-m;
+  padding: 0 variables.$space-m;
   background: white;
   border-bottom: 1px solid rgba(0, 0, 0, 0.2);
   z-index: 2;

--- a/src/components/organizations/organizationlist/OrganizationList.scss
+++ b/src/components/organizations/organizationlist/OrganizationList.scss
@@ -1,4 +1,4 @@
-@import '../../../variables';
+@use '../../../variables';
 
 .organization-list-wrapper {
   position: fixed;
@@ -61,7 +61,7 @@
   flex-direction: row;
   align-items: center;
   .status-badge-in-review {
-    background-color: $primary-pale;
+    background-color: variables.$primary-pale;
   }
 }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -5903,7 +5903,7 @@ __metadata:
     redux-devtools-extension: "npm:^2.13.8"
     redux-thunk: "npm:^2.3.0"
     reinvented-color-wheel: "npm:^0.2.10"
-    sass: "npm:^1.49.8"
+    sass: "npm:^1.77.4"
     sinon: "npm:^11.1.2"
     tss-react: "npm:^3.3.1"
     typescript: "npm:^5.4.5"
@@ -16010,7 +16010,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"sass@npm:^1.49.8":
+"sass@npm:^1.77.4":
   version: 1.77.4
   resolution: "sass@npm:1.77.4"
   dependencies:


### PR DESCRIPTION
1. sassのアップグレード
2. sass-migratorで`@use`へ移行するために、`_variables.scss`を絶対パスでiのimportを相対パスに変更
3. sass-migratorですべての`.scss`から再帰的に`@import`を削除
```bash
npx sass-migrator module --migrate-deps ./src/**/*.scss
```