### PR TITLE
Ignore warnings about source maps for mui.

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -13,6 +13,15 @@ export default defineConfig(({ mode }) => {
     build: {
       sourcemap: true,
       outDir: '../build',
+      rollupOptions: {
+        onwarn(warning, defaultHandler) {
+          // See: https://github.com/vitejs/vite/issues/15012
+          if (warning.code === 'SOURCEMAP_ERROR') {
+            return;
+          }
+          defaultHandler(warning);
+        },
+      },
     },
     server: {
       port: 3000,


### PR DESCRIPTION
This pull request ignores many warning outputs about source maps for mui during building. See: https://github.com/vitejs/vite/issues/15012