### PR TITLE
Reformat source codes with Prettier.

### DIFF
--- a/src/components/catalog/Catalog.tsx
+++ b/src/components/catalog/Catalog.tsx
@@ -2,7 +2,12 @@ import React, { useEffect, useState } from 'react';
 import { Button, CssBaseline } from '@mui/material';
 import Header from './header/Header.container';
 import Content from './content/Content.container';
-import { OptionsObject, ProviderContext, SnackbarKey, withSnackbar } from 'notistack';
+import {
+  OptionsObject,
+  ProviderContext,
+  SnackbarKey,
+  withSnackbar,
+} from 'notistack';
 import { CatalogActionsType, CatalogStateType } from './Catalog.container';
 import { NotificationItem } from '../../actions/actions';
 import CloseIcon from '@mui/icons-material/Close';

--- a/src/components/configure/Configure.tsx
+++ b/src/components/configure/Configure.tsx
@@ -1,7 +1,12 @@
 /* eslint-disable no-undef */
 import React, { useEffect, useState } from 'react';
 import './Configure.scss';
-import { OptionsObject, ProviderContext, SnackbarKey, withSnackbar } from 'notistack';
+import {
+  OptionsObject,
+  ProviderContext,
+  SnackbarKey,
+  withSnackbar,
+} from 'notistack';
 import Header from './header/Header.container';
 import Content from './content/Content.container';
 import {

--- a/src/components/keyboards/KeyboardDefinitionManagement.tsx
+++ b/src/components/keyboards/KeyboardDefinitionManagement.tsx
@@ -3,7 +3,12 @@ import {
   KeyboardDefinitionManagementActionsType,
   KeyboardDefinitionManagementStateType,
 } from './KeyboardDefinitionManagement.container';
-import { OptionsObject, ProviderContext, SnackbarKey, withSnackbar } from 'notistack';
+import {
+  OptionsObject,
+  ProviderContext,
+  SnackbarKey,
+  withSnackbar,
+} from 'notistack';
 import { NotificationItem } from '../../actions/actions';
 import { Button, CssBaseline } from '@mui/material';
 import CloseIcon from '@mui/icons-material/Close';

--- a/src/components/organizations/OrganizationManagement.tsx
+++ b/src/components/organizations/OrganizationManagement.tsx
@@ -2,7 +2,12 @@ import {
   OrganizationManagementActionsType,
   OrganizationManagementStateType,
 } from './OrganizationManagement.container';
-import { OptionsObject, ProviderContext, SnackbarKey, withSnackbar } from 'notistack';
+import {
+  OptionsObject,
+  ProviderContext,
+  SnackbarKey,
+  withSnackbar,
+} from 'notistack';
 import { NotificationItem } from '../../actions/actions';
 import React, { useEffect, useState } from 'react';
 import { Button, CssBaseline } from '@mui/material';

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -11,7 +11,7 @@ import reportWebVitals from './reportWebVitals';
 import OGP from './components/common/ogp/OGP.container';
 import { HelmetProvider } from 'react-helmet-async';
 import { createTheme, ThemeProvider } from '@mui/material/styles';
-import { createRoot } from "react-dom/client"
+import { createRoot } from 'react-dom/client';
 
 const store = createStore(
   reducers,
@@ -32,7 +32,7 @@ root.render(
         </ThemeProvider>
       </HelmetProvider>
     </React.StrictMode>
-  </Provider>,
+  </Provider>
 );
 
 // If you want to start measuring performance in your app, pass a function

--- a/src/services/labellang/AsciiLabelBelgian.ts
+++ b/src/services/labellang/AsciiLabelBelgian.ts
@@ -1,645 +1,644 @@
 import { AsciiLabel } from './AsciiLabel';
-        
+
 export const AsciiLabelBelgian: AsciiLabel[] = [
   {
-    "ascii": 0,
-    "code": 0,
-    "label": ""
+    ascii: 0,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 1,
-    "code": 0,
-    "label": ""
+    ascii: 1,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 2,
-    "code": 0,
-    "label": ""
+    ascii: 2,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 3,
-    "code": 0,
-    "label": ""
+    ascii: 3,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 4,
-    "code": 0,
-    "label": ""
+    ascii: 4,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 5,
-    "code": 0,
-    "label": ""
+    ascii: 5,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 6,
-    "code": 0,
-    "label": ""
+    ascii: 6,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 7,
-    "code": 0,
-    "label": ""
+    ascii: 7,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 8,
-    "code": 42,
-    "label": "back space"
+    ascii: 8,
+    code: 42,
+    label: 'back space',
   },
   {
-    "ascii": 9,
-    "code": 43,
-    "label": "tab"
+    ascii: 9,
+    code: 43,
+    label: 'tab',
   },
   {
-    "ascii": 10,
-    "code": 40,
-    "label": "enter"
+    ascii: 10,
+    code: 40,
+    label: 'enter',
   },
   {
-    "ascii": 11,
-    "code": 0,
-    "label": ""
+    ascii: 11,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 12,
-    "code": 0,
-    "label": ""
+    ascii: 12,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 13,
-    "code": 0,
-    "label": ""
+    ascii: 13,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 14,
-    "code": 0,
-    "label": ""
+    ascii: 14,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 15,
-    "code": 0,
-    "label": ""
+    ascii: 15,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 16,
-    "code": 0,
-    "label": ""
+    ascii: 16,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 17,
-    "code": 0,
-    "label": ""
+    ascii: 17,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 18,
-    "code": 0,
-    "label": ""
+    ascii: 18,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 19,
-    "code": 0,
-    "label": ""
+    ascii: 19,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 20,
-    "code": 0,
-    "label": ""
+    ascii: 20,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 21,
-    "code": 0,
-    "label": ""
+    ascii: 21,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 22,
-    "code": 0,
-    "label": ""
+    ascii: 22,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 23,
-    "code": 0,
-    "label": ""
+    ascii: 23,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 24,
-    "code": 0,
-    "label": ""
+    ascii: 24,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 25,
-    "code": 0,
-    "label": ""
+    ascii: 25,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 26,
-    "code": 0,
-    "label": ""
+    ascii: 26,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 27,
-    "code": 41,
-    "label": "esc"
+    ascii: 27,
+    code: 41,
+    label: 'esc',
   },
   {
-    "ascii": 28,
-    "code": 0,
-    "label": ""
+    ascii: 28,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 29,
-    "code": 0,
-    "label": ""
+    ascii: 29,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 30,
-    "code": 0,
-    "label": ""
+    ascii: 30,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 31,
-    "code": 0,
-    "label": ""
+    ascii: 31,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 32,
-    "code": 44,
-    "label": "space"
+    ascii: 32,
+    code: 44,
+    label: 'space',
   },
   {
-    "ascii": 33,
-    "code": 37,
-    "label": "!"
+    ascii: 33,
+    code: 37,
+    label: '!',
   },
   {
-    "ascii": 34,
-    "code": 32,
-    "label": "\""
+    ascii: 34,
+    code: 32,
+    label: '"',
   },
   {
-    "ascii": 35,
-    "code": 32,
-    "label": "\""
+    ascii: 35,
+    code: 32,
+    label: '"',
   },
   {
-    "ascii": 36,
-    "code": 48,
-    "label": "$"
+    ascii: 36,
+    code: 48,
+    label: '$',
   },
   {
-    "ascii": 37,
-    "code": 564,
-    "label": "%"
+    ascii: 37,
+    code: 564,
+    label: '%',
   },
   {
-    "ascii": 38,
-    "code": 30,
-    "label": "&"
+    ascii: 38,
+    code: 30,
+    label: '&',
   },
   {
-    "ascii": 39,
-    "code": 33,
-    "label": "'"
+    ascii: 39,
+    code: 33,
+    label: "'",
   },
   {
-    "ascii": 40,
-    "code": 34,
-    "label": "("
+    ascii: 40,
+    code: 34,
+    label: '(',
   },
   {
-    "ascii": 41,
-    "code": 45,
-    "label": ")"
+    ascii: 41,
+    code: 45,
+    label: ')',
   },
   {
-    "ascii": 42,
-    "code": 560,
-    "label": "*"
+    ascii: 42,
+    code: 560,
+    label: '*',
   },
   {
-    "ascii": 43,
-    "code": 568,
-    "label": "+"
+    ascii: 43,
+    code: 568,
+    label: '+',
   },
   {
-    "ascii": 44,
-    "code": 16,
-    "label": ","
+    ascii: 44,
+    code: 16,
+    label: ',',
   },
   {
-    "ascii": 45,
-    "code": 46,
-    "label": "-"
+    ascii: 45,
+    code: 46,
+    label: '-',
   },
   {
-    "ascii": 46,
-    "code": 566,
-    "label": "."
+    ascii: 46,
+    code: 566,
+    label: '.',
   },
   {
-    "ascii": 47,
-    "code": 567,
-    "label": "/"
+    ascii: 47,
+    code: 567,
+    label: '/',
   },
   {
-    "ascii": 48,
-    "code": 551,
-    "label": "0"
+    ascii: 48,
+    code: 551,
+    label: '0',
   },
   {
-    "ascii": 49,
-    "code": 542,
-    "label": "1"
+    ascii: 49,
+    code: 542,
+    label: '1',
   },
   {
-    "ascii": 50,
-    "code": 543,
-    "label": "2"
+    ascii: 50,
+    code: 543,
+    label: '2',
   },
   {
-    "ascii": 51,
-    "code": 544,
-    "label": "3"
+    ascii: 51,
+    code: 544,
+    label: '3',
   },
   {
-    "ascii": 52,
-    "code": 545,
-    "label": "4"
+    ascii: 52,
+    code: 545,
+    label: '4',
   },
   {
-    "ascii": 53,
-    "code": 546,
-    "label": "5"
+    ascii: 53,
+    code: 546,
+    label: '5',
   },
   {
-    "ascii": 54,
-    "code": 547,
-    "label": "6"
+    ascii: 54,
+    code: 547,
+    label: '6',
   },
   {
-    "ascii": 55,
-    "code": 548,
-    "label": "7"
+    ascii: 55,
+    code: 548,
+    label: '7',
   },
   {
-    "ascii": 56,
-    "code": 549,
-    "label": "8"
+    ascii: 56,
+    code: 549,
+    label: '8',
   },
   {
-    "ascii": 57,
-    "code": 550,
-    "label": "9"
+    ascii: 57,
+    code: 550,
+    label: '9',
   },
   {
-    "ascii": 58,
-    "code": 55,
-    "label": ":"
+    ascii: 58,
+    code: 55,
+    label: ':',
   },
   {
-    "ascii": 59,
-    "code": 54,
-    "label": ";"
+    ascii: 59,
+    code: 54,
+    label: ';',
   },
   {
-    "ascii": 60,
-    "code": 100,
-    "label": "<"
+    ascii: 60,
+    code: 100,
+    label: '<',
   },
   {
-    "ascii": 61,
-    "code": 56,
-    "label": "="
+    ascii: 61,
+    code: 56,
+    label: '=',
   },
   {
-    "ascii": 62,
-    "code": 612,
-    "label": ">"
+    ascii: 62,
+    code: 612,
+    label: '>',
   },
   {
-    "ascii": 63,
-    "code": 528,
-    "label": "?"
+    ascii: 63,
+    code: 528,
+    label: '?',
   },
   {
-    "ascii": 64,
-    "code": 31,
-    "label": "é"
+    ascii: 64,
+    code: 31,
+    label: 'é',
   },
   {
-    "ascii": 65,
-    "code": 532,
-    "label": "A"
+    ascii: 65,
+    code: 532,
+    label: 'A',
   },
   {
-    "ascii": 66,
-    "code": 517,
-    "label": "B"
+    ascii: 66,
+    code: 517,
+    label: 'B',
   },
   {
-    "ascii": 67,
-    "code": 518,
-    "label": "C"
+    ascii: 67,
+    code: 518,
+    label: 'C',
   },
   {
-    "ascii": 68,
-    "code": 519,
-    "label": "D"
+    ascii: 68,
+    code: 519,
+    label: 'D',
   },
   {
-    "ascii": 69,
-    "code": 520,
-    "label": "E"
+    ascii: 69,
+    code: 520,
+    label: 'E',
   },
   {
-    "ascii": 70,
-    "code": 521,
-    "label": "F"
+    ascii: 70,
+    code: 521,
+    label: 'F',
   },
   {
-    "ascii": 71,
-    "code": 522,
-    "label": "G"
+    ascii: 71,
+    code: 522,
+    label: 'G',
   },
   {
-    "ascii": 72,
-    "code": 523,
-    "label": "H"
+    ascii: 72,
+    code: 523,
+    label: 'H',
   },
   {
-    "ascii": 73,
-    "code": 524,
-    "label": "I"
+    ascii: 73,
+    code: 524,
+    label: 'I',
   },
   {
-    "ascii": 74,
-    "code": 525,
-    "label": "J"
+    ascii: 74,
+    code: 525,
+    label: 'J',
   },
   {
-    "ascii": 75,
-    "code": 526,
-    "label": "K"
+    ascii: 75,
+    code: 526,
+    label: 'K',
   },
   {
-    "ascii": 76,
-    "code": 527,
-    "label": "L"
+    ascii: 76,
+    code: 527,
+    label: 'L',
   },
   {
-    "ascii": 77,
-    "code": 563,
-    "label": "M"
+    ascii: 77,
+    code: 563,
+    label: 'M',
   },
   {
-    "ascii": 78,
-    "code": 529,
-    "label": "N"
+    ascii: 78,
+    code: 529,
+    label: 'N',
   },
   {
-    "ascii": 79,
-    "code": 530,
-    "label": "O"
+    ascii: 79,
+    code: 530,
+    label: 'O',
   },
   {
-    "ascii": 80,
-    "code": 531,
-    "label": "P"
+    ascii: 80,
+    code: 531,
+    label: 'P',
   },
   {
-    "ascii": 81,
-    "code": 516,
-    "label": "Q"
+    ascii: 81,
+    code: 516,
+    label: 'Q',
   },
   {
-    "ascii": 82,
-    "code": 533,
-    "label": "R"
+    ascii: 82,
+    code: 533,
+    label: 'R',
   },
   {
-    "ascii": 83,
-    "code": 534,
-    "label": "S"
+    ascii: 83,
+    code: 534,
+    label: 'S',
   },
   {
-    "ascii": 84,
-    "code": 535,
-    "label": "T"
+    ascii: 84,
+    code: 535,
+    label: 'T',
   },
   {
-    "ascii": 85,
-    "code": 536,
-    "label": "U"
+    ascii: 85,
+    code: 536,
+    label: 'U',
   },
   {
-    "ascii": 86,
-    "code": 537,
-    "label": "V"
+    ascii: 86,
+    code: 537,
+    label: 'V',
   },
   {
-    "ascii": 87,
-    "code": 541,
-    "label": "W"
+    ascii: 87,
+    code: 541,
+    label: 'W',
   },
   {
-    "ascii": 88,
-    "code": 539,
-    "label": "X"
+    ascii: 88,
+    code: 539,
+    label: 'X',
   },
   {
-    "ascii": 89,
-    "code": 540,
-    "label": "Y"
+    ascii: 89,
+    code: 540,
+    label: 'Y',
   },
   {
-    "ascii": 90,
-    "code": 538,
-    "label": "Z"
+    ascii: 90,
+    code: 538,
+    label: 'Z',
   },
   {
-    "ascii": 91,
-    "code": 47,
-    "label": "^ (dead)"
+    ascii: 91,
+    code: 47,
+    label: '^ (dead)',
   },
   {
-    "ascii": 92,
-    "code": 100,
-    "label": "<"
+    ascii: 92,
+    code: 100,
+    label: '<',
   },
   {
-    "ascii": 93,
-    "code": 48,
-    "label": "$"
+    ascii: 93,
+    code: 48,
+    label: '$',
   },
   {
-    "ascii": 94,
-    "code": 35,
-    "label": "§"
+    ascii: 94,
+    code: 35,
+    label: '§',
   },
   {
-    "ascii": 95,
-    "code": 558,
-    "label": "_"
+    ascii: 95,
+    code: 558,
+    label: '_',
   },
   {
-    "ascii": 96,
-    "code": 50,
-    "label": "µ"
+    ascii: 96,
+    code: 50,
+    label: 'µ',
   },
   {
-    "ascii": 97,
-    "code": 20,
-    "label": "a"
+    ascii: 97,
+    code: 20,
+    label: 'a',
   },
   {
-    "ascii": 98,
-    "code": 5,
-    "label": "b"
+    ascii: 98,
+    code: 5,
+    label: 'b',
   },
   {
-    "ascii": 99,
-    "code": 6,
-    "label": "c"
+    ascii: 99,
+    code: 6,
+    label: 'c',
   },
   {
-    "ascii": 100,
-    "code": 7,
-    "label": "d"
+    ascii: 100,
+    code: 7,
+    label: 'd',
   },
   {
-    "ascii": 101,
-    "code": 8,
-    "label": "e"
+    ascii: 101,
+    code: 8,
+    label: 'e',
   },
   {
-    "ascii": 102,
-    "code": 9,
-    "label": "f"
+    ascii: 102,
+    code: 9,
+    label: 'f',
   },
   {
-    "ascii": 103,
-    "code": 10,
-    "label": "g"
+    ascii: 103,
+    code: 10,
+    label: 'g',
   },
   {
-    "ascii": 104,
-    "code": 11,
-    "label": "h"
+    ascii: 104,
+    code: 11,
+    label: 'h',
   },
   {
-    "ascii": 105,
-    "code": 12,
-    "label": "i"
+    ascii: 105,
+    code: 12,
+    label: 'i',
   },
   {
-    "ascii": 106,
-    "code": 13,
-    "label": "j"
+    ascii: 106,
+    code: 13,
+    label: 'j',
   },
   {
-    "ascii": 107,
-    "code": 14,
-    "label": "k"
+    ascii: 107,
+    code: 14,
+    label: 'k',
   },
   {
-    "ascii": 108,
-    "code": 15,
-    "label": "l"
+    ascii: 108,
+    code: 15,
+    label: 'l',
   },
   {
-    "ascii": 109,
-    "code": 51,
-    "label": "m"
+    ascii: 109,
+    code: 51,
+    label: 'm',
   },
   {
-    "ascii": 110,
-    "code": 17,
-    "label": "n"
+    ascii: 110,
+    code: 17,
+    label: 'n',
   },
   {
-    "ascii": 111,
-    "code": 18,
-    "label": "o"
+    ascii: 111,
+    code: 18,
+    label: 'o',
   },
   {
-    "ascii": 112,
-    "code": 19,
-    "label": "p"
+    ascii: 112,
+    code: 19,
+    label: 'p',
   },
   {
-    "ascii": 113,
-    "code": 4,
-    "label": "q"
+    ascii: 113,
+    code: 4,
+    label: 'q',
   },
   {
-    "ascii": 114,
-    "code": 21,
-    "label": "r"
+    ascii: 114,
+    code: 21,
+    label: 'r',
   },
   {
-    "ascii": 115,
-    "code": 22,
-    "label": "s"
+    ascii: 115,
+    code: 22,
+    label: 's',
   },
   {
-    "ascii": 116,
-    "code": 23,
-    "label": "t"
+    ascii: 116,
+    code: 23,
+    label: 't',
   },
   {
-    "ascii": 117,
-    "code": 24,
-    "label": "u"
+    ascii: 117,
+    code: 24,
+    label: 'u',
   },
   {
-    "ascii": 118,
-    "code": 25,
-    "label": "v"
+    ascii: 118,
+    code: 25,
+    label: 'v',
   },
   {
-    "ascii": 119,
-    "code": 29,
-    "label": "w"
+    ascii: 119,
+    code: 29,
+    label: 'w',
   },
   {
-    "ascii": 120,
-    "code": 27,
-    "label": "x"
+    ascii: 120,
+    code: 27,
+    label: 'x',
   },
   {
-    "ascii": 121,
-    "code": 28,
-    "label": "y"
+    ascii: 121,
+    code: 28,
+    label: 'y',
   },
   {
-    "ascii": 122,
-    "code": 26,
-    "label": "z"
+    ascii: 122,
+    code: 26,
+    label: 'z',
   },
   {
-    "ascii": 123,
-    "code": 38,
-    "label": "ç"
+    ascii: 123,
+    code: 38,
+    label: 'ç',
   },
   {
-    "ascii": 124,
-    "code": 30,
-    "label": "&"
+    ascii: 124,
+    code: 30,
+    label: '&',
   },
   {
-    "ascii": 125,
-    "code": 39,
-    "label": "à"
+    ascii: 125,
+    code: 39,
+    label: 'à',
   },
   {
-    "ascii": 126,
-    "code": 56,
-    "label": "="
+    ascii: 126,
+    code: 56,
+    label: '=',
   },
   {
-    "ascii": 127,
-    "code": 76,
-    "label": "del"
-  }
+    ascii: 127,
+    code: 76,
+    label: 'del',
+  },
 ];
-    

--- a/src/services/labellang/AsciiLabelBepo.ts
+++ b/src/services/labellang/AsciiLabelBepo.ts
@@ -1,645 +1,644 @@
 import { AsciiLabel } from './AsciiLabel';
-        
+
 export const AsciiLabelBepo: AsciiLabel[] = [
   {
-    "ascii": 0,
-    "code": 0,
-    "label": ""
+    ascii: 0,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 1,
-    "code": 0,
-    "label": ""
+    ascii: 1,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 2,
-    "code": 0,
-    "label": ""
+    ascii: 2,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 3,
-    "code": 0,
-    "label": ""
+    ascii: 3,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 4,
-    "code": 0,
-    "label": ""
+    ascii: 4,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 5,
-    "code": 0,
-    "label": ""
+    ascii: 5,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 6,
-    "code": 0,
-    "label": ""
+    ascii: 6,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 7,
-    "code": 0,
-    "label": ""
+    ascii: 7,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 8,
-    "code": 42,
-    "label": "back space"
+    ascii: 8,
+    code: 42,
+    label: 'back space',
   },
   {
-    "ascii": 9,
-    "code": 43,
-    "label": "tab"
+    ascii: 9,
+    code: 43,
+    label: 'tab',
   },
   {
-    "ascii": 10,
-    "code": 40,
-    "label": "enter"
+    ascii: 10,
+    code: 40,
+    label: 'enter',
   },
   {
-    "ascii": 11,
-    "code": 0,
-    "label": ""
+    ascii: 11,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 12,
-    "code": 0,
-    "label": ""
+    ascii: 12,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 13,
-    "code": 0,
-    "label": ""
+    ascii: 13,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 14,
-    "code": 0,
-    "label": ""
+    ascii: 14,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 15,
-    "code": 0,
-    "label": ""
+    ascii: 15,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 16,
-    "code": 0,
-    "label": ""
+    ascii: 16,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 17,
-    "code": 0,
-    "label": ""
+    ascii: 17,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 18,
-    "code": 0,
-    "label": ""
+    ascii: 18,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 19,
-    "code": 0,
-    "label": ""
+    ascii: 19,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 20,
-    "code": 0,
-    "label": ""
+    ascii: 20,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 21,
-    "code": 0,
-    "label": ""
+    ascii: 21,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 22,
-    "code": 0,
-    "label": ""
+    ascii: 22,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 23,
-    "code": 0,
-    "label": ""
+    ascii: 23,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 24,
-    "code": 0,
-    "label": ""
+    ascii: 24,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 25,
-    "code": 0,
-    "label": ""
+    ascii: 25,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 26,
-    "code": 0,
-    "label": ""
+    ascii: 26,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 27,
-    "code": 41,
-    "label": "esc"
+    ascii: 27,
+    code: 41,
+    label: 'esc',
   },
   {
-    "ascii": 28,
-    "code": 0,
-    "label": ""
+    ascii: 28,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 29,
-    "code": 0,
-    "label": ""
+    ascii: 29,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 30,
-    "code": 0,
-    "label": ""
+    ascii: 30,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 31,
-    "code": 0,
-    "label": ""
+    ascii: 31,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 32,
-    "code": 44,
-    "label": "space"
+    ascii: 32,
+    code: 44,
+    label: 'space',
   },
   {
-    "ascii": 33,
-    "code": 540,
-    "label": "!"
+    ascii: 33,
+    code: 540,
+    label: '!',
   },
   {
-    "ascii": 34,
-    "code": 30,
-    "label": "\""
+    ascii: 34,
+    code: 30,
+    label: '"',
   },
   {
-    "ascii": 35,
-    "code": 565,
-    "label": "#"
+    ascii: 35,
+    code: 565,
+    label: '#',
   },
   {
-    "ascii": 36,
-    "code": 53,
-    "label": "$"
+    ascii: 36,
+    code: 53,
+    label: '$',
   },
   {
-    "ascii": 37,
-    "code": 46,
-    "label": "%"
+    ascii: 37,
+    code: 46,
+    label: '%',
   },
   {
-    "ascii": 38,
-    "code": 8,
-    "label": "p"
+    ascii: 38,
+    code: 8,
+    label: 'p',
   },
   {
-    "ascii": 39,
-    "code": 17,
-    "label": "'"
+    ascii: 39,
+    code: 17,
+    label: "'",
   },
   {
-    "ascii": 40,
-    "code": 33,
-    "label": "("
+    ascii: 40,
+    code: 33,
+    label: '(',
   },
   {
-    "ascii": 41,
-    "code": 34,
-    "label": ")"
+    ascii: 41,
+    code: 34,
+    label: ')',
   },
   {
-    "ascii": 42,
-    "code": 39,
-    "label": "*"
+    ascii: 42,
+    code: 39,
+    label: '*',
   },
   {
-    "ascii": 43,
-    "code": 36,
-    "label": "+"
+    ascii: 43,
+    code: 36,
+    label: '+',
   },
   {
-    "ascii": 44,
-    "code": 10,
-    "label": ","
+    ascii: 44,
+    code: 10,
+    label: ',',
   },
   {
-    "ascii": 45,
-    "code": 37,
-    "label": "-"
+    ascii: 45,
+    code: 37,
+    label: '-',
   },
   {
-    "ascii": 46,
-    "code": 25,
-    "label": "."
+    ascii: 46,
+    code: 25,
+    label: '.',
   },
   {
-    "ascii": 47,
-    "code": 38,
-    "label": "/"
+    ascii: 47,
+    code: 38,
+    label: '/',
   },
   {
-    "ascii": 48,
-    "code": 551,
-    "label": "0"
+    ascii: 48,
+    code: 551,
+    label: '0',
   },
   {
-    "ascii": 49,
-    "code": 542,
-    "label": "1"
+    ascii: 49,
+    code: 542,
+    label: '1',
   },
   {
-    "ascii": 50,
-    "code": 543,
-    "label": "2"
+    ascii: 50,
+    code: 543,
+    label: '2',
   },
   {
-    "ascii": 51,
-    "code": 544,
-    "label": "3"
+    ascii: 51,
+    code: 544,
+    label: '3',
   },
   {
-    "ascii": 52,
-    "code": 545,
-    "label": "4"
+    ascii: 52,
+    code: 545,
+    label: '4',
   },
   {
-    "ascii": 53,
-    "code": 546,
-    "label": "5"
+    ascii: 53,
+    code: 546,
+    label: '5',
   },
   {
-    "ascii": 54,
-    "code": 547,
-    "label": "6"
+    ascii: 54,
+    code: 547,
+    label: '6',
   },
   {
-    "ascii": 55,
-    "code": 548,
-    "label": "7"
+    ascii: 55,
+    code: 548,
+    label: '7',
   },
   {
-    "ascii": 56,
-    "code": 549,
-    "label": "8"
+    ascii: 56,
+    code: 549,
+    label: '8',
   },
   {
-    "ascii": 57,
-    "code": 550,
-    "label": "9"
+    ascii: 57,
+    code: 550,
+    label: '9',
   },
   {
-    "ascii": 58,
-    "code": 537,
-    "label": ":"
+    ascii: 58,
+    code: 537,
+    label: ':',
   },
   {
-    "ascii": 59,
-    "code": 522,
-    "label": ";"
+    ascii: 59,
+    code: 522,
+    label: ';',
   },
   {
-    "ascii": 60,
-    "code": 31,
-    "label": "«"
+    ascii: 60,
+    code: 31,
+    label: '«',
   },
   {
-    "ascii": 61,
-    "code": 45,
-    "label": "="
+    ascii: 61,
+    code: 45,
+    label: '=',
   },
   {
-    "ascii": 62,
-    "code": 32,
-    "label": "»"
+    ascii: 62,
+    code: 32,
+    label: '»',
   },
   {
-    "ascii": 63,
-    "code": 529,
-    "label": "?"
+    ascii: 63,
+    code: 529,
+    label: '?',
   },
   {
-    "ascii": 64,
-    "code": 35,
-    "label": "@"
+    ascii: 64,
+    code: 35,
+    label: '@',
   },
   {
-    "ascii": 65,
-    "code": 516,
-    "label": "A"
+    ascii: 65,
+    code: 516,
+    label: 'A',
   },
   {
-    "ascii": 66,
-    "code": 532,
-    "label": "B"
+    ascii: 66,
+    code: 532,
+    label: 'B',
   },
   {
-    "ascii": 67,
-    "code": 523,
-    "label": "C"
+    ascii: 67,
+    code: 523,
+    label: 'C',
   },
   {
-    "ascii": 68,
-    "code": 524,
-    "label": "D"
+    ascii: 68,
+    code: 524,
+    label: 'D',
   },
   {
-    "ascii": 69,
-    "code": 521,
-    "label": "E"
+    ascii: 69,
+    code: 521,
+    label: 'E',
   },
   {
-    "ascii": 70,
-    "code": 568,
-    "label": "F"
+    ascii: 70,
+    code: 568,
+    label: 'F',
   },
   {
-    "ascii": 71,
-    "code": 566,
-    "label": "G"
+    ascii: 71,
+    code: 566,
+    label: 'G',
   },
   {
-    "ascii": 72,
-    "code": 567,
-    "label": "H"
+    ascii: 72,
+    code: 567,
+    label: 'H',
   },
   {
-    "ascii": 73,
-    "code": 519,
-    "label": "I"
+    ascii: 73,
+    code: 519,
+    label: 'I',
   },
   {
-    "ascii": 74,
-    "code": 531,
-    "label": "J"
+    ascii: 74,
+    code: 531,
+    label: 'J',
   },
   {
-    "ascii": 75,
-    "code": 517,
-    "label": "K"
+    ascii: 75,
+    code: 517,
+    label: 'K',
   },
   {
-    "ascii": 76,
-    "code": 530,
-    "label": "L"
+    ascii: 76,
+    code: 530,
+    label: 'L',
   },
   {
-    "ascii": 77,
-    "code": 564,
-    "label": "M"
+    ascii: 77,
+    code: 564,
+    label: 'M',
   },
   {
-    "ascii": 78,
-    "code": 563,
-    "label": "N"
+    ascii: 78,
+    code: 563,
+    label: 'N',
   },
   {
-    "ascii": 79,
-    "code": 533,
-    "label": "O"
+    ascii: 79,
+    code: 533,
+    label: 'O',
   },
   {
-    "ascii": 80,
-    "code": 520,
-    "label": "P"
+    ascii: 80,
+    code: 520,
+    label: 'P',
   },
   {
-    "ascii": 81,
-    "code": 528,
-    "label": "Q"
+    ascii: 81,
+    code: 528,
+    label: 'Q',
   },
   {
-    "ascii": 82,
-    "code": 527,
-    "label": "R"
+    ascii: 82,
+    code: 527,
+    label: 'R',
   },
   {
-    "ascii": 83,
-    "code": 526,
-    "label": "S"
+    ascii: 83,
+    code: 526,
+    label: 'S',
   },
   {
-    "ascii": 84,
-    "code": 525,
-    "label": "T"
+    ascii: 84,
+    code: 525,
+    label: 'T',
   },
   {
-    "ascii": 85,
-    "code": 534,
-    "label": "U"
+    ascii: 85,
+    code: 534,
+    label: 'U',
   },
   {
-    "ascii": 86,
-    "code": 536,
-    "label": "V"
+    ascii: 86,
+    code: 536,
+    label: 'V',
   },
   {
-    "ascii": 87,
-    "code": 560,
-    "label": "W"
+    ascii: 87,
+    code: 560,
+    label: 'W',
   },
   {
-    "ascii": 88,
-    "code": 518,
-    "label": "X"
+    ascii: 88,
+    code: 518,
+    label: 'X',
   },
   {
-    "ascii": 89,
-    "code": 539,
-    "label": "Y"
+    ascii: 89,
+    code: 539,
+    label: 'Y',
   },
   {
-    "ascii": 90,
-    "code": 559,
-    "label": "Z"
+    ascii: 90,
+    code: 559,
+    label: 'Z',
   },
   {
-    "ascii": 91,
-    "code": 33,
-    "label": "("
+    ascii: 91,
+    code: 33,
+    label: '(',
   },
   {
-    "ascii": 92,
-    "code": 29,
-    "label": "À"
+    ascii: 92,
+    code: 29,
+    label: 'À',
   },
   {
-    "ascii": 93,
-    "code": 34,
-    "label": ")"
+    ascii: 93,
+    code: 34,
+    label: ')',
   },
   {
-    "ascii": 94,
-    "code": 35,
-    "label": "@"
+    ascii: 94,
+    code: 35,
+    label: '@',
   },
   {
-    "ascii": 95,
-    "code": 44,
-    "label": "space"
+    ascii: 95,
+    code: 44,
+    label: 'space',
   },
   {
-    "ascii": 96,
-    "code": 558,
-    "label": "`"
+    ascii: 96,
+    code: 558,
+    label: '`',
   },
   {
-    "ascii": 97,
-    "code": 4,
-    "label": "a"
+    ascii: 97,
+    code: 4,
+    label: 'a',
   },
   {
-    "ascii": 98,
-    "code": 20,
-    "label": "b"
+    ascii: 98,
+    code: 20,
+    label: 'b',
   },
   {
-    "ascii": 99,
-    "code": 11,
-    "label": "c"
+    ascii: 99,
+    code: 11,
+    label: 'c',
   },
   {
-    "ascii": 100,
-    "code": 12,
-    "label": "d"
+    ascii: 100,
+    code: 12,
+    label: 'd',
   },
   {
-    "ascii": 101,
-    "code": 9,
-    "label": "e"
+    ascii: 101,
+    code: 9,
+    label: 'e',
   },
   {
-    "ascii": 102,
-    "code": 56,
-    "label": "f"
+    ascii: 102,
+    code: 56,
+    label: 'f',
   },
   {
-    "ascii": 103,
-    "code": 54,
-    "label": "g"
+    ascii: 103,
+    code: 54,
+    label: 'g',
   },
   {
-    "ascii": 104,
-    "code": 55,
-    "label": "h"
+    ascii: 104,
+    code: 55,
+    label: 'h',
   },
   {
-    "ascii": 105,
-    "code": 7,
-    "label": "i"
+    ascii: 105,
+    code: 7,
+    label: 'i',
   },
   {
-    "ascii": 106,
-    "code": 19,
-    "label": "j"
+    ascii: 106,
+    code: 19,
+    label: 'j',
   },
   {
-    "ascii": 107,
-    "code": 5,
-    "label": "k"
+    ascii: 107,
+    code: 5,
+    label: 'k',
   },
   {
-    "ascii": 108,
-    "code": 18,
-    "label": "l"
+    ascii: 108,
+    code: 18,
+    label: 'l',
   },
   {
-    "ascii": 109,
-    "code": 52,
-    "label": "m"
+    ascii: 109,
+    code: 52,
+    label: 'm',
   },
   {
-    "ascii": 110,
-    "code": 51,
-    "label": "n"
+    ascii: 110,
+    code: 51,
+    label: 'n',
   },
   {
-    "ascii": 111,
-    "code": 21,
-    "label": "o"
+    ascii: 111,
+    code: 21,
+    label: 'o',
   },
   {
-    "ascii": 112,
-    "code": 8,
-    "label": "p"
+    ascii: 112,
+    code: 8,
+    label: 'p',
   },
   {
-    "ascii": 113,
-    "code": 16,
-    "label": "q"
+    ascii: 113,
+    code: 16,
+    label: 'q',
   },
   {
-    "ascii": 114,
-    "code": 15,
-    "label": "r"
+    ascii: 114,
+    code: 15,
+    label: 'r',
   },
   {
-    "ascii": 115,
-    "code": 14,
-    "label": "s"
+    ascii: 115,
+    code: 14,
+    label: 's',
   },
   {
-    "ascii": 116,
-    "code": 13,
-    "label": "t"
+    ascii: 116,
+    code: 13,
+    label: 't',
   },
   {
-    "ascii": 117,
-    "code": 22,
-    "label": "u"
+    ascii: 117,
+    code: 22,
+    label: 'u',
   },
   {
-    "ascii": 118,
-    "code": 24,
-    "label": "v"
+    ascii: 118,
+    code: 24,
+    label: 'v',
   },
   {
-    "ascii": 119,
-    "code": 48,
-    "label": "w"
+    ascii: 119,
+    code: 48,
+    label: 'w',
   },
   {
-    "ascii": 120,
-    "code": 6,
-    "label": "x"
+    ascii: 120,
+    code: 6,
+    label: 'x',
   },
   {
-    "ascii": 121,
-    "code": 27,
-    "label": "y"
+    ascii: 121,
+    code: 27,
+    label: 'y',
   },
   {
-    "ascii": 122,
-    "code": 47,
-    "label": "z"
+    ascii: 122,
+    code: 47,
+    label: 'z',
   },
   {
-    "ascii": 123,
-    "code": 27,
-    "label": "y"
+    ascii: 123,
+    code: 27,
+    label: 'y',
   },
   {
-    "ascii": 124,
-    "code": 20,
-    "label": "b"
+    ascii: 124,
+    code: 20,
+    label: 'b',
   },
   {
-    "ascii": 125,
-    "code": 6,
-    "label": "x"
+    ascii: 125,
+    code: 6,
+    label: 'x',
   },
   {
-    "ascii": 126,
-    "code": 5,
-    "label": "k"
+    ascii: 126,
+    code: 5,
+    label: 'k',
   },
   {
-    "ascii": 127,
-    "code": 76,
-    "label": "del"
-  }
+    ascii: 127,
+    code: 76,
+    label: 'del',
+  },
 ];
-    

--- a/src/services/labellang/AsciiLabelBr_abnt2.ts
+++ b/src/services/labellang/AsciiLabelBr_abnt2.ts
@@ -1,645 +1,644 @@
 import { AsciiLabel } from './AsciiLabel';
-        
+
 export const AsciiLabelBr_abnt2: AsciiLabel[] = [
   {
-    "ascii": 0,
-    "code": 0,
-    "label": ""
+    ascii: 0,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 1,
-    "code": 0,
-    "label": ""
+    ascii: 1,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 2,
-    "code": 0,
-    "label": ""
+    ascii: 2,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 3,
-    "code": 0,
-    "label": ""
+    ascii: 3,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 4,
-    "code": 0,
-    "label": ""
+    ascii: 4,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 5,
-    "code": 0,
-    "label": ""
+    ascii: 5,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 6,
-    "code": 0,
-    "label": ""
+    ascii: 6,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 7,
-    "code": 0,
-    "label": ""
+    ascii: 7,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 8,
-    "code": 42,
-    "label": "back space"
+    ascii: 8,
+    code: 42,
+    label: 'back space',
   },
   {
-    "ascii": 9,
-    "code": 43,
-    "label": "tab"
+    ascii: 9,
+    code: 43,
+    label: 'tab',
   },
   {
-    "ascii": 10,
-    "code": 40,
-    "label": "enter"
+    ascii: 10,
+    code: 40,
+    label: 'enter',
   },
   {
-    "ascii": 11,
-    "code": 0,
-    "label": ""
+    ascii: 11,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 12,
-    "code": 0,
-    "label": ""
+    ascii: 12,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 13,
-    "code": 0,
-    "label": ""
+    ascii: 13,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 14,
-    "code": 0,
-    "label": ""
+    ascii: 14,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 15,
-    "code": 0,
-    "label": ""
+    ascii: 15,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 16,
-    "code": 0,
-    "label": ""
+    ascii: 16,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 17,
-    "code": 0,
-    "label": ""
+    ascii: 17,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 18,
-    "code": 0,
-    "label": ""
+    ascii: 18,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 19,
-    "code": 0,
-    "label": ""
+    ascii: 19,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 20,
-    "code": 0,
-    "label": ""
+    ascii: 20,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 21,
-    "code": 0,
-    "label": ""
+    ascii: 21,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 22,
-    "code": 0,
-    "label": ""
+    ascii: 22,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 23,
-    "code": 0,
-    "label": ""
+    ascii: 23,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 24,
-    "code": 0,
-    "label": ""
+    ascii: 24,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 25,
-    "code": 0,
-    "label": ""
+    ascii: 25,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 26,
-    "code": 0,
-    "label": ""
+    ascii: 26,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 27,
-    "code": 41,
-    "label": "esc"
+    ascii: 27,
+    code: 41,
+    label: 'esc',
   },
   {
-    "ascii": 28,
-    "code": 0,
-    "label": ""
+    ascii: 28,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 29,
-    "code": 0,
-    "label": ""
+    ascii: 29,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 30,
-    "code": 0,
-    "label": ""
+    ascii: 30,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 31,
-    "code": 0,
-    "label": ""
+    ascii: 31,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 32,
-    "code": 44,
-    "label": "space"
+    ascii: 32,
+    code: 44,
+    label: 'space',
   },
   {
-    "ascii": 33,
-    "code": 542,
-    "label": "!"
+    ascii: 33,
+    code: 542,
+    label: '!',
   },
   {
-    "ascii": 34,
-    "code": 565,
-    "label": "\""
+    ascii: 34,
+    code: 565,
+    label: '"',
   },
   {
-    "ascii": 35,
-    "code": 544,
-    "label": "#"
+    ascii: 35,
+    code: 544,
+    label: '#',
   },
   {
-    "ascii": 36,
-    "code": 545,
-    "label": "$"
+    ascii: 36,
+    code: 545,
+    label: '$',
   },
   {
-    "ascii": 37,
-    "code": 546,
-    "label": "%"
+    ascii: 37,
+    code: 546,
+    label: '%',
   },
   {
-    "ascii": 38,
-    "code": 548,
-    "label": "&"
+    ascii: 38,
+    code: 548,
+    label: '&',
   },
   {
-    "ascii": 39,
-    "code": 53,
-    "label": "'"
+    ascii: 39,
+    code: 53,
+    label: "'",
   },
   {
-    "ascii": 40,
-    "code": 550,
-    "label": "("
+    ascii: 40,
+    code: 550,
+    label: '(',
   },
   {
-    "ascii": 41,
-    "code": 551,
-    "label": ")"
+    ascii: 41,
+    code: 551,
+    label: ')',
   },
   {
-    "ascii": 42,
-    "code": 549,
-    "label": "*"
+    ascii: 42,
+    code: 549,
+    label: '*',
   },
   {
-    "ascii": 43,
-    "code": 558,
-    "label": "+"
+    ascii: 43,
+    code: 558,
+    label: '+',
   },
   {
-    "ascii": 44,
-    "code": 54,
-    "label": ","
+    ascii: 44,
+    code: 54,
+    label: ',',
   },
   {
-    "ascii": 45,
-    "code": 45,
-    "label": "-"
+    ascii: 45,
+    code: 45,
+    label: '-',
   },
   {
-    "ascii": 46,
-    "code": 55,
-    "label": "."
+    ascii: 46,
+    code: 55,
+    label: '.',
   },
   {
-    "ascii": 47,
-    "code": 135,
-    "label": "/"
+    ascii: 47,
+    code: 135,
+    label: '/',
   },
   {
-    "ascii": 48,
-    "code": 39,
-    "label": "0"
+    ascii: 48,
+    code: 39,
+    label: '0',
   },
   {
-    "ascii": 49,
-    "code": 30,
-    "label": "1"
+    ascii: 49,
+    code: 30,
+    label: '1',
   },
   {
-    "ascii": 50,
-    "code": 31,
-    "label": "2"
+    ascii: 50,
+    code: 31,
+    label: '2',
   },
   {
-    "ascii": 51,
-    "code": 32,
-    "label": "3"
+    ascii: 51,
+    code: 32,
+    label: '3',
   },
   {
-    "ascii": 52,
-    "code": 33,
-    "label": "4"
+    ascii: 52,
+    code: 33,
+    label: '4',
   },
   {
-    "ascii": 53,
-    "code": 34,
-    "label": "5"
+    ascii: 53,
+    code: 34,
+    label: '5',
   },
   {
-    "ascii": 54,
-    "code": 35,
-    "label": "6"
+    ascii: 54,
+    code: 35,
+    label: '6',
   },
   {
-    "ascii": 55,
-    "code": 36,
-    "label": "7"
+    ascii: 55,
+    code: 36,
+    label: '7',
   },
   {
-    "ascii": 56,
-    "code": 37,
-    "label": "8"
+    ascii: 56,
+    code: 37,
+    label: '8',
   },
   {
-    "ascii": 57,
-    "code": 38,
-    "label": "9"
+    ascii: 57,
+    code: 38,
+    label: '9',
   },
   {
-    "ascii": 58,
-    "code": 568,
-    "label": ":"
+    ascii: 58,
+    code: 568,
+    label: ':',
   },
   {
-    "ascii": 59,
-    "code": 56,
-    "label": ";"
+    ascii: 59,
+    code: 56,
+    label: ';',
   },
   {
-    "ascii": 60,
-    "code": 566,
-    "label": "<"
+    ascii: 60,
+    code: 566,
+    label: '<',
   },
   {
-    "ascii": 61,
-    "code": 46,
-    "label": "="
+    ascii: 61,
+    code: 46,
+    label: '=',
   },
   {
-    "ascii": 62,
-    "code": 567,
-    "label": ">"
+    ascii: 62,
+    code: 567,
+    label: '>',
   },
   {
-    "ascii": 63,
-    "code": 647,
-    "label": "?"
+    ascii: 63,
+    code: 647,
+    label: '?',
   },
   {
-    "ascii": 64,
-    "code": 543,
-    "label": "@"
+    ascii: 64,
+    code: 543,
+    label: '@',
   },
   {
-    "ascii": 65,
-    "code": 516,
-    "label": "A"
+    ascii: 65,
+    code: 516,
+    label: 'A',
   },
   {
-    "ascii": 66,
-    "code": 517,
-    "label": "B"
+    ascii: 66,
+    code: 517,
+    label: 'B',
   },
   {
-    "ascii": 67,
-    "code": 518,
-    "label": "C"
+    ascii: 67,
+    code: 518,
+    label: 'C',
   },
   {
-    "ascii": 68,
-    "code": 519,
-    "label": "D"
+    ascii: 68,
+    code: 519,
+    label: 'D',
   },
   {
-    "ascii": 69,
-    "code": 520,
-    "label": "E"
+    ascii: 69,
+    code: 520,
+    label: 'E',
   },
   {
-    "ascii": 70,
-    "code": 521,
-    "label": "F"
+    ascii: 70,
+    code: 521,
+    label: 'F',
   },
   {
-    "ascii": 71,
-    "code": 522,
-    "label": "G"
+    ascii: 71,
+    code: 522,
+    label: 'G',
   },
   {
-    "ascii": 72,
-    "code": 523,
-    "label": "H"
+    ascii: 72,
+    code: 523,
+    label: 'H',
   },
   {
-    "ascii": 73,
-    "code": 524,
-    "label": "I"
+    ascii: 73,
+    code: 524,
+    label: 'I',
   },
   {
-    "ascii": 74,
-    "code": 525,
-    "label": "J"
+    ascii: 74,
+    code: 525,
+    label: 'J',
   },
   {
-    "ascii": 75,
-    "code": 526,
-    "label": "K"
+    ascii: 75,
+    code: 526,
+    label: 'K',
   },
   {
-    "ascii": 76,
-    "code": 527,
-    "label": "L"
+    ascii: 76,
+    code: 527,
+    label: 'L',
   },
   {
-    "ascii": 77,
-    "code": 528,
-    "label": "M"
+    ascii: 77,
+    code: 528,
+    label: 'M',
   },
   {
-    "ascii": 78,
-    "code": 529,
-    "label": "N"
+    ascii: 78,
+    code: 529,
+    label: 'N',
   },
   {
-    "ascii": 79,
-    "code": 530,
-    "label": "O"
+    ascii: 79,
+    code: 530,
+    label: 'O',
   },
   {
-    "ascii": 80,
-    "code": 531,
-    "label": "P"
+    ascii: 80,
+    code: 531,
+    label: 'P',
   },
   {
-    "ascii": 81,
-    "code": 532,
-    "label": "Q"
+    ascii: 81,
+    code: 532,
+    label: 'Q',
   },
   {
-    "ascii": 82,
-    "code": 533,
-    "label": "R"
+    ascii: 82,
+    code: 533,
+    label: 'R',
   },
   {
-    "ascii": 83,
-    "code": 534,
-    "label": "S"
+    ascii: 83,
+    code: 534,
+    label: 'S',
   },
   {
-    "ascii": 84,
-    "code": 535,
-    "label": "T"
+    ascii: 84,
+    code: 535,
+    label: 'T',
   },
   {
-    "ascii": 85,
-    "code": 536,
-    "label": "U"
+    ascii: 85,
+    code: 536,
+    label: 'U',
   },
   {
-    "ascii": 86,
-    "code": 537,
-    "label": "V"
+    ascii: 86,
+    code: 537,
+    label: 'V',
   },
   {
-    "ascii": 87,
-    "code": 538,
-    "label": "W"
+    ascii: 87,
+    code: 538,
+    label: 'W',
   },
   {
-    "ascii": 88,
-    "code": 539,
-    "label": "X"
+    ascii: 88,
+    code: 539,
+    label: 'X',
   },
   {
-    "ascii": 89,
-    "code": 540,
-    "label": "Y"
+    ascii: 89,
+    code: 540,
+    label: 'Y',
   },
   {
-    "ascii": 90,
-    "code": 541,
-    "label": "Z"
+    ascii: 90,
+    code: 541,
+    label: 'Z',
   },
   {
-    "ascii": 91,
-    "code": 48,
-    "label": "["
+    ascii: 91,
+    code: 48,
+    label: '[',
   },
   {
-    "ascii": 92,
-    "code": 100,
-    "label": "(backslash)"
+    ascii: 92,
+    code: 100,
+    label: '(backslash)',
   },
   {
-    "ascii": 93,
-    "code": 49,
-    "label": "]"
+    ascii: 93,
+    code: 49,
+    label: ']',
   },
   {
-    "ascii": 94,
-    "code": 564,
-    "label": "^ (dead)"
+    ascii: 94,
+    code: 564,
+    label: '^ (dead)',
   },
   {
-    "ascii": 95,
-    "code": 557,
-    "label": "_"
+    ascii: 95,
+    code: 557,
+    label: '_',
   },
   {
-    "ascii": 96,
-    "code": 559,
-    "label": "` (dead)"
+    ascii: 96,
+    code: 559,
+    label: '` (dead)',
   },
   {
-    "ascii": 97,
-    "code": 4,
-    "label": "a"
+    ascii: 97,
+    code: 4,
+    label: 'a',
   },
   {
-    "ascii": 98,
-    "code": 5,
-    "label": "b"
+    ascii: 98,
+    code: 5,
+    label: 'b',
   },
   {
-    "ascii": 99,
-    "code": 6,
-    "label": "c"
+    ascii: 99,
+    code: 6,
+    label: 'c',
   },
   {
-    "ascii": 100,
-    "code": 7,
-    "label": "d"
+    ascii: 100,
+    code: 7,
+    label: 'd',
   },
   {
-    "ascii": 101,
-    "code": 8,
-    "label": "e"
+    ascii: 101,
+    code: 8,
+    label: 'e',
   },
   {
-    "ascii": 102,
-    "code": 9,
-    "label": "f"
+    ascii: 102,
+    code: 9,
+    label: 'f',
   },
   {
-    "ascii": 103,
-    "code": 10,
-    "label": "g"
+    ascii: 103,
+    code: 10,
+    label: 'g',
   },
   {
-    "ascii": 104,
-    "code": 11,
-    "label": "h"
+    ascii: 104,
+    code: 11,
+    label: 'h',
   },
   {
-    "ascii": 105,
-    "code": 12,
-    "label": "i"
+    ascii: 105,
+    code: 12,
+    label: 'i',
   },
   {
-    "ascii": 106,
-    "code": 13,
-    "label": "j"
+    ascii: 106,
+    code: 13,
+    label: 'j',
   },
   {
-    "ascii": 107,
-    "code": 14,
-    "label": "k"
+    ascii: 107,
+    code: 14,
+    label: 'k',
   },
   {
-    "ascii": 108,
-    "code": 15,
-    "label": "l"
+    ascii: 108,
+    code: 15,
+    label: 'l',
   },
   {
-    "ascii": 109,
-    "code": 16,
-    "label": "m"
+    ascii: 109,
+    code: 16,
+    label: 'm',
   },
   {
-    "ascii": 110,
-    "code": 17,
-    "label": "n"
+    ascii: 110,
+    code: 17,
+    label: 'n',
   },
   {
-    "ascii": 111,
-    "code": 18,
-    "label": "o"
+    ascii: 111,
+    code: 18,
+    label: 'o',
   },
   {
-    "ascii": 112,
-    "code": 19,
-    "label": "p"
+    ascii: 112,
+    code: 19,
+    label: 'p',
   },
   {
-    "ascii": 113,
-    "code": 20,
-    "label": "q"
+    ascii: 113,
+    code: 20,
+    label: 'q',
   },
   {
-    "ascii": 114,
-    "code": 21,
-    "label": "r"
+    ascii: 114,
+    code: 21,
+    label: 'r',
   },
   {
-    "ascii": 115,
-    "code": 22,
-    "label": "s"
+    ascii: 115,
+    code: 22,
+    label: 's',
   },
   {
-    "ascii": 116,
-    "code": 23,
-    "label": "t"
+    ascii: 116,
+    code: 23,
+    label: 't',
   },
   {
-    "ascii": 117,
-    "code": 24,
-    "label": "u"
+    ascii: 117,
+    code: 24,
+    label: 'u',
   },
   {
-    "ascii": 118,
-    "code": 25,
-    "label": "v"
+    ascii: 118,
+    code: 25,
+    label: 'v',
   },
   {
-    "ascii": 119,
-    "code": 26,
-    "label": "w"
+    ascii: 119,
+    code: 26,
+    label: 'w',
   },
   {
-    "ascii": 120,
-    "code": 27,
-    "label": "x"
+    ascii: 120,
+    code: 27,
+    label: 'x',
   },
   {
-    "ascii": 121,
-    "code": 28,
-    "label": "y"
+    ascii: 121,
+    code: 28,
+    label: 'y',
   },
   {
-    "ascii": 122,
-    "code": 29,
-    "label": "z"
+    ascii: 122,
+    code: 29,
+    label: 'z',
   },
   {
-    "ascii": 123,
-    "code": 560,
-    "label": "{"
+    ascii: 123,
+    code: 560,
+    label: '{',
   },
   {
-    "ascii": 124,
-    "code": 612,
-    "label": "|"
+    ascii: 124,
+    code: 612,
+    label: '|',
   },
   {
-    "ascii": 125,
-    "code": 561,
-    "label": "}"
+    ascii: 125,
+    code: 561,
+    label: '}',
   },
   {
-    "ascii": 126,
-    "code": 52,
-    "label": "~ (dead)"
+    ascii: 126,
+    code: 52,
+    label: '~ (dead)',
   },
   {
-    "ascii": 127,
-    "code": 76,
-    "label": "del"
-  }
+    ascii: 127,
+    code: 76,
+    label: 'del',
+  },
 ];
-    

--- a/src/services/labellang/AsciiLabelCanadian_multilingual.ts
+++ b/src/services/labellang/AsciiLabelCanadian_multilingual.ts
@@ -1,645 +1,644 @@
 import { AsciiLabel } from './AsciiLabel';
-        
+
 export const AsciiLabelCanadian_multilingual: AsciiLabel[] = [
   {
-    "ascii": 0,
-    "code": 0,
-    "label": ""
+    ascii: 0,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 1,
-    "code": 0,
-    "label": ""
+    ascii: 1,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 2,
-    "code": 0,
-    "label": ""
+    ascii: 2,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 3,
-    "code": 0,
-    "label": ""
+    ascii: 3,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 4,
-    "code": 0,
-    "label": ""
+    ascii: 4,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 5,
-    "code": 0,
-    "label": ""
+    ascii: 5,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 6,
-    "code": 0,
-    "label": ""
+    ascii: 6,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 7,
-    "code": 0,
-    "label": ""
+    ascii: 7,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 8,
-    "code": 42,
-    "label": "back space"
+    ascii: 8,
+    code: 42,
+    label: 'back space',
   },
   {
-    "ascii": 9,
-    "code": 43,
-    "label": "tab"
+    ascii: 9,
+    code: 43,
+    label: 'tab',
   },
   {
-    "ascii": 10,
-    "code": 40,
-    "label": "enter"
+    ascii: 10,
+    code: 40,
+    label: 'enter',
   },
   {
-    "ascii": 11,
-    "code": 0,
-    "label": ""
+    ascii: 11,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 12,
-    "code": 0,
-    "label": ""
+    ascii: 12,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 13,
-    "code": 0,
-    "label": ""
+    ascii: 13,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 14,
-    "code": 0,
-    "label": ""
+    ascii: 14,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 15,
-    "code": 0,
-    "label": ""
+    ascii: 15,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 16,
-    "code": 0,
-    "label": ""
+    ascii: 16,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 17,
-    "code": 0,
-    "label": ""
+    ascii: 17,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 18,
-    "code": 0,
-    "label": ""
+    ascii: 18,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 19,
-    "code": 0,
-    "label": ""
+    ascii: 19,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 20,
-    "code": 0,
-    "label": ""
+    ascii: 20,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 21,
-    "code": 0,
-    "label": ""
+    ascii: 21,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 22,
-    "code": 0,
-    "label": ""
+    ascii: 22,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 23,
-    "code": 0,
-    "label": ""
+    ascii: 23,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 24,
-    "code": 0,
-    "label": ""
+    ascii: 24,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 25,
-    "code": 0,
-    "label": ""
+    ascii: 25,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 26,
-    "code": 0,
-    "label": ""
+    ascii: 26,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 27,
-    "code": 41,
-    "label": "esc"
+    ascii: 27,
+    code: 41,
+    label: 'esc',
   },
   {
-    "ascii": 28,
-    "code": 0,
-    "label": ""
+    ascii: 28,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 29,
-    "code": 0,
-    "label": ""
+    ascii: 29,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 30,
-    "code": 0,
-    "label": ""
+    ascii: 30,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 31,
-    "code": 0,
-    "label": ""
+    ascii: 31,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 32,
-    "code": 44,
-    "label": "space"
+    ascii: 32,
+    code: 44,
+    label: 'space',
   },
   {
-    "ascii": 33,
-    "code": 542,
-    "label": "!"
+    ascii: 33,
+    code: 542,
+    label: '!',
   },
   {
-    "ascii": 34,
-    "code": 567,
-    "label": "\""
+    ascii: 34,
+    code: 567,
+    label: '"',
   },
   {
-    "ascii": 35,
-    "code": 544,
-    "label": "#"
+    ascii: 35,
+    code: 544,
+    label: '#',
   },
   {
-    "ascii": 36,
-    "code": 545,
-    "label": "$"
+    ascii: 36,
+    code: 545,
+    label: '$',
   },
   {
-    "ascii": 37,
-    "code": 546,
-    "label": "%"
+    ascii: 37,
+    code: 546,
+    label: '%',
   },
   {
-    "ascii": 38,
-    "code": 548,
-    "label": "&"
+    ascii: 38,
+    code: 548,
+    label: '&',
   },
   {
-    "ascii": 39,
-    "code": 566,
-    "label": "'"
+    ascii: 39,
+    code: 566,
+    label: "'",
   },
   {
-    "ascii": 40,
-    "code": 550,
-    "label": "("
+    ascii: 40,
+    code: 550,
+    label: '(',
   },
   {
-    "ascii": 41,
-    "code": 551,
-    "label": ")"
+    ascii: 41,
+    code: 551,
+    label: ')',
   },
   {
-    "ascii": 42,
-    "code": 549,
-    "label": "*"
+    ascii: 42,
+    code: 549,
+    label: '*',
   },
   {
-    "ascii": 43,
-    "code": 558,
-    "label": "+"
+    ascii: 43,
+    code: 558,
+    label: '+',
   },
   {
-    "ascii": 44,
-    "code": 54,
-    "label": ","
+    ascii: 44,
+    code: 54,
+    label: ',',
   },
   {
-    "ascii": 45,
-    "code": 45,
-    "label": "-"
+    ascii: 45,
+    code: 45,
+    label: '-',
   },
   {
-    "ascii": 46,
-    "code": 55,
-    "label": "."
+    ascii: 46,
+    code: 55,
+    label: '.',
   },
   {
-    "ascii": 47,
-    "code": 53,
-    "label": "/"
+    ascii: 47,
+    code: 53,
+    label: '/',
   },
   {
-    "ascii": 48,
-    "code": 39,
-    "label": "0"
+    ascii: 48,
+    code: 39,
+    label: '0',
   },
   {
-    "ascii": 49,
-    "code": 30,
-    "label": "1"
+    ascii: 49,
+    code: 30,
+    label: '1',
   },
   {
-    "ascii": 50,
-    "code": 31,
-    "label": "2"
+    ascii: 50,
+    code: 31,
+    label: '2',
   },
   {
-    "ascii": 51,
-    "code": 32,
-    "label": "3"
+    ascii: 51,
+    code: 32,
+    label: '3',
   },
   {
-    "ascii": 52,
-    "code": 33,
-    "label": "4"
+    ascii: 52,
+    code: 33,
+    label: '4',
   },
   {
-    "ascii": 53,
-    "code": 34,
-    "label": "5"
+    ascii: 53,
+    code: 34,
+    label: '5',
   },
   {
-    "ascii": 54,
-    "code": 35,
-    "label": "6"
+    ascii: 54,
+    code: 35,
+    label: '6',
   },
   {
-    "ascii": 55,
-    "code": 36,
-    "label": "7"
+    ascii: 55,
+    code: 36,
+    label: '7',
   },
   {
-    "ascii": 56,
-    "code": 37,
-    "label": "8"
+    ascii: 56,
+    code: 37,
+    label: '8',
   },
   {
-    "ascii": 57,
-    "code": 38,
-    "label": "9"
+    ascii: 57,
+    code: 38,
+    label: '9',
   },
   {
-    "ascii": 58,
-    "code": 563,
-    "label": ":"
+    ascii: 58,
+    code: 563,
+    label: ':',
   },
   {
-    "ascii": 59,
-    "code": 51,
-    "label": ";"
+    ascii: 59,
+    code: 51,
+    label: ';',
   },
   {
-    "ascii": 60,
-    "code": 55,
-    "label": "."
+    ascii: 60,
+    code: 55,
+    label: '.',
   },
   {
-    "ascii": 61,
-    "code": 46,
-    "label": "="
+    ascii: 61,
+    code: 46,
+    label: '=',
   },
   {
-    "ascii": 62,
-    "code": 54,
-    "label": ","
+    ascii: 62,
+    code: 54,
+    label: ',',
   },
   {
-    "ascii": 63,
-    "code": 547,
-    "label": "?"
+    ascii: 63,
+    code: 547,
+    label: '?',
   },
   {
-    "ascii": 64,
-    "code": 543,
-    "label": "@"
+    ascii: 64,
+    code: 543,
+    label: '@',
   },
   {
-    "ascii": 65,
-    "code": 516,
-    "label": "A"
+    ascii: 65,
+    code: 516,
+    label: 'A',
   },
   {
-    "ascii": 66,
-    "code": 517,
-    "label": "B"
+    ascii: 66,
+    code: 517,
+    label: 'B',
   },
   {
-    "ascii": 67,
-    "code": 518,
-    "label": "C"
+    ascii: 67,
+    code: 518,
+    label: 'C',
   },
   {
-    "ascii": 68,
-    "code": 519,
-    "label": "D"
+    ascii: 68,
+    code: 519,
+    label: 'D',
   },
   {
-    "ascii": 69,
-    "code": 520,
-    "label": "E"
+    ascii: 69,
+    code: 520,
+    label: 'E',
   },
   {
-    "ascii": 70,
-    "code": 521,
-    "label": "F"
+    ascii: 70,
+    code: 521,
+    label: 'F',
   },
   {
-    "ascii": 71,
-    "code": 522,
-    "label": "G"
+    ascii: 71,
+    code: 522,
+    label: 'G',
   },
   {
-    "ascii": 72,
-    "code": 523,
-    "label": "H"
+    ascii: 72,
+    code: 523,
+    label: 'H',
   },
   {
-    "ascii": 73,
-    "code": 524,
-    "label": "I"
+    ascii: 73,
+    code: 524,
+    label: 'I',
   },
   {
-    "ascii": 74,
-    "code": 525,
-    "label": "J"
+    ascii: 74,
+    code: 525,
+    label: 'J',
   },
   {
-    "ascii": 75,
-    "code": 526,
-    "label": "K"
+    ascii: 75,
+    code: 526,
+    label: 'K',
   },
   {
-    "ascii": 76,
-    "code": 527,
-    "label": "L"
+    ascii: 76,
+    code: 527,
+    label: 'L',
   },
   {
-    "ascii": 77,
-    "code": 528,
-    "label": "M"
+    ascii: 77,
+    code: 528,
+    label: 'M',
   },
   {
-    "ascii": 78,
-    "code": 529,
-    "label": "N"
+    ascii: 78,
+    code: 529,
+    label: 'N',
   },
   {
-    "ascii": 79,
-    "code": 530,
-    "label": "O"
+    ascii: 79,
+    code: 530,
+    label: 'O',
   },
   {
-    "ascii": 80,
-    "code": 531,
-    "label": "P"
+    ascii: 80,
+    code: 531,
+    label: 'P',
   },
   {
-    "ascii": 81,
-    "code": 532,
-    "label": "Q"
+    ascii: 81,
+    code: 532,
+    label: 'Q',
   },
   {
-    "ascii": 82,
-    "code": 533,
-    "label": "R"
+    ascii: 82,
+    code: 533,
+    label: 'R',
   },
   {
-    "ascii": 83,
-    "code": 534,
-    "label": "S"
+    ascii: 83,
+    code: 534,
+    label: 'S',
   },
   {
-    "ascii": 84,
-    "code": 535,
-    "label": "T"
+    ascii: 84,
+    code: 535,
+    label: 'T',
   },
   {
-    "ascii": 85,
-    "code": 536,
-    "label": "U"
+    ascii: 85,
+    code: 536,
+    label: 'U',
   },
   {
-    "ascii": 86,
-    "code": 537,
-    "label": "V"
+    ascii: 86,
+    code: 537,
+    label: 'V',
   },
   {
-    "ascii": 87,
-    "code": 538,
-    "label": "W"
+    ascii: 87,
+    code: 538,
+    label: 'W',
   },
   {
-    "ascii": 88,
-    "code": 539,
-    "label": "X"
+    ascii: 88,
+    code: 539,
+    label: 'X',
   },
   {
-    "ascii": 89,
-    "code": 540,
-    "label": "Y"
+    ascii: 89,
+    code: 540,
+    label: 'Y',
   },
   {
-    "ascii": 90,
-    "code": 541,
-    "label": "Z"
+    ascii: 90,
+    code: 541,
+    label: 'Z',
   },
   {
-    "ascii": 91,
-    "code": 38,
-    "label": "9"
+    ascii: 91,
+    code: 38,
+    label: '9',
   },
   {
-    "ascii": 92,
-    "code": 565,
-    "label": "(backslash)"
+    ascii: 92,
+    code: 565,
+    label: '(backslash)',
   },
   {
-    "ascii": 93,
-    "code": 39,
-    "label": "0"
+    ascii: 93,
+    code: 39,
+    label: '0',
   },
   {
-    "ascii": 94,
-    "code": 47,
-    "label": "^ (dead)"
+    ascii: 94,
+    code: 47,
+    label: '^ (dead)',
   },
   {
-    "ascii": 95,
-    "code": 557,
-    "label": "_"
+    ascii: 95,
+    code: 557,
+    label: '_',
   },
   {
-    "ascii": 96,
-    "code": 47,
-    "label": "^ (dead)"
+    ascii: 96,
+    code: 47,
+    label: '^ (dead)',
   },
   {
-    "ascii": 97,
-    "code": 4,
-    "label": "a"
+    ascii: 97,
+    code: 4,
+    label: 'a',
   },
   {
-    "ascii": 98,
-    "code": 5,
-    "label": "b"
+    ascii: 98,
+    code: 5,
+    label: 'b',
   },
   {
-    "ascii": 99,
-    "code": 6,
-    "label": "c"
+    ascii: 99,
+    code: 6,
+    label: 'c',
   },
   {
-    "ascii": 100,
-    "code": 7,
-    "label": "d"
+    ascii: 100,
+    code: 7,
+    label: 'd',
   },
   {
-    "ascii": 101,
-    "code": 8,
-    "label": "e"
+    ascii: 101,
+    code: 8,
+    label: 'e',
   },
   {
-    "ascii": 102,
-    "code": 9,
-    "label": "f"
+    ascii: 102,
+    code: 9,
+    label: 'f',
   },
   {
-    "ascii": 103,
-    "code": 10,
-    "label": "g"
+    ascii: 103,
+    code: 10,
+    label: 'g',
   },
   {
-    "ascii": 104,
-    "code": 11,
-    "label": "h"
+    ascii: 104,
+    code: 11,
+    label: 'h',
   },
   {
-    "ascii": 105,
-    "code": 12,
-    "label": "i"
+    ascii: 105,
+    code: 12,
+    label: 'i',
   },
   {
-    "ascii": 106,
-    "code": 13,
-    "label": "j"
+    ascii: 106,
+    code: 13,
+    label: 'j',
   },
   {
-    "ascii": 107,
-    "code": 14,
-    "label": "k"
+    ascii: 107,
+    code: 14,
+    label: 'k',
   },
   {
-    "ascii": 108,
-    "code": 15,
-    "label": "l"
+    ascii: 108,
+    code: 15,
+    label: 'l',
   },
   {
-    "ascii": 109,
-    "code": 16,
-    "label": "m"
+    ascii: 109,
+    code: 16,
+    label: 'm',
   },
   {
-    "ascii": 110,
-    "code": 17,
-    "label": "n"
+    ascii: 110,
+    code: 17,
+    label: 'n',
   },
   {
-    "ascii": 111,
-    "code": 18,
-    "label": "o"
+    ascii: 111,
+    code: 18,
+    label: 'o',
   },
   {
-    "ascii": 112,
-    "code": 19,
-    "label": "p"
+    ascii: 112,
+    code: 19,
+    label: 'p',
   },
   {
-    "ascii": 113,
-    "code": 20,
-    "label": "q"
+    ascii: 113,
+    code: 20,
+    label: 'q',
   },
   {
-    "ascii": 114,
-    "code": 21,
-    "label": "r"
+    ascii: 114,
+    code: 21,
+    label: 'r',
   },
   {
-    "ascii": 115,
-    "code": 22,
-    "label": "s"
+    ascii: 115,
+    code: 22,
+    label: 's',
   },
   {
-    "ascii": 116,
-    "code": 23,
-    "label": "t"
+    ascii: 116,
+    code: 23,
+    label: 't',
   },
   {
-    "ascii": 117,
-    "code": 24,
-    "label": "u"
+    ascii: 117,
+    code: 24,
+    label: 'u',
   },
   {
-    "ascii": 118,
-    "code": 25,
-    "label": "v"
+    ascii: 118,
+    code: 25,
+    label: 'v',
   },
   {
-    "ascii": 119,
-    "code": 26,
-    "label": "w"
+    ascii: 119,
+    code: 26,
+    label: 'w',
   },
   {
-    "ascii": 120,
-    "code": 27,
-    "label": "x"
+    ascii: 120,
+    code: 27,
+    label: 'x',
   },
   {
-    "ascii": 121,
-    "code": 28,
-    "label": "y"
+    ascii: 121,
+    code: 28,
+    label: 'y',
   },
   {
-    "ascii": 122,
-    "code": 29,
-    "label": "z"
+    ascii: 122,
+    code: 29,
+    label: 'z',
   },
   {
-    "ascii": 123,
-    "code": 36,
-    "label": "7"
+    ascii: 123,
+    code: 36,
+    label: '7',
   },
   {
-    "ascii": 124,
-    "code": 53,
-    "label": "/"
+    ascii: 124,
+    code: 53,
+    label: '/',
   },
   {
-    "ascii": 125,
-    "code": 37,
-    "label": "8"
+    ascii: 125,
+    code: 37,
+    label: '8',
   },
   {
-    "ascii": 126,
-    "code": 48,
-    "label": "Ç"
+    ascii: 126,
+    code: 48,
+    label: 'Ç',
   },
   {
-    "ascii": 127,
-    "code": 76,
-    "label": "del"
-  }
+    ascii: 127,
+    code: 76,
+    label: 'del',
+  },
 ];
-    

--- a/src/services/labellang/AsciiLabelColemak.ts
+++ b/src/services/labellang/AsciiLabelColemak.ts
@@ -1,645 +1,644 @@
 import { AsciiLabel } from './AsciiLabel';
-        
+
 export const AsciiLabelColemak: AsciiLabel[] = [
   {
-    "ascii": 0,
-    "code": 0,
-    "label": ""
+    ascii: 0,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 1,
-    "code": 0,
-    "label": ""
+    ascii: 1,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 2,
-    "code": 0,
-    "label": ""
+    ascii: 2,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 3,
-    "code": 0,
-    "label": ""
+    ascii: 3,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 4,
-    "code": 0,
-    "label": ""
+    ascii: 4,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 5,
-    "code": 0,
-    "label": ""
+    ascii: 5,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 6,
-    "code": 0,
-    "label": ""
+    ascii: 6,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 7,
-    "code": 0,
-    "label": ""
+    ascii: 7,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 8,
-    "code": 42,
-    "label": "back space"
+    ascii: 8,
+    code: 42,
+    label: 'back space',
   },
   {
-    "ascii": 9,
-    "code": 43,
-    "label": "tab"
+    ascii: 9,
+    code: 43,
+    label: 'tab',
   },
   {
-    "ascii": 10,
-    "code": 40,
-    "label": "enter"
+    ascii: 10,
+    code: 40,
+    label: 'enter',
   },
   {
-    "ascii": 11,
-    "code": 0,
-    "label": ""
+    ascii: 11,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 12,
-    "code": 0,
-    "label": ""
+    ascii: 12,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 13,
-    "code": 0,
-    "label": ""
+    ascii: 13,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 14,
-    "code": 0,
-    "label": ""
+    ascii: 14,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 15,
-    "code": 0,
-    "label": ""
+    ascii: 15,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 16,
-    "code": 0,
-    "label": ""
+    ascii: 16,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 17,
-    "code": 0,
-    "label": ""
+    ascii: 17,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 18,
-    "code": 0,
-    "label": ""
+    ascii: 18,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 19,
-    "code": 0,
-    "label": ""
+    ascii: 19,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 20,
-    "code": 0,
-    "label": ""
+    ascii: 20,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 21,
-    "code": 0,
-    "label": ""
+    ascii: 21,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 22,
-    "code": 0,
-    "label": ""
+    ascii: 22,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 23,
-    "code": 0,
-    "label": ""
+    ascii: 23,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 24,
-    "code": 0,
-    "label": ""
+    ascii: 24,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 25,
-    "code": 0,
-    "label": ""
+    ascii: 25,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 26,
-    "code": 0,
-    "label": ""
+    ascii: 26,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 27,
-    "code": 41,
-    "label": "esc"
+    ascii: 27,
+    code: 41,
+    label: 'esc',
   },
   {
-    "ascii": 28,
-    "code": 0,
-    "label": ""
+    ascii: 28,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 29,
-    "code": 0,
-    "label": ""
+    ascii: 29,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 30,
-    "code": 0,
-    "label": ""
+    ascii: 30,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 31,
-    "code": 0,
-    "label": ""
+    ascii: 31,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 32,
-    "code": 44,
-    "label": "space"
+    ascii: 32,
+    code: 44,
+    label: 'space',
   },
   {
-    "ascii": 33,
-    "code": 30,
-    "label": "1"
+    ascii: 33,
+    code: 30,
+    label: '1',
   },
   {
-    "ascii": 34,
-    "code": 52,
-    "label": "'"
+    ascii: 34,
+    code: 52,
+    label: "'",
   },
   {
-    "ascii": 35,
-    "code": 32,
-    "label": "3"
+    ascii: 35,
+    code: 32,
+    label: '3',
   },
   {
-    "ascii": 36,
-    "code": 33,
-    "label": "4"
+    ascii: 36,
+    code: 33,
+    label: '4',
   },
   {
-    "ascii": 37,
-    "code": 34,
-    "label": "5"
+    ascii: 37,
+    code: 34,
+    label: '5',
   },
   {
-    "ascii": 38,
-    "code": 36,
-    "label": "7"
+    ascii: 38,
+    code: 36,
+    label: '7',
   },
   {
-    "ascii": 39,
-    "code": 52,
-    "label": "'"
+    ascii: 39,
+    code: 52,
+    label: "'",
   },
   {
-    "ascii": 40,
-    "code": 38,
-    "label": "9"
+    ascii: 40,
+    code: 38,
+    label: '9',
   },
   {
-    "ascii": 41,
-    "code": 39,
-    "label": "0"
+    ascii: 41,
+    code: 39,
+    label: '0',
   },
   {
-    "ascii": 42,
-    "code": 37,
-    "label": "8"
+    ascii: 42,
+    code: 37,
+    label: '8',
   },
   {
-    "ascii": 43,
-    "code": 46,
-    "label": "="
+    ascii: 43,
+    code: 46,
+    label: '=',
   },
   {
-    "ascii": 44,
-    "code": 54,
-    "label": ","
+    ascii: 44,
+    code: 54,
+    label: ',',
   },
   {
-    "ascii": 45,
-    "code": 45,
-    "label": "-"
+    ascii: 45,
+    code: 45,
+    label: '-',
   },
   {
-    "ascii": 46,
-    "code": 55,
-    "label": "."
+    ascii: 46,
+    code: 55,
+    label: '.',
   },
   {
-    "ascii": 47,
-    "code": 56,
-    "label": "/"
+    ascii: 47,
+    code: 56,
+    label: '/',
   },
   {
-    "ascii": 48,
-    "code": 39,
-    "label": "0"
+    ascii: 48,
+    code: 39,
+    label: '0',
   },
   {
-    "ascii": 49,
-    "code": 30,
-    "label": "1"
+    ascii: 49,
+    code: 30,
+    label: '1',
   },
   {
-    "ascii": 50,
-    "code": 31,
-    "label": "2"
+    ascii: 50,
+    code: 31,
+    label: '2',
   },
   {
-    "ascii": 51,
-    "code": 32,
-    "label": "3"
+    ascii: 51,
+    code: 32,
+    label: '3',
   },
   {
-    "ascii": 52,
-    "code": 33,
-    "label": "4"
+    ascii: 52,
+    code: 33,
+    label: '4',
   },
   {
-    "ascii": 53,
-    "code": 34,
-    "label": "5"
+    ascii: 53,
+    code: 34,
+    label: '5',
   },
   {
-    "ascii": 54,
-    "code": 35,
-    "label": "6"
+    ascii: 54,
+    code: 35,
+    label: '6',
   },
   {
-    "ascii": 55,
-    "code": 36,
-    "label": "7"
+    ascii: 55,
+    code: 36,
+    label: '7',
   },
   {
-    "ascii": 56,
-    "code": 37,
-    "label": "8"
+    ascii: 56,
+    code: 37,
+    label: '8',
   },
   {
-    "ascii": 57,
-    "code": 38,
-    "label": "9"
+    ascii: 57,
+    code: 38,
+    label: '9',
   },
   {
-    "ascii": 58,
-    "code": 19,
-    "label": ";"
+    ascii: 58,
+    code: 19,
+    label: ';',
   },
   {
-    "ascii": 59,
-    "code": 19,
-    "label": ";"
+    ascii: 59,
+    code: 19,
+    label: ';',
   },
   {
-    "ascii": 60,
-    "code": 54,
-    "label": ","
+    ascii: 60,
+    code: 54,
+    label: ',',
   },
   {
-    "ascii": 61,
-    "code": 46,
-    "label": "="
+    ascii: 61,
+    code: 46,
+    label: '=',
   },
   {
-    "ascii": 62,
-    "code": 55,
-    "label": "."
+    ascii: 62,
+    code: 55,
+    label: '.',
   },
   {
-    "ascii": 63,
-    "code": 56,
-    "label": "/"
+    ascii: 63,
+    code: 56,
+    label: '/',
   },
   {
-    "ascii": 64,
-    "code": 31,
-    "label": "2"
+    ascii: 64,
+    code: 31,
+    label: '2',
   },
   {
-    "ascii": 65,
-    "code": 4,
-    "label": "a"
+    ascii: 65,
+    code: 4,
+    label: 'a',
   },
   {
-    "ascii": 66,
-    "code": 5,
-    "label": "b"
+    ascii: 66,
+    code: 5,
+    label: 'b',
   },
   {
-    "ascii": 67,
-    "code": 6,
-    "label": "c"
+    ascii: 67,
+    code: 6,
+    label: 'c',
   },
   {
-    "ascii": 68,
-    "code": 10,
-    "label": "d"
+    ascii: 68,
+    code: 10,
+    label: 'd',
   },
   {
-    "ascii": 69,
-    "code": 14,
-    "label": "e"
+    ascii: 69,
+    code: 14,
+    label: 'e',
   },
   {
-    "ascii": 70,
-    "code": 8,
-    "label": "f"
+    ascii: 70,
+    code: 8,
+    label: 'f',
   },
   {
-    "ascii": 71,
-    "code": 23,
-    "label": "g"
+    ascii: 71,
+    code: 23,
+    label: 'g',
   },
   {
-    "ascii": 72,
-    "code": 11,
-    "label": "h"
+    ascii: 72,
+    code: 11,
+    label: 'h',
   },
   {
-    "ascii": 73,
-    "code": 15,
-    "label": "i"
+    ascii: 73,
+    code: 15,
+    label: 'i',
   },
   {
-    "ascii": 74,
-    "code": 28,
-    "label": "j"
+    ascii: 74,
+    code: 28,
+    label: 'j',
   },
   {
-    "ascii": 75,
-    "code": 17,
-    "label": "k"
+    ascii: 75,
+    code: 17,
+    label: 'k',
   },
   {
-    "ascii": 76,
-    "code": 24,
-    "label": "l"
+    ascii: 76,
+    code: 24,
+    label: 'l',
   },
   {
-    "ascii": 77,
-    "code": 16,
-    "label": "m"
+    ascii: 77,
+    code: 16,
+    label: 'm',
   },
   {
-    "ascii": 78,
-    "code": 13,
-    "label": "n"
+    ascii: 78,
+    code: 13,
+    label: 'n',
   },
   {
-    "ascii": 79,
-    "code": 51,
-    "label": "o"
+    ascii: 79,
+    code: 51,
+    label: 'o',
   },
   {
-    "ascii": 80,
-    "code": 21,
-    "label": "p"
+    ascii: 80,
+    code: 21,
+    label: 'p',
   },
   {
-    "ascii": 81,
-    "code": 20,
-    "label": "q"
+    ascii: 81,
+    code: 20,
+    label: 'q',
   },
   {
-    "ascii": 82,
-    "code": 22,
-    "label": "r"
+    ascii: 82,
+    code: 22,
+    label: 'r',
   },
   {
-    "ascii": 83,
-    "code": 7,
-    "label": "s"
+    ascii: 83,
+    code: 7,
+    label: 's',
   },
   {
-    "ascii": 84,
-    "code": 9,
-    "label": "t"
+    ascii: 84,
+    code: 9,
+    label: 't',
   },
   {
-    "ascii": 85,
-    "code": 12,
-    "label": "u"
+    ascii: 85,
+    code: 12,
+    label: 'u',
   },
   {
-    "ascii": 86,
-    "code": 25,
-    "label": "v"
+    ascii: 86,
+    code: 25,
+    label: 'v',
   },
   {
-    "ascii": 87,
-    "code": 26,
-    "label": "w"
+    ascii: 87,
+    code: 26,
+    label: 'w',
   },
   {
-    "ascii": 88,
-    "code": 27,
-    "label": "x"
+    ascii: 88,
+    code: 27,
+    label: 'x',
   },
   {
-    "ascii": 89,
-    "code": 18,
-    "label": "y"
+    ascii: 89,
+    code: 18,
+    label: 'y',
   },
   {
-    "ascii": 90,
-    "code": 29,
-    "label": "z"
+    ascii: 90,
+    code: 29,
+    label: 'z',
   },
   {
-    "ascii": 91,
-    "code": 47,
-    "label": "["
+    ascii: 91,
+    code: 47,
+    label: '[',
   },
   {
-    "ascii": 92,
-    "code": 49,
-    "label": "(backslash)"
+    ascii: 92,
+    code: 49,
+    label: '(backslash)',
   },
   {
-    "ascii": 93,
-    "code": 48,
-    "label": "]"
+    ascii: 93,
+    code: 48,
+    label: ']',
   },
   {
-    "ascii": 94,
-    "code": 35,
-    "label": "6"
+    ascii: 94,
+    code: 35,
+    label: '6',
   },
   {
-    "ascii": 95,
-    "code": 45,
-    "label": "-"
+    ascii: 95,
+    code: 45,
+    label: '-',
   },
   {
-    "ascii": 96,
-    "code": 53,
-    "label": "`"
+    ascii: 96,
+    code: 53,
+    label: '`',
   },
   {
-    "ascii": 97,
-    "code": 4,
-    "label": "a"
+    ascii: 97,
+    code: 4,
+    label: 'a',
   },
   {
-    "ascii": 98,
-    "code": 5,
-    "label": "b"
+    ascii: 98,
+    code: 5,
+    label: 'b',
   },
   {
-    "ascii": 99,
-    "code": 6,
-    "label": "c"
+    ascii: 99,
+    code: 6,
+    label: 'c',
   },
   {
-    "ascii": 100,
-    "code": 10,
-    "label": "d"
+    ascii: 100,
+    code: 10,
+    label: 'd',
   },
   {
-    "ascii": 101,
-    "code": 14,
-    "label": "e"
+    ascii: 101,
+    code: 14,
+    label: 'e',
   },
   {
-    "ascii": 102,
-    "code": 8,
-    "label": "f"
+    ascii: 102,
+    code: 8,
+    label: 'f',
   },
   {
-    "ascii": 103,
-    "code": 23,
-    "label": "g"
+    ascii: 103,
+    code: 23,
+    label: 'g',
   },
   {
-    "ascii": 104,
-    "code": 11,
-    "label": "h"
+    ascii: 104,
+    code: 11,
+    label: 'h',
   },
   {
-    "ascii": 105,
-    "code": 15,
-    "label": "i"
+    ascii: 105,
+    code: 15,
+    label: 'i',
   },
   {
-    "ascii": 106,
-    "code": 28,
-    "label": "j"
+    ascii: 106,
+    code: 28,
+    label: 'j',
   },
   {
-    "ascii": 107,
-    "code": 17,
-    "label": "k"
+    ascii: 107,
+    code: 17,
+    label: 'k',
   },
   {
-    "ascii": 108,
-    "code": 24,
-    "label": "l"
+    ascii: 108,
+    code: 24,
+    label: 'l',
   },
   {
-    "ascii": 109,
-    "code": 16,
-    "label": "m"
+    ascii: 109,
+    code: 16,
+    label: 'm',
   },
   {
-    "ascii": 110,
-    "code": 13,
-    "label": "n"
+    ascii: 110,
+    code: 13,
+    label: 'n',
   },
   {
-    "ascii": 111,
-    "code": 51,
-    "label": "o"
+    ascii: 111,
+    code: 51,
+    label: 'o',
   },
   {
-    "ascii": 112,
-    "code": 21,
-    "label": "p"
+    ascii: 112,
+    code: 21,
+    label: 'p',
   },
   {
-    "ascii": 113,
-    "code": 20,
-    "label": "q"
+    ascii: 113,
+    code: 20,
+    label: 'q',
   },
   {
-    "ascii": 114,
-    "code": 22,
-    "label": "r"
+    ascii: 114,
+    code: 22,
+    label: 'r',
   },
   {
-    "ascii": 115,
-    "code": 7,
-    "label": "s"
+    ascii: 115,
+    code: 7,
+    label: 's',
   },
   {
-    "ascii": 116,
-    "code": 9,
-    "label": "t"
+    ascii: 116,
+    code: 9,
+    label: 't',
   },
   {
-    "ascii": 117,
-    "code": 12,
-    "label": "u"
+    ascii: 117,
+    code: 12,
+    label: 'u',
   },
   {
-    "ascii": 118,
-    "code": 25,
-    "label": "v"
+    ascii: 118,
+    code: 25,
+    label: 'v',
   },
   {
-    "ascii": 119,
-    "code": 26,
-    "label": "w"
+    ascii: 119,
+    code: 26,
+    label: 'w',
   },
   {
-    "ascii": 120,
-    "code": 27,
-    "label": "x"
+    ascii: 120,
+    code: 27,
+    label: 'x',
   },
   {
-    "ascii": 121,
-    "code": 18,
-    "label": "y"
+    ascii: 121,
+    code: 18,
+    label: 'y',
   },
   {
-    "ascii": 122,
-    "code": 29,
-    "label": "z"
+    ascii: 122,
+    code: 29,
+    label: 'z',
   },
   {
-    "ascii": 123,
-    "code": 47,
-    "label": "["
+    ascii: 123,
+    code: 47,
+    label: '[',
   },
   {
-    "ascii": 124,
-    "code": 49,
-    "label": "(backslash)"
+    ascii: 124,
+    code: 49,
+    label: '(backslash)',
   },
   {
-    "ascii": 125,
-    "code": 48,
-    "label": "]"
+    ascii: 125,
+    code: 48,
+    label: ']',
   },
   {
-    "ascii": 126,
-    "code": 53,
-    "label": "`"
+    ascii: 126,
+    code: 53,
+    label: '`',
   },
   {
-    "ascii": 127,
-    "code": 76,
-    "label": "del"
-  }
+    ascii: 127,
+    code: 76,
+    label: 'del',
+  },
 ];
-    

--- a/src/services/labellang/AsciiLabelCroatian.ts
+++ b/src/services/labellang/AsciiLabelCroatian.ts
@@ -1,645 +1,644 @@
 import { AsciiLabel } from './AsciiLabel';
-        
+
 export const AsciiLabelCroatian: AsciiLabel[] = [
   {
-    "ascii": 0,
-    "code": 0,
-    "label": ""
+    ascii: 0,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 1,
-    "code": 0,
-    "label": ""
+    ascii: 1,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 2,
-    "code": 0,
-    "label": ""
+    ascii: 2,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 3,
-    "code": 0,
-    "label": ""
+    ascii: 3,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 4,
-    "code": 0,
-    "label": ""
+    ascii: 4,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 5,
-    "code": 0,
-    "label": ""
+    ascii: 5,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 6,
-    "code": 0,
-    "label": ""
+    ascii: 6,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 7,
-    "code": 0,
-    "label": ""
+    ascii: 7,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 8,
-    "code": 42,
-    "label": "back space"
+    ascii: 8,
+    code: 42,
+    label: 'back space',
   },
   {
-    "ascii": 9,
-    "code": 43,
-    "label": "tab"
+    ascii: 9,
+    code: 43,
+    label: 'tab',
   },
   {
-    "ascii": 10,
-    "code": 40,
-    "label": "enter"
+    ascii: 10,
+    code: 40,
+    label: 'enter',
   },
   {
-    "ascii": 11,
-    "code": 0,
-    "label": ""
+    ascii: 11,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 12,
-    "code": 0,
-    "label": ""
+    ascii: 12,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 13,
-    "code": 0,
-    "label": ""
+    ascii: 13,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 14,
-    "code": 0,
-    "label": ""
+    ascii: 14,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 15,
-    "code": 0,
-    "label": ""
+    ascii: 15,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 16,
-    "code": 0,
-    "label": ""
+    ascii: 16,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 17,
-    "code": 0,
-    "label": ""
+    ascii: 17,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 18,
-    "code": 0,
-    "label": ""
+    ascii: 18,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 19,
-    "code": 0,
-    "label": ""
+    ascii: 19,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 20,
-    "code": 0,
-    "label": ""
+    ascii: 20,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 21,
-    "code": 0,
-    "label": ""
+    ascii: 21,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 22,
-    "code": 0,
-    "label": ""
+    ascii: 22,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 23,
-    "code": 0,
-    "label": ""
+    ascii: 23,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 24,
-    "code": 0,
-    "label": ""
+    ascii: 24,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 25,
-    "code": 0,
-    "label": ""
+    ascii: 25,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 26,
-    "code": 0,
-    "label": ""
+    ascii: 26,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 27,
-    "code": 41,
-    "label": "esc"
+    ascii: 27,
+    code: 41,
+    label: 'esc',
   },
   {
-    "ascii": 28,
-    "code": 0,
-    "label": ""
+    ascii: 28,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 29,
-    "code": 0,
-    "label": ""
+    ascii: 29,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 30,
-    "code": 0,
-    "label": ""
+    ascii: 30,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 31,
-    "code": 0,
-    "label": ""
+    ascii: 31,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 32,
-    "code": 44,
-    "label": "space"
+    ascii: 32,
+    code: 44,
+    label: 'space',
   },
   {
-    "ascii": 33,
-    "code": 542,
-    "label": "!"
+    ascii: 33,
+    code: 542,
+    label: '!',
   },
   {
-    "ascii": 34,
-    "code": 543,
-    "label": "\""
+    ascii: 34,
+    code: 543,
+    label: '"',
   },
   {
-    "ascii": 35,
-    "code": 544,
-    "label": "#"
+    ascii: 35,
+    code: 544,
+    label: '#',
   },
   {
-    "ascii": 36,
-    "code": 545,
-    "label": "$"
+    ascii: 36,
+    code: 545,
+    label: '$',
   },
   {
-    "ascii": 37,
-    "code": 546,
-    "label": "%"
+    ascii: 37,
+    code: 546,
+    label: '%',
   },
   {
-    "ascii": 38,
-    "code": 547,
-    "label": "&"
+    ascii: 38,
+    code: 547,
+    label: '&',
   },
   {
-    "ascii": 39,
-    "code": 45,
-    "label": "'"
+    ascii: 39,
+    code: 45,
+    label: "'",
   },
   {
-    "ascii": 40,
-    "code": 549,
-    "label": "("
+    ascii: 40,
+    code: 549,
+    label: '(',
   },
   {
-    "ascii": 41,
-    "code": 550,
-    "label": ")"
+    ascii: 41,
+    code: 550,
+    label: ')',
   },
   {
-    "ascii": 42,
-    "code": 558,
-    "label": "*"
+    ascii: 42,
+    code: 558,
+    label: '*',
   },
   {
-    "ascii": 43,
-    "code": 46,
-    "label": "+"
+    ascii: 43,
+    code: 46,
+    label: '+',
   },
   {
-    "ascii": 44,
-    "code": 54,
-    "label": ","
+    ascii: 44,
+    code: 54,
+    label: ',',
   },
   {
-    "ascii": 45,
-    "code": 56,
-    "label": "-"
+    ascii: 45,
+    code: 56,
+    label: '-',
   },
   {
-    "ascii": 46,
-    "code": 55,
-    "label": "."
+    ascii: 46,
+    code: 55,
+    label: '.',
   },
   {
-    "ascii": 47,
-    "code": 548,
-    "label": "/"
+    ascii: 47,
+    code: 548,
+    label: '/',
   },
   {
-    "ascii": 48,
-    "code": 39,
-    "label": "0"
+    ascii: 48,
+    code: 39,
+    label: '0',
   },
   {
-    "ascii": 49,
-    "code": 30,
-    "label": "1"
+    ascii: 49,
+    code: 30,
+    label: '1',
   },
   {
-    "ascii": 50,
-    "code": 31,
-    "label": "2"
+    ascii: 50,
+    code: 31,
+    label: '2',
   },
   {
-    "ascii": 51,
-    "code": 32,
-    "label": "3"
+    ascii: 51,
+    code: 32,
+    label: '3',
   },
   {
-    "ascii": 52,
-    "code": 33,
-    "label": "4"
+    ascii: 52,
+    code: 33,
+    label: '4',
   },
   {
-    "ascii": 53,
-    "code": 34,
-    "label": "5"
+    ascii: 53,
+    code: 34,
+    label: '5',
   },
   {
-    "ascii": 54,
-    "code": 35,
-    "label": "6"
+    ascii: 54,
+    code: 35,
+    label: '6',
   },
   {
-    "ascii": 55,
-    "code": 36,
-    "label": "7"
+    ascii: 55,
+    code: 36,
+    label: '7',
   },
   {
-    "ascii": 56,
-    "code": 37,
-    "label": "8"
+    ascii: 56,
+    code: 37,
+    label: '8',
   },
   {
-    "ascii": 57,
-    "code": 38,
-    "label": "9"
+    ascii: 57,
+    code: 38,
+    label: '9',
   },
   {
-    "ascii": 58,
-    "code": 567,
-    "label": ":"
+    ascii: 58,
+    code: 567,
+    label: ':',
   },
   {
-    "ascii": 59,
-    "code": 566,
-    "label": ";"
+    ascii: 59,
+    code: 566,
+    label: ';',
   },
   {
-    "ascii": 60,
-    "code": 100,
-    "label": "<"
+    ascii: 60,
+    code: 100,
+    label: '<',
   },
   {
-    "ascii": 61,
-    "code": 551,
-    "label": "="
+    ascii: 61,
+    code: 551,
+    label: '=',
   },
   {
-    "ascii": 62,
-    "code": 612,
-    "label": ">"
+    ascii: 62,
+    code: 612,
+    label: '>',
   },
   {
-    "ascii": 63,
-    "code": 557,
-    "label": "?"
+    ascii: 63,
+    code: 557,
+    label: '?',
   },
   {
-    "ascii": 64,
-    "code": 25,
-    "label": "v"
+    ascii: 64,
+    code: 25,
+    label: 'v',
   },
   {
-    "ascii": 65,
-    "code": 516,
-    "label": "A"
+    ascii: 65,
+    code: 516,
+    label: 'A',
   },
   {
-    "ascii": 66,
-    "code": 517,
-    "label": "B"
+    ascii: 66,
+    code: 517,
+    label: 'B',
   },
   {
-    "ascii": 67,
-    "code": 518,
-    "label": "C"
+    ascii: 67,
+    code: 518,
+    label: 'C',
   },
   {
-    "ascii": 68,
-    "code": 519,
-    "label": "D"
+    ascii: 68,
+    code: 519,
+    label: 'D',
   },
   {
-    "ascii": 69,
-    "code": 520,
-    "label": "E"
+    ascii: 69,
+    code: 520,
+    label: 'E',
   },
   {
-    "ascii": 70,
-    "code": 521,
-    "label": "F"
+    ascii: 70,
+    code: 521,
+    label: 'F',
   },
   {
-    "ascii": 71,
-    "code": 522,
-    "label": "G"
+    ascii: 71,
+    code: 522,
+    label: 'G',
   },
   {
-    "ascii": 72,
-    "code": 523,
-    "label": "H"
+    ascii: 72,
+    code: 523,
+    label: 'H',
   },
   {
-    "ascii": 73,
-    "code": 524,
-    "label": "I"
+    ascii: 73,
+    code: 524,
+    label: 'I',
   },
   {
-    "ascii": 74,
-    "code": 525,
-    "label": "J"
+    ascii: 74,
+    code: 525,
+    label: 'J',
   },
   {
-    "ascii": 75,
-    "code": 526,
-    "label": "K"
+    ascii: 75,
+    code: 526,
+    label: 'K',
   },
   {
-    "ascii": 76,
-    "code": 527,
-    "label": "L"
+    ascii: 76,
+    code: 527,
+    label: 'L',
   },
   {
-    "ascii": 77,
-    "code": 528,
-    "label": "M"
+    ascii: 77,
+    code: 528,
+    label: 'M',
   },
   {
-    "ascii": 78,
-    "code": 529,
-    "label": "N"
+    ascii: 78,
+    code: 529,
+    label: 'N',
   },
   {
-    "ascii": 79,
-    "code": 530,
-    "label": "O"
+    ascii: 79,
+    code: 530,
+    label: 'O',
   },
   {
-    "ascii": 80,
-    "code": 531,
-    "label": "P"
+    ascii: 80,
+    code: 531,
+    label: 'P',
   },
   {
-    "ascii": 81,
-    "code": 532,
-    "label": "Q"
+    ascii: 81,
+    code: 532,
+    label: 'Q',
   },
   {
-    "ascii": 82,
-    "code": 533,
-    "label": "R"
+    ascii: 82,
+    code: 533,
+    label: 'R',
   },
   {
-    "ascii": 83,
-    "code": 534,
-    "label": "S"
+    ascii: 83,
+    code: 534,
+    label: 'S',
   },
   {
-    "ascii": 84,
-    "code": 535,
-    "label": "T"
+    ascii: 84,
+    code: 535,
+    label: 'T',
   },
   {
-    "ascii": 85,
-    "code": 536,
-    "label": "U"
+    ascii: 85,
+    code: 536,
+    label: 'U',
   },
   {
-    "ascii": 86,
-    "code": 537,
-    "label": "V"
+    ascii: 86,
+    code: 537,
+    label: 'V',
   },
   {
-    "ascii": 87,
-    "code": 538,
-    "label": "W"
+    ascii: 87,
+    code: 538,
+    label: 'W',
   },
   {
-    "ascii": 88,
-    "code": 539,
-    "label": "X"
+    ascii: 88,
+    code: 539,
+    label: 'X',
   },
   {
-    "ascii": 89,
-    "code": 541,
-    "label": "Y"
+    ascii: 89,
+    code: 541,
+    label: 'Y',
   },
   {
-    "ascii": 90,
-    "code": 540,
-    "label": "Z"
+    ascii: 90,
+    code: 540,
+    label: 'Z',
   },
   {
-    "ascii": 91,
-    "code": 9,
-    "label": "f"
+    ascii: 91,
+    code: 9,
+    label: 'f',
   },
   {
-    "ascii": 92,
-    "code": 20,
-    "label": "q"
+    ascii: 92,
+    code: 20,
+    label: 'q',
   },
   {
-    "ascii": 93,
-    "code": 10,
-    "label": "g"
+    ascii: 93,
+    code: 10,
+    label: 'g',
   },
   {
-    "ascii": 94,
-    "code": 32,
-    "label": "3"
+    ascii: 94,
+    code: 32,
+    label: '3',
   },
   {
-    "ascii": 95,
-    "code": 568,
-    "label": "_"
+    ascii: 95,
+    code: 568,
+    label: '_',
   },
   {
-    "ascii": 96,
-    "code": 36,
-    "label": "7"
+    ascii: 96,
+    code: 36,
+    label: '7',
   },
   {
-    "ascii": 97,
-    "code": 4,
-    "label": "a"
+    ascii: 97,
+    code: 4,
+    label: 'a',
   },
   {
-    "ascii": 98,
-    "code": 5,
-    "label": "b"
+    ascii: 98,
+    code: 5,
+    label: 'b',
   },
   {
-    "ascii": 99,
-    "code": 6,
-    "label": "c"
+    ascii: 99,
+    code: 6,
+    label: 'c',
   },
   {
-    "ascii": 100,
-    "code": 7,
-    "label": "d"
+    ascii: 100,
+    code: 7,
+    label: 'd',
   },
   {
-    "ascii": 101,
-    "code": 8,
-    "label": "e"
+    ascii: 101,
+    code: 8,
+    label: 'e',
   },
   {
-    "ascii": 102,
-    "code": 9,
-    "label": "f"
+    ascii: 102,
+    code: 9,
+    label: 'f',
   },
   {
-    "ascii": 103,
-    "code": 10,
-    "label": "g"
+    ascii: 103,
+    code: 10,
+    label: 'g',
   },
   {
-    "ascii": 104,
-    "code": 11,
-    "label": "h"
+    ascii: 104,
+    code: 11,
+    label: 'h',
   },
   {
-    "ascii": 105,
-    "code": 12,
-    "label": "i"
+    ascii: 105,
+    code: 12,
+    label: 'i',
   },
   {
-    "ascii": 106,
-    "code": 13,
-    "label": "j"
+    ascii: 106,
+    code: 13,
+    label: 'j',
   },
   {
-    "ascii": 107,
-    "code": 14,
-    "label": "k"
+    ascii: 107,
+    code: 14,
+    label: 'k',
   },
   {
-    "ascii": 108,
-    "code": 15,
-    "label": "l"
+    ascii: 108,
+    code: 15,
+    label: 'l',
   },
   {
-    "ascii": 109,
-    "code": 16,
-    "label": "m"
+    ascii: 109,
+    code: 16,
+    label: 'm',
   },
   {
-    "ascii": 110,
-    "code": 17,
-    "label": "n"
+    ascii: 110,
+    code: 17,
+    label: 'n',
   },
   {
-    "ascii": 111,
-    "code": 18,
-    "label": "o"
+    ascii: 111,
+    code: 18,
+    label: 'o',
   },
   {
-    "ascii": 112,
-    "code": 19,
-    "label": "p"
+    ascii: 112,
+    code: 19,
+    label: 'p',
   },
   {
-    "ascii": 113,
-    "code": 20,
-    "label": "q"
+    ascii: 113,
+    code: 20,
+    label: 'q',
   },
   {
-    "ascii": 114,
-    "code": 21,
-    "label": "r"
+    ascii: 114,
+    code: 21,
+    label: 'r',
   },
   {
-    "ascii": 115,
-    "code": 22,
-    "label": "s"
+    ascii: 115,
+    code: 22,
+    label: 's',
   },
   {
-    "ascii": 116,
-    "code": 23,
-    "label": "t"
+    ascii: 116,
+    code: 23,
+    label: 't',
   },
   {
-    "ascii": 117,
-    "code": 24,
-    "label": "u"
+    ascii: 117,
+    code: 24,
+    label: 'u',
   },
   {
-    "ascii": 118,
-    "code": 25,
-    "label": "v"
+    ascii: 118,
+    code: 25,
+    label: 'v',
   },
   {
-    "ascii": 119,
-    "code": 26,
-    "label": "w"
+    ascii: 119,
+    code: 26,
+    label: 'w',
   },
   {
-    "ascii": 120,
-    "code": 27,
-    "label": "x"
+    ascii: 120,
+    code: 27,
+    label: 'x',
   },
   {
-    "ascii": 121,
-    "code": 29,
-    "label": "y"
+    ascii: 121,
+    code: 29,
+    label: 'y',
   },
   {
-    "ascii": 122,
-    "code": 28,
-    "label": "z"
+    ascii: 122,
+    code: 28,
+    label: 'z',
   },
   {
-    "ascii": 123,
-    "code": 5,
-    "label": "b"
+    ascii: 123,
+    code: 5,
+    label: 'b',
   },
   {
-    "ascii": 124,
-    "code": 26,
-    "label": "w"
+    ascii: 124,
+    code: 26,
+    label: 'w',
   },
   {
-    "ascii": 125,
-    "code": 17,
-    "label": "n"
+    ascii: 125,
+    code: 17,
+    label: 'n',
   },
   {
-    "ascii": 126,
-    "code": 30,
-    "label": "1"
+    ascii: 126,
+    code: 30,
+    label: '1',
   },
   {
-    "ascii": 127,
-    "code": 76,
-    "label": "del"
-  }
+    ascii: 127,
+    code: 76,
+    label: 'del',
+  },
 ];
-    

--- a/src/services/labellang/AsciiLabelCzech.ts
+++ b/src/services/labellang/AsciiLabelCzech.ts
@@ -1,645 +1,644 @@
 import { AsciiLabel } from './AsciiLabel';
-        
+
 export const AsciiLabelCzech: AsciiLabel[] = [
   {
-    "ascii": 0,
-    "code": 0,
-    "label": ""
+    ascii: 0,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 1,
-    "code": 0,
-    "label": ""
+    ascii: 1,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 2,
-    "code": 0,
-    "label": ""
+    ascii: 2,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 3,
-    "code": 0,
-    "label": ""
+    ascii: 3,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 4,
-    "code": 0,
-    "label": ""
+    ascii: 4,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 5,
-    "code": 0,
-    "label": ""
+    ascii: 5,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 6,
-    "code": 0,
-    "label": ""
+    ascii: 6,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 7,
-    "code": 0,
-    "label": ""
+    ascii: 7,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 8,
-    "code": 42,
-    "label": "back space"
+    ascii: 8,
+    code: 42,
+    label: 'back space',
   },
   {
-    "ascii": 9,
-    "code": 43,
-    "label": "tab"
+    ascii: 9,
+    code: 43,
+    label: 'tab',
   },
   {
-    "ascii": 10,
-    "code": 40,
-    "label": "enter"
+    ascii: 10,
+    code: 40,
+    label: 'enter',
   },
   {
-    "ascii": 11,
-    "code": 0,
-    "label": ""
+    ascii: 11,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 12,
-    "code": 0,
-    "label": ""
+    ascii: 12,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 13,
-    "code": 0,
-    "label": ""
+    ascii: 13,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 14,
-    "code": 0,
-    "label": ""
+    ascii: 14,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 15,
-    "code": 0,
-    "label": ""
+    ascii: 15,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 16,
-    "code": 0,
-    "label": ""
+    ascii: 16,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 17,
-    "code": 0,
-    "label": ""
+    ascii: 17,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 18,
-    "code": 0,
-    "label": ""
+    ascii: 18,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 19,
-    "code": 0,
-    "label": ""
+    ascii: 19,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 20,
-    "code": 0,
-    "label": ""
+    ascii: 20,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 21,
-    "code": 0,
-    "label": ""
+    ascii: 21,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 22,
-    "code": 0,
-    "label": ""
+    ascii: 22,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 23,
-    "code": 0,
-    "label": ""
+    ascii: 23,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 24,
-    "code": 0,
-    "label": ""
+    ascii: 24,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 25,
-    "code": 0,
-    "label": ""
+    ascii: 25,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 26,
-    "code": 0,
-    "label": ""
+    ascii: 26,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 27,
-    "code": 41,
-    "label": "esc"
+    ascii: 27,
+    code: 41,
+    label: 'esc',
   },
   {
-    "ascii": 28,
-    "code": 0,
-    "label": ""
+    ascii: 28,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 29,
-    "code": 0,
-    "label": ""
+    ascii: 29,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 30,
-    "code": 0,
-    "label": ""
+    ascii: 30,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 31,
-    "code": 0,
-    "label": ""
+    ascii: 31,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 32,
-    "code": 44,
-    "label": "space"
+    ascii: 32,
+    code: 44,
+    label: 'space',
   },
   {
-    "ascii": 33,
-    "code": 564,
-    "label": "!"
+    ascii: 33,
+    code: 564,
+    label: '!',
   },
   {
-    "ascii": 34,
-    "code": 563,
-    "label": "\""
+    ascii: 34,
+    code: 563,
+    label: '"',
   },
   {
-    "ascii": 35,
-    "code": 27,
-    "label": "x"
+    ascii: 35,
+    code: 27,
+    label: 'x',
   },
   {
-    "ascii": 36,
-    "code": 51,
-    "label": "ů"
+    ascii: 36,
+    code: 51,
+    label: 'ů',
   },
   {
-    "ascii": 37,
-    "code": 557,
-    "label": "="
+    ascii: 37,
+    code: 557,
+    label: '=',
   },
   {
-    "ascii": 38,
-    "code": 6,
-    "label": "c"
+    ascii: 38,
+    code: 6,
+    label: 'c',
   },
   {
-    "ascii": 39,
-    "code": 562,
-    "label": "'"
+    ascii: 39,
+    code: 562,
+    label: "'",
   },
   {
-    "ascii": 40,
-    "code": 560,
-    "label": "("
+    ascii: 40,
+    code: 560,
+    label: '(',
   },
   {
-    "ascii": 41,
-    "code": 560,
-    "label": "("
+    ascii: 41,
+    code: 560,
+    label: '(',
   },
   {
-    "ascii": 42,
-    "code": 56,
-    "label": "-"
+    ascii: 42,
+    code: 56,
+    label: '-',
   },
   {
-    "ascii": 43,
-    "code": 30,
-    "label": "+"
+    ascii: 43,
+    code: 30,
+    label: '+',
   },
   {
-    "ascii": 44,
-    "code": 54,
-    "label": ","
+    ascii: 44,
+    code: 54,
+    label: ',',
   },
   {
-    "ascii": 45,
-    "code": 56,
-    "label": "-"
+    ascii: 45,
+    code: 56,
+    label: '-',
   },
   {
-    "ascii": 46,
-    "code": 55,
-    "label": "."
+    ascii: 46,
+    code: 55,
+    label: '.',
   },
   {
-    "ascii": 47,
-    "code": 559,
-    "label": "/"
+    ascii: 47,
+    code: 559,
+    label: '/',
   },
   {
-    "ascii": 48,
-    "code": 551,
-    "label": "0"
+    ascii: 48,
+    code: 551,
+    label: '0',
   },
   {
-    "ascii": 49,
-    "code": 542,
-    "label": "%"
+    ascii: 49,
+    code: 542,
+    label: '%',
   },
   {
-    "ascii": 50,
-    "code": 543,
-    "label": "2"
+    ascii: 50,
+    code: 543,
+    label: '2',
   },
   {
-    "ascii": 51,
-    "code": 544,
-    "label": "3"
+    ascii: 51,
+    code: 544,
+    label: '3',
   },
   {
-    "ascii": 52,
-    "code": 545,
-    "label": "4"
+    ascii: 52,
+    code: 545,
+    label: '4',
   },
   {
-    "ascii": 53,
-    "code": 546,
-    "label": "5"
+    ascii: 53,
+    code: 546,
+    label: '5',
   },
   {
-    "ascii": 54,
-    "code": 547,
-    "label": "6"
+    ascii: 54,
+    code: 547,
+    label: '6',
   },
   {
-    "ascii": 55,
-    "code": 548,
-    "label": "7"
+    ascii: 55,
+    code: 548,
+    label: '7',
   },
   {
-    "ascii": 56,
-    "code": 549,
-    "label": "8"
+    ascii: 56,
+    code: 549,
+    label: '8',
   },
   {
-    "ascii": 57,
-    "code": 550,
-    "label": "9"
+    ascii: 57,
+    code: 550,
+    label: '9',
   },
   {
-    "ascii": 58,
-    "code": 567,
-    "label": ":"
+    ascii: 58,
+    code: 567,
+    label: ':',
   },
   {
-    "ascii": 59,
-    "code": 53,
-    "label": ";"
+    ascii: 59,
+    code: 53,
+    label: ';',
   },
   {
-    "ascii": 60,
-    "code": 54,
-    "label": ","
+    ascii: 60,
+    code: 54,
+    label: ',',
   },
   {
-    "ascii": 61,
-    "code": 45,
-    "label": "="
+    ascii: 61,
+    code: 45,
+    label: '=',
   },
   {
-    "ascii": 62,
-    "code": 55,
-    "label": "."
+    ascii: 62,
+    code: 55,
+    label: '.',
   },
   {
-    "ascii": 63,
-    "code": 566,
-    "label": "?"
+    ascii: 63,
+    code: 566,
+    label: '?',
   },
   {
-    "ascii": 64,
-    "code": 25,
-    "label": "v"
+    ascii: 64,
+    code: 25,
+    label: 'v',
   },
   {
-    "ascii": 65,
-    "code": 516,
-    "label": "A"
+    ascii: 65,
+    code: 516,
+    label: 'A',
   },
   {
-    "ascii": 66,
-    "code": 517,
-    "label": "B"
+    ascii: 66,
+    code: 517,
+    label: 'B',
   },
   {
-    "ascii": 67,
-    "code": 518,
-    "label": "C"
+    ascii: 67,
+    code: 518,
+    label: 'C',
   },
   {
-    "ascii": 68,
-    "code": 519,
-    "label": "D"
+    ascii: 68,
+    code: 519,
+    label: 'D',
   },
   {
-    "ascii": 69,
-    "code": 520,
-    "label": "E"
+    ascii: 69,
+    code: 520,
+    label: 'E',
   },
   {
-    "ascii": 70,
-    "code": 521,
-    "label": "F"
+    ascii: 70,
+    code: 521,
+    label: 'F',
   },
   {
-    "ascii": 71,
-    "code": 522,
-    "label": "G"
+    ascii: 71,
+    code: 522,
+    label: 'G',
   },
   {
-    "ascii": 72,
-    "code": 523,
-    "label": "H"
+    ascii: 72,
+    code: 523,
+    label: 'H',
   },
   {
-    "ascii": 73,
-    "code": 524,
-    "label": "I"
+    ascii: 73,
+    code: 524,
+    label: 'I',
   },
   {
-    "ascii": 74,
-    "code": 525,
-    "label": "J"
+    ascii: 74,
+    code: 525,
+    label: 'J',
   },
   {
-    "ascii": 75,
-    "code": 526,
-    "label": "K"
+    ascii: 75,
+    code: 526,
+    label: 'K',
   },
   {
-    "ascii": 76,
-    "code": 527,
-    "label": "L"
+    ascii: 76,
+    code: 527,
+    label: 'L',
   },
   {
-    "ascii": 77,
-    "code": 528,
-    "label": "M"
+    ascii: 77,
+    code: 528,
+    label: 'M',
   },
   {
-    "ascii": 78,
-    "code": 529,
-    "label": "N"
+    ascii: 78,
+    code: 529,
+    label: 'N',
   },
   {
-    "ascii": 79,
-    "code": 530,
-    "label": "O"
+    ascii: 79,
+    code: 530,
+    label: 'O',
   },
   {
-    "ascii": 80,
-    "code": 531,
-    "label": "P"
+    ascii: 80,
+    code: 531,
+    label: 'P',
   },
   {
-    "ascii": 81,
-    "code": 532,
-    "label": "Q"
+    ascii: 81,
+    code: 532,
+    label: 'Q',
   },
   {
-    "ascii": 82,
-    "code": 533,
-    "label": "R"
+    ascii: 82,
+    code: 533,
+    label: 'R',
   },
   {
-    "ascii": 83,
-    "code": 534,
-    "label": "S"
+    ascii: 83,
+    code: 534,
+    label: 'S',
   },
   {
-    "ascii": 84,
-    "code": 535,
-    "label": "T"
+    ascii: 84,
+    code: 535,
+    label: 'T',
   },
   {
-    "ascii": 85,
-    "code": 536,
-    "label": "U"
+    ascii: 85,
+    code: 536,
+    label: 'U',
   },
   {
-    "ascii": 86,
-    "code": 537,
-    "label": "V"
+    ascii: 86,
+    code: 537,
+    label: 'V',
   },
   {
-    "ascii": 87,
-    "code": 538,
-    "label": "W"
+    ascii: 87,
+    code: 538,
+    label: 'W',
   },
   {
-    "ascii": 88,
-    "code": 539,
-    "label": "X"
+    ascii: 88,
+    code: 539,
+    label: 'X',
   },
   {
-    "ascii": 89,
-    "code": 541,
-    "label": "Y"
+    ascii: 89,
+    code: 541,
+    label: 'Y',
   },
   {
-    "ascii": 90,
-    "code": 540,
-    "label": "Z"
+    ascii: 90,
+    code: 540,
+    label: 'Z',
   },
   {
-    "ascii": 91,
-    "code": 9,
-    "label": "f"
+    ascii: 91,
+    code: 9,
+    label: 'f',
   },
   {
-    "ascii": 92,
-    "code": 100,
-    "label": "(backslash)"
+    ascii: 92,
+    code: 100,
+    label: '(backslash)',
   },
   {
-    "ascii": 93,
-    "code": 10,
-    "label": "g"
+    ascii: 93,
+    code: 10,
+    label: 'g',
   },
   {
-    "ascii": 94,
-    "code": 32,
-    "label": "š"
+    ascii: 94,
+    code: 32,
+    label: 'š',
   },
   {
-    "ascii": 95,
-    "code": 568,
-    "label": "_"
+    ascii: 95,
+    code: 568,
+    label: '_',
   },
   {
-    "ascii": 96,
-    "code": 36,
-    "label": "ý"
+    ascii: 96,
+    code: 36,
+    label: 'ý',
   },
   {
-    "ascii": 97,
-    "code": 4,
-    "label": "a"
+    ascii: 97,
+    code: 4,
+    label: 'a',
   },
   {
-    "ascii": 98,
-    "code": 5,
-    "label": "b"
+    ascii: 98,
+    code: 5,
+    label: 'b',
   },
   {
-    "ascii": 99,
-    "code": 6,
-    "label": "c"
+    ascii: 99,
+    code: 6,
+    label: 'c',
   },
   {
-    "ascii": 100,
-    "code": 7,
-    "label": "d"
+    ascii: 100,
+    code: 7,
+    label: 'd',
   },
   {
-    "ascii": 101,
-    "code": 8,
-    "label": "e"
+    ascii: 101,
+    code: 8,
+    label: 'e',
   },
   {
-    "ascii": 102,
-    "code": 9,
-    "label": "f"
+    ascii: 102,
+    code: 9,
+    label: 'f',
   },
   {
-    "ascii": 103,
-    "code": 10,
-    "label": "g"
+    ascii: 103,
+    code: 10,
+    label: 'g',
   },
   {
-    "ascii": 104,
-    "code": 11,
-    "label": "h"
+    ascii: 104,
+    code: 11,
+    label: 'h',
   },
   {
-    "ascii": 105,
-    "code": 12,
-    "label": "i"
+    ascii: 105,
+    code: 12,
+    label: 'i',
   },
   {
-    "ascii": 106,
-    "code": 13,
-    "label": "j"
+    ascii: 106,
+    code: 13,
+    label: 'j',
   },
   {
-    "ascii": 107,
-    "code": 14,
-    "label": "k"
+    ascii: 107,
+    code: 14,
+    label: 'k',
   },
   {
-    "ascii": 108,
-    "code": 15,
-    "label": "l"
+    ascii: 108,
+    code: 15,
+    label: 'l',
   },
   {
-    "ascii": 109,
-    "code": 16,
-    "label": "m"
+    ascii: 109,
+    code: 16,
+    label: 'm',
   },
   {
-    "ascii": 110,
-    "code": 17,
-    "label": "n"
+    ascii: 110,
+    code: 17,
+    label: 'n',
   },
   {
-    "ascii": 111,
-    "code": 18,
-    "label": "o"
+    ascii: 111,
+    code: 18,
+    label: 'o',
   },
   {
-    "ascii": 112,
-    "code": 19,
-    "label": "p"
+    ascii: 112,
+    code: 19,
+    label: 'p',
   },
   {
-    "ascii": 113,
-    "code": 20,
-    "label": "q"
+    ascii: 113,
+    code: 20,
+    label: 'q',
   },
   {
-    "ascii": 114,
-    "code": 21,
-    "label": "r"
+    ascii: 114,
+    code: 21,
+    label: 'r',
   },
   {
-    "ascii": 115,
-    "code": 22,
-    "label": "s"
+    ascii: 115,
+    code: 22,
+    label: 's',
   },
   {
-    "ascii": 116,
-    "code": 23,
-    "label": "t"
+    ascii: 116,
+    code: 23,
+    label: 't',
   },
   {
-    "ascii": 117,
-    "code": 24,
-    "label": "u"
+    ascii: 117,
+    code: 24,
+    label: 'u',
   },
   {
-    "ascii": 118,
-    "code": 25,
-    "label": "v"
+    ascii: 118,
+    code: 25,
+    label: 'v',
   },
   {
-    "ascii": 119,
-    "code": 26,
-    "label": "w"
+    ascii: 119,
+    code: 26,
+    label: 'w',
   },
   {
-    "ascii": 120,
-    "code": 27,
-    "label": "x"
+    ascii: 120,
+    code: 27,
+    label: 'x',
   },
   {
-    "ascii": 121,
-    "code": 29,
-    "label": "y"
+    ascii: 121,
+    code: 29,
+    label: 'y',
   },
   {
-    "ascii": 122,
-    "code": 28,
-    "label": "z"
+    ascii: 122,
+    code: 28,
+    label: 'z',
   },
   {
-    "ascii": 123,
-    "code": 5,
-    "label": "b"
+    ascii: 123,
+    code: 5,
+    label: 'b',
   },
   {
-    "ascii": 124,
-    "code": 100,
-    "label": "(backslash)"
+    ascii: 124,
+    code: 100,
+    label: '(backslash)',
   },
   {
-    "ascii": 125,
-    "code": 17,
-    "label": "n"
+    ascii: 125,
+    code: 17,
+    label: 'n',
   },
   {
-    "ascii": 126,
-    "code": 30,
-    "label": "+"
+    ascii: 126,
+    code: 30,
+    label: '+',
   },
   {
-    "ascii": 127,
-    "code": 76,
-    "label": "del"
-  }
+    ascii: 127,
+    code: 76,
+    label: 'del',
+  },
 ];
-    

--- a/src/services/labellang/AsciiLabelDanish.ts
+++ b/src/services/labellang/AsciiLabelDanish.ts
@@ -1,645 +1,644 @@
 import { AsciiLabel } from './AsciiLabel';
-        
+
 export const AsciiLabelDanish: AsciiLabel[] = [
   {
-    "ascii": 0,
-    "code": 0,
-    "label": ""
+    ascii: 0,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 1,
-    "code": 0,
-    "label": ""
+    ascii: 1,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 2,
-    "code": 0,
-    "label": ""
+    ascii: 2,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 3,
-    "code": 0,
-    "label": ""
+    ascii: 3,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 4,
-    "code": 0,
-    "label": ""
+    ascii: 4,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 5,
-    "code": 0,
-    "label": ""
+    ascii: 5,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 6,
-    "code": 0,
-    "label": ""
+    ascii: 6,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 7,
-    "code": 0,
-    "label": ""
+    ascii: 7,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 8,
-    "code": 42,
-    "label": "back space"
+    ascii: 8,
+    code: 42,
+    label: 'back space',
   },
   {
-    "ascii": 9,
-    "code": 43,
-    "label": "tab"
+    ascii: 9,
+    code: 43,
+    label: 'tab',
   },
   {
-    "ascii": 10,
-    "code": 40,
-    "label": "enter"
+    ascii: 10,
+    code: 40,
+    label: 'enter',
   },
   {
-    "ascii": 11,
-    "code": 0,
-    "label": ""
+    ascii: 11,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 12,
-    "code": 0,
-    "label": ""
+    ascii: 12,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 13,
-    "code": 0,
-    "label": ""
+    ascii: 13,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 14,
-    "code": 0,
-    "label": ""
+    ascii: 14,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 15,
-    "code": 0,
-    "label": ""
+    ascii: 15,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 16,
-    "code": 0,
-    "label": ""
+    ascii: 16,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 17,
-    "code": 0,
-    "label": ""
+    ascii: 17,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 18,
-    "code": 0,
-    "label": ""
+    ascii: 18,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 19,
-    "code": 0,
-    "label": ""
+    ascii: 19,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 20,
-    "code": 0,
-    "label": ""
+    ascii: 20,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 21,
-    "code": 0,
-    "label": ""
+    ascii: 21,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 22,
-    "code": 0,
-    "label": ""
+    ascii: 22,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 23,
-    "code": 0,
-    "label": ""
+    ascii: 23,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 24,
-    "code": 0,
-    "label": ""
+    ascii: 24,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 25,
-    "code": 0,
-    "label": ""
+    ascii: 25,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 26,
-    "code": 0,
-    "label": ""
+    ascii: 26,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 27,
-    "code": 41,
-    "label": "esc"
+    ascii: 27,
+    code: 41,
+    label: 'esc',
   },
   {
-    "ascii": 28,
-    "code": 0,
-    "label": ""
+    ascii: 28,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 29,
-    "code": 0,
-    "label": ""
+    ascii: 29,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 30,
-    "code": 0,
-    "label": ""
+    ascii: 30,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 31,
-    "code": 0,
-    "label": ""
+    ascii: 31,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 32,
-    "code": 44,
-    "label": "space"
+    ascii: 32,
+    code: 44,
+    label: 'space',
   },
   {
-    "ascii": 33,
-    "code": 542,
-    "label": "!"
+    ascii: 33,
+    code: 542,
+    label: '!',
   },
   {
-    "ascii": 34,
-    "code": 543,
-    "label": "\""
+    ascii: 34,
+    code: 543,
+    label: '"',
   },
   {
-    "ascii": 35,
-    "code": 544,
-    "label": "#"
+    ascii: 35,
+    code: 544,
+    label: '#',
   },
   {
-    "ascii": 36,
-    "code": 33,
-    "label": "4"
+    ascii: 36,
+    code: 33,
+    label: '4',
   },
   {
-    "ascii": 37,
-    "code": 546,
-    "label": "%"
+    ascii: 37,
+    code: 546,
+    label: '%',
   },
   {
-    "ascii": 38,
-    "code": 547,
-    "label": "&"
+    ascii: 38,
+    code: 547,
+    label: '&',
   },
   {
-    "ascii": 39,
-    "code": 50,
-    "label": "'"
+    ascii: 39,
+    code: 50,
+    label: "'",
   },
   {
-    "ascii": 40,
-    "code": 549,
-    "label": "("
+    ascii: 40,
+    code: 549,
+    label: '(',
   },
   {
-    "ascii": 41,
-    "code": 550,
-    "label": ")"
+    ascii: 41,
+    code: 550,
+    label: ')',
   },
   {
-    "ascii": 42,
-    "code": 562,
-    "label": "*"
+    ascii: 42,
+    code: 562,
+    label: '*',
   },
   {
-    "ascii": 43,
-    "code": 45,
-    "label": "+"
+    ascii: 43,
+    code: 45,
+    label: '+',
   },
   {
-    "ascii": 44,
-    "code": 54,
-    "label": ","
+    ascii: 44,
+    code: 54,
+    label: ',',
   },
   {
-    "ascii": 45,
-    "code": 56,
-    "label": "-"
+    ascii: 45,
+    code: 56,
+    label: '-',
   },
   {
-    "ascii": 46,
-    "code": 55,
-    "label": "."
+    ascii: 46,
+    code: 55,
+    label: '.',
   },
   {
-    "ascii": 47,
-    "code": 548,
-    "label": "/"
+    ascii: 47,
+    code: 548,
+    label: '/',
   },
   {
-    "ascii": 48,
-    "code": 39,
-    "label": "0"
+    ascii: 48,
+    code: 39,
+    label: '0',
   },
   {
-    "ascii": 49,
-    "code": 30,
-    "label": "1"
+    ascii: 49,
+    code: 30,
+    label: '1',
   },
   {
-    "ascii": 50,
-    "code": 31,
-    "label": "2"
+    ascii: 50,
+    code: 31,
+    label: '2',
   },
   {
-    "ascii": 51,
-    "code": 32,
-    "label": "3"
+    ascii: 51,
+    code: 32,
+    label: '3',
   },
   {
-    "ascii": 52,
-    "code": 33,
-    "label": "4"
+    ascii: 52,
+    code: 33,
+    label: '4',
   },
   {
-    "ascii": 53,
-    "code": 34,
-    "label": "5"
+    ascii: 53,
+    code: 34,
+    label: '5',
   },
   {
-    "ascii": 54,
-    "code": 35,
-    "label": "6"
+    ascii: 54,
+    code: 35,
+    label: '6',
   },
   {
-    "ascii": 55,
-    "code": 36,
-    "label": "7"
+    ascii: 55,
+    code: 36,
+    label: '7',
   },
   {
-    "ascii": 56,
-    "code": 37,
-    "label": "8"
+    ascii: 56,
+    code: 37,
+    label: '8',
   },
   {
-    "ascii": 57,
-    "code": 38,
-    "label": "9"
+    ascii: 57,
+    code: 38,
+    label: '9',
   },
   {
-    "ascii": 58,
-    "code": 567,
-    "label": ":"
+    ascii: 58,
+    code: 567,
+    label: ':',
   },
   {
-    "ascii": 59,
-    "code": 566,
-    "label": ";"
+    ascii: 59,
+    code: 566,
+    label: ';',
   },
   {
-    "ascii": 60,
-    "code": 100,
-    "label": "<"
+    ascii: 60,
+    code: 100,
+    label: '<',
   },
   {
-    "ascii": 61,
-    "code": 551,
-    "label": "="
+    ascii: 61,
+    code: 551,
+    label: '=',
   },
   {
-    "ascii": 62,
-    "code": 612,
-    "label": ">"
+    ascii: 62,
+    code: 612,
+    label: '>',
   },
   {
-    "ascii": 63,
-    "code": 557,
-    "label": "?"
+    ascii: 63,
+    code: 557,
+    label: '?',
   },
   {
-    "ascii": 64,
-    "code": 31,
-    "label": "2"
+    ascii: 64,
+    code: 31,
+    label: '2',
   },
   {
-    "ascii": 65,
-    "code": 516,
-    "label": "A"
+    ascii: 65,
+    code: 516,
+    label: 'A',
   },
   {
-    "ascii": 66,
-    "code": 517,
-    "label": "B"
+    ascii: 66,
+    code: 517,
+    label: 'B',
   },
   {
-    "ascii": 67,
-    "code": 518,
-    "label": "C"
+    ascii: 67,
+    code: 518,
+    label: 'C',
   },
   {
-    "ascii": 68,
-    "code": 519,
-    "label": "D"
+    ascii: 68,
+    code: 519,
+    label: 'D',
   },
   {
-    "ascii": 69,
-    "code": 520,
-    "label": "E"
+    ascii: 69,
+    code: 520,
+    label: 'E',
   },
   {
-    "ascii": 70,
-    "code": 521,
-    "label": "F"
+    ascii: 70,
+    code: 521,
+    label: 'F',
   },
   {
-    "ascii": 71,
-    "code": 522,
-    "label": "G"
+    ascii: 71,
+    code: 522,
+    label: 'G',
   },
   {
-    "ascii": 72,
-    "code": 523,
-    "label": "H"
+    ascii: 72,
+    code: 523,
+    label: 'H',
   },
   {
-    "ascii": 73,
-    "code": 524,
-    "label": "I"
+    ascii: 73,
+    code: 524,
+    label: 'I',
   },
   {
-    "ascii": 74,
-    "code": 525,
-    "label": "J"
+    ascii: 74,
+    code: 525,
+    label: 'J',
   },
   {
-    "ascii": 75,
-    "code": 526,
-    "label": "K"
+    ascii: 75,
+    code: 526,
+    label: 'K',
   },
   {
-    "ascii": 76,
-    "code": 527,
-    "label": "L"
+    ascii: 76,
+    code: 527,
+    label: 'L',
   },
   {
-    "ascii": 77,
-    "code": 528,
-    "label": "M"
+    ascii: 77,
+    code: 528,
+    label: 'M',
   },
   {
-    "ascii": 78,
-    "code": 529,
-    "label": "N"
+    ascii: 78,
+    code: 529,
+    label: 'N',
   },
   {
-    "ascii": 79,
-    "code": 530,
-    "label": "O"
+    ascii: 79,
+    code: 530,
+    label: 'O',
   },
   {
-    "ascii": 80,
-    "code": 531,
-    "label": "P"
+    ascii: 80,
+    code: 531,
+    label: 'P',
   },
   {
-    "ascii": 81,
-    "code": 532,
-    "label": "Q"
+    ascii: 81,
+    code: 532,
+    label: 'Q',
   },
   {
-    "ascii": 82,
-    "code": 533,
-    "label": "R"
+    ascii: 82,
+    code: 533,
+    label: 'R',
   },
   {
-    "ascii": 83,
-    "code": 534,
-    "label": "S"
+    ascii: 83,
+    code: 534,
+    label: 'S',
   },
   {
-    "ascii": 84,
-    "code": 535,
-    "label": "T"
+    ascii: 84,
+    code: 535,
+    label: 'T',
   },
   {
-    "ascii": 85,
-    "code": 536,
-    "label": "U"
+    ascii: 85,
+    code: 536,
+    label: 'U',
   },
   {
-    "ascii": 86,
-    "code": 537,
-    "label": "V"
+    ascii: 86,
+    code: 537,
+    label: 'V',
   },
   {
-    "ascii": 87,
-    "code": 538,
-    "label": "W"
+    ascii: 87,
+    code: 538,
+    label: 'W',
   },
   {
-    "ascii": 88,
-    "code": 539,
-    "label": "X"
+    ascii: 88,
+    code: 539,
+    label: 'X',
   },
   {
-    "ascii": 89,
-    "code": 540,
-    "label": "Y"
+    ascii: 89,
+    code: 540,
+    label: 'Y',
   },
   {
-    "ascii": 90,
-    "code": 541,
-    "label": "Z"
+    ascii: 90,
+    code: 541,
+    label: 'Z',
   },
   {
-    "ascii": 91,
-    "code": 37,
-    "label": "8"
+    ascii: 91,
+    code: 37,
+    label: '8',
   },
   {
-    "ascii": 92,
-    "code": 100,
-    "label": "<"
+    ascii: 92,
+    code: 100,
+    label: '<',
   },
   {
-    "ascii": 93,
-    "code": 38,
-    "label": "9"
+    ascii: 93,
+    code: 38,
+    label: '9',
   },
   {
-    "ascii": 94,
-    "code": 560,
-    "label": "^ (dead)"
+    ascii: 94,
+    code: 560,
+    label: '^ (dead)',
   },
   {
-    "ascii": 95,
-    "code": 568,
-    "label": "_"
+    ascii: 95,
+    code: 568,
+    label: '_',
   },
   {
-    "ascii": 96,
-    "code": 558,
-    "label": "` (dead)"
+    ascii: 96,
+    code: 558,
+    label: '` (dead)',
   },
   {
-    "ascii": 97,
-    "code": 4,
-    "label": "a"
+    ascii: 97,
+    code: 4,
+    label: 'a',
   },
   {
-    "ascii": 98,
-    "code": 5,
-    "label": "b"
+    ascii: 98,
+    code: 5,
+    label: 'b',
   },
   {
-    "ascii": 99,
-    "code": 6,
-    "label": "c"
+    ascii: 99,
+    code: 6,
+    label: 'c',
   },
   {
-    "ascii": 100,
-    "code": 7,
-    "label": "d"
+    ascii: 100,
+    code: 7,
+    label: 'd',
   },
   {
-    "ascii": 101,
-    "code": 8,
-    "label": "e"
+    ascii: 101,
+    code: 8,
+    label: 'e',
   },
   {
-    "ascii": 102,
-    "code": 9,
-    "label": "f"
+    ascii: 102,
+    code: 9,
+    label: 'f',
   },
   {
-    "ascii": 103,
-    "code": 10,
-    "label": "g"
+    ascii: 103,
+    code: 10,
+    label: 'g',
   },
   {
-    "ascii": 104,
-    "code": 11,
-    "label": "h"
+    ascii: 104,
+    code: 11,
+    label: 'h',
   },
   {
-    "ascii": 105,
-    "code": 12,
-    "label": "i"
+    ascii: 105,
+    code: 12,
+    label: 'i',
   },
   {
-    "ascii": 106,
-    "code": 13,
-    "label": "j"
+    ascii: 106,
+    code: 13,
+    label: 'j',
   },
   {
-    "ascii": 107,
-    "code": 14,
-    "label": "k"
+    ascii: 107,
+    code: 14,
+    label: 'k',
   },
   {
-    "ascii": 108,
-    "code": 15,
-    "label": "l"
+    ascii: 108,
+    code: 15,
+    label: 'l',
   },
   {
-    "ascii": 109,
-    "code": 16,
-    "label": "m"
+    ascii: 109,
+    code: 16,
+    label: 'm',
   },
   {
-    "ascii": 110,
-    "code": 17,
-    "label": "n"
+    ascii: 110,
+    code: 17,
+    label: 'n',
   },
   {
-    "ascii": 111,
-    "code": 18,
-    "label": "o"
+    ascii: 111,
+    code: 18,
+    label: 'o',
   },
   {
-    "ascii": 112,
-    "code": 19,
-    "label": "p"
+    ascii: 112,
+    code: 19,
+    label: 'p',
   },
   {
-    "ascii": 113,
-    "code": 20,
-    "label": "q"
+    ascii: 113,
+    code: 20,
+    label: 'q',
   },
   {
-    "ascii": 114,
-    "code": 21,
-    "label": "r"
+    ascii: 114,
+    code: 21,
+    label: 'r',
   },
   {
-    "ascii": 115,
-    "code": 22,
-    "label": "s"
+    ascii: 115,
+    code: 22,
+    label: 's',
   },
   {
-    "ascii": 116,
-    "code": 23,
-    "label": "t"
+    ascii: 116,
+    code: 23,
+    label: 't',
   },
   {
-    "ascii": 117,
-    "code": 24,
-    "label": "u"
+    ascii: 117,
+    code: 24,
+    label: 'u',
   },
   {
-    "ascii": 118,
-    "code": 25,
-    "label": "v"
+    ascii: 118,
+    code: 25,
+    label: 'v',
   },
   {
-    "ascii": 119,
-    "code": 26,
-    "label": "w"
+    ascii: 119,
+    code: 26,
+    label: 'w',
   },
   {
-    "ascii": 120,
-    "code": 27,
-    "label": "x"
+    ascii: 120,
+    code: 27,
+    label: 'x',
   },
   {
-    "ascii": 121,
-    "code": 28,
-    "label": "y"
+    ascii: 121,
+    code: 28,
+    label: 'y',
   },
   {
-    "ascii": 122,
-    "code": 29,
-    "label": "z"
+    ascii: 122,
+    code: 29,
+    label: 'z',
   },
   {
-    "ascii": 123,
-    "code": 36,
-    "label": "7"
+    ascii: 123,
+    code: 36,
+    label: '7',
   },
   {
-    "ascii": 124,
-    "code": 46,
-    "label": "´ (dead)"
+    ascii: 124,
+    code: 46,
+    label: '´ (dead)',
   },
   {
-    "ascii": 125,
-    "code": 39,
-    "label": "0"
+    ascii: 125,
+    code: 39,
+    label: '0',
   },
   {
-    "ascii": 126,
-    "code": 48,
-    "label": "¨ (dead)"
+    ascii: 126,
+    code: 48,
+    label: '¨ (dead)',
   },
   {
-    "ascii": 127,
-    "code": 76,
-    "label": "del"
-  }
+    ascii: 127,
+    code: 76,
+    label: 'del',
+  },
 ];
-    

--- a/src/services/labellang/AsciiLabelDvorak.ts
+++ b/src/services/labellang/AsciiLabelDvorak.ts
@@ -1,645 +1,644 @@
 import { AsciiLabel } from './AsciiLabel';
-        
+
 export const AsciiLabelDvorak: AsciiLabel[] = [
   {
-    "ascii": 0,
-    "code": 0,
-    "label": ""
+    ascii: 0,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 1,
-    "code": 0,
-    "label": ""
+    ascii: 1,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 2,
-    "code": 0,
-    "label": ""
+    ascii: 2,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 3,
-    "code": 0,
-    "label": ""
+    ascii: 3,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 4,
-    "code": 0,
-    "label": ""
+    ascii: 4,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 5,
-    "code": 0,
-    "label": ""
+    ascii: 5,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 6,
-    "code": 0,
-    "label": ""
+    ascii: 6,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 7,
-    "code": 0,
-    "label": ""
+    ascii: 7,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 8,
-    "code": 42,
-    "label": "back space"
+    ascii: 8,
+    code: 42,
+    label: 'back space',
   },
   {
-    "ascii": 9,
-    "code": 43,
-    "label": "tab"
+    ascii: 9,
+    code: 43,
+    label: 'tab',
   },
   {
-    "ascii": 10,
-    "code": 40,
-    "label": "enter"
+    ascii: 10,
+    code: 40,
+    label: 'enter',
   },
   {
-    "ascii": 11,
-    "code": 0,
-    "label": ""
+    ascii: 11,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 12,
-    "code": 0,
-    "label": ""
+    ascii: 12,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 13,
-    "code": 0,
-    "label": ""
+    ascii: 13,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 14,
-    "code": 0,
-    "label": ""
+    ascii: 14,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 15,
-    "code": 0,
-    "label": ""
+    ascii: 15,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 16,
-    "code": 0,
-    "label": ""
+    ascii: 16,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 17,
-    "code": 0,
-    "label": ""
+    ascii: 17,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 18,
-    "code": 0,
-    "label": ""
+    ascii: 18,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 19,
-    "code": 0,
-    "label": ""
+    ascii: 19,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 20,
-    "code": 0,
-    "label": ""
+    ascii: 20,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 21,
-    "code": 0,
-    "label": ""
+    ascii: 21,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 22,
-    "code": 0,
-    "label": ""
+    ascii: 22,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 23,
-    "code": 0,
-    "label": ""
+    ascii: 23,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 24,
-    "code": 0,
-    "label": ""
+    ascii: 24,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 25,
-    "code": 0,
-    "label": ""
+    ascii: 25,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 26,
-    "code": 0,
-    "label": ""
+    ascii: 26,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 27,
-    "code": 41,
-    "label": "esc"
+    ascii: 27,
+    code: 41,
+    label: 'esc',
   },
   {
-    "ascii": 28,
-    "code": 0,
-    "label": ""
+    ascii: 28,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 29,
-    "code": 0,
-    "label": ""
+    ascii: 29,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 30,
-    "code": 0,
-    "label": ""
+    ascii: 30,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 31,
-    "code": 0,
-    "label": ""
+    ascii: 31,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 32,
-    "code": 44,
-    "label": "space"
+    ascii: 32,
+    code: 44,
+    label: 'space',
   },
   {
-    "ascii": 33,
-    "code": 30,
-    "label": "1"
+    ascii: 33,
+    code: 30,
+    label: '1',
   },
   {
-    "ascii": 34,
-    "code": 20,
-    "label": "'"
+    ascii: 34,
+    code: 20,
+    label: "'",
   },
   {
-    "ascii": 35,
-    "code": 32,
-    "label": "3"
+    ascii: 35,
+    code: 32,
+    label: '3',
   },
   {
-    "ascii": 36,
-    "code": 33,
-    "label": "4"
+    ascii: 36,
+    code: 33,
+    label: '4',
   },
   {
-    "ascii": 37,
-    "code": 34,
-    "label": "5"
+    ascii: 37,
+    code: 34,
+    label: '5',
   },
   {
-    "ascii": 38,
-    "code": 36,
-    "label": "7"
+    ascii: 38,
+    code: 36,
+    label: '7',
   },
   {
-    "ascii": 39,
-    "code": 20,
-    "label": "'"
+    ascii: 39,
+    code: 20,
+    label: "'",
   },
   {
-    "ascii": 40,
-    "code": 38,
-    "label": "9"
+    ascii: 40,
+    code: 38,
+    label: '9',
   },
   {
-    "ascii": 41,
-    "code": 39,
-    "label": "0"
+    ascii: 41,
+    code: 39,
+    label: '0',
   },
   {
-    "ascii": 42,
-    "code": 37,
-    "label": "8"
+    ascii: 42,
+    code: 37,
+    label: '8',
   },
   {
-    "ascii": 43,
-    "code": 48,
-    "label": "="
+    ascii: 43,
+    code: 48,
+    label: '=',
   },
   {
-    "ascii": 44,
-    "code": 26,
-    "label": ","
+    ascii: 44,
+    code: 26,
+    label: ',',
   },
   {
-    "ascii": 45,
-    "code": 52,
-    "label": "-"
+    ascii: 45,
+    code: 52,
+    label: '-',
   },
   {
-    "ascii": 46,
-    "code": 8,
-    "label": "."
+    ascii: 46,
+    code: 8,
+    label: '.',
   },
   {
-    "ascii": 47,
-    "code": 47,
-    "label": "/"
+    ascii: 47,
+    code: 47,
+    label: '/',
   },
   {
-    "ascii": 48,
-    "code": 39,
-    "label": "0"
+    ascii: 48,
+    code: 39,
+    label: '0',
   },
   {
-    "ascii": 49,
-    "code": 30,
-    "label": "1"
+    ascii: 49,
+    code: 30,
+    label: '1',
   },
   {
-    "ascii": 50,
-    "code": 31,
-    "label": "2"
+    ascii: 50,
+    code: 31,
+    label: '2',
   },
   {
-    "ascii": 51,
-    "code": 32,
-    "label": "3"
+    ascii: 51,
+    code: 32,
+    label: '3',
   },
   {
-    "ascii": 52,
-    "code": 33,
-    "label": "4"
+    ascii: 52,
+    code: 33,
+    label: '4',
   },
   {
-    "ascii": 53,
-    "code": 34,
-    "label": "5"
+    ascii: 53,
+    code: 34,
+    label: '5',
   },
   {
-    "ascii": 54,
-    "code": 35,
-    "label": "6"
+    ascii: 54,
+    code: 35,
+    label: '6',
   },
   {
-    "ascii": 55,
-    "code": 36,
-    "label": "7"
+    ascii: 55,
+    code: 36,
+    label: '7',
   },
   {
-    "ascii": 56,
-    "code": 37,
-    "label": "8"
+    ascii: 56,
+    code: 37,
+    label: '8',
   },
   {
-    "ascii": 57,
-    "code": 38,
-    "label": "9"
+    ascii: 57,
+    code: 38,
+    label: '9',
   },
   {
-    "ascii": 58,
-    "code": 29,
-    "label": ";"
+    ascii: 58,
+    code: 29,
+    label: ';',
   },
   {
-    "ascii": 59,
-    "code": 29,
-    "label": ";"
+    ascii: 59,
+    code: 29,
+    label: ';',
   },
   {
-    "ascii": 60,
-    "code": 26,
-    "label": ","
+    ascii: 60,
+    code: 26,
+    label: ',',
   },
   {
-    "ascii": 61,
-    "code": 48,
-    "label": "="
+    ascii: 61,
+    code: 48,
+    label: '=',
   },
   {
-    "ascii": 62,
-    "code": 8,
-    "label": "."
+    ascii: 62,
+    code: 8,
+    label: '.',
   },
   {
-    "ascii": 63,
-    "code": 47,
-    "label": "/"
+    ascii: 63,
+    code: 47,
+    label: '/',
   },
   {
-    "ascii": 64,
-    "code": 31,
-    "label": "2"
+    ascii: 64,
+    code: 31,
+    label: '2',
   },
   {
-    "ascii": 65,
-    "code": 4,
-    "label": "a"
+    ascii: 65,
+    code: 4,
+    label: 'a',
   },
   {
-    "ascii": 66,
-    "code": 17,
-    "label": "b"
+    ascii: 66,
+    code: 17,
+    label: 'b',
   },
   {
-    "ascii": 67,
-    "code": 12,
-    "label": "c"
+    ascii: 67,
+    code: 12,
+    label: 'c',
   },
   {
-    "ascii": 68,
-    "code": 11,
-    "label": "d"
+    ascii: 68,
+    code: 11,
+    label: 'd',
   },
   {
-    "ascii": 69,
-    "code": 7,
-    "label": "e"
+    ascii: 69,
+    code: 7,
+    label: 'e',
   },
   {
-    "ascii": 70,
-    "code": 28,
-    "label": "f"
+    ascii: 70,
+    code: 28,
+    label: 'f',
   },
   {
-    "ascii": 71,
-    "code": 24,
-    "label": "g"
+    ascii: 71,
+    code: 24,
+    label: 'g',
   },
   {
-    "ascii": 72,
-    "code": 13,
-    "label": "h"
+    ascii: 72,
+    code: 13,
+    label: 'h',
   },
   {
-    "ascii": 73,
-    "code": 10,
-    "label": "i"
+    ascii: 73,
+    code: 10,
+    label: 'i',
   },
   {
-    "ascii": 74,
-    "code": 6,
-    "label": "j"
+    ascii: 74,
+    code: 6,
+    label: 'j',
   },
   {
-    "ascii": 75,
-    "code": 25,
-    "label": "k"
+    ascii: 75,
+    code: 25,
+    label: 'k',
   },
   {
-    "ascii": 76,
-    "code": 19,
-    "label": "l"
+    ascii: 76,
+    code: 19,
+    label: 'l',
   },
   {
-    "ascii": 77,
-    "code": 16,
-    "label": "m"
+    ascii: 77,
+    code: 16,
+    label: 'm',
   },
   {
-    "ascii": 78,
-    "code": 15,
-    "label": "n"
+    ascii: 78,
+    code: 15,
+    label: 'n',
   },
   {
-    "ascii": 79,
-    "code": 22,
-    "label": "o"
+    ascii: 79,
+    code: 22,
+    label: 'o',
   },
   {
-    "ascii": 80,
-    "code": 21,
-    "label": "p"
+    ascii: 80,
+    code: 21,
+    label: 'p',
   },
   {
-    "ascii": 81,
-    "code": 27,
-    "label": "q"
+    ascii: 81,
+    code: 27,
+    label: 'q',
   },
   {
-    "ascii": 82,
-    "code": 18,
-    "label": "r"
+    ascii: 82,
+    code: 18,
+    label: 'r',
   },
   {
-    "ascii": 83,
-    "code": 51,
-    "label": "s"
+    ascii: 83,
+    code: 51,
+    label: 's',
   },
   {
-    "ascii": 84,
-    "code": 14,
-    "label": "t"
+    ascii: 84,
+    code: 14,
+    label: 't',
   },
   {
-    "ascii": 85,
-    "code": 9,
-    "label": "u"
+    ascii: 85,
+    code: 9,
+    label: 'u',
   },
   {
-    "ascii": 86,
-    "code": 55,
-    "label": "v"
+    ascii: 86,
+    code: 55,
+    label: 'v',
   },
   {
-    "ascii": 87,
-    "code": 54,
-    "label": "w"
+    ascii: 87,
+    code: 54,
+    label: 'w',
   },
   {
-    "ascii": 88,
-    "code": 5,
-    "label": "x"
+    ascii: 88,
+    code: 5,
+    label: 'x',
   },
   {
-    "ascii": 89,
-    "code": 23,
-    "label": "y"
+    ascii: 89,
+    code: 23,
+    label: 'y',
   },
   {
-    "ascii": 90,
-    "code": 56,
-    "label": "z"
+    ascii: 90,
+    code: 56,
+    label: 'z',
   },
   {
-    "ascii": 91,
-    "code": 45,
-    "label": "["
+    ascii: 91,
+    code: 45,
+    label: '[',
   },
   {
-    "ascii": 92,
-    "code": 49,
-    "label": "(backslash)"
+    ascii: 92,
+    code: 49,
+    label: '(backslash)',
   },
   {
-    "ascii": 93,
-    "code": 46,
-    "label": "]"
+    ascii: 93,
+    code: 46,
+    label: ']',
   },
   {
-    "ascii": 94,
-    "code": 35,
-    "label": "6"
+    ascii: 94,
+    code: 35,
+    label: '6',
   },
   {
-    "ascii": 95,
-    "code": 52,
-    "label": "-"
+    ascii: 95,
+    code: 52,
+    label: '-',
   },
   {
-    "ascii": 96,
-    "code": 53,
-    "label": "`"
+    ascii: 96,
+    code: 53,
+    label: '`',
   },
   {
-    "ascii": 97,
-    "code": 4,
-    "label": "a"
+    ascii: 97,
+    code: 4,
+    label: 'a',
   },
   {
-    "ascii": 98,
-    "code": 17,
-    "label": "b"
+    ascii: 98,
+    code: 17,
+    label: 'b',
   },
   {
-    "ascii": 99,
-    "code": 12,
-    "label": "c"
+    ascii: 99,
+    code: 12,
+    label: 'c',
   },
   {
-    "ascii": 100,
-    "code": 11,
-    "label": "d"
+    ascii: 100,
+    code: 11,
+    label: 'd',
   },
   {
-    "ascii": 101,
-    "code": 7,
-    "label": "e"
+    ascii: 101,
+    code: 7,
+    label: 'e',
   },
   {
-    "ascii": 102,
-    "code": 28,
-    "label": "f"
+    ascii: 102,
+    code: 28,
+    label: 'f',
   },
   {
-    "ascii": 103,
-    "code": 24,
-    "label": "g"
+    ascii: 103,
+    code: 24,
+    label: 'g',
   },
   {
-    "ascii": 104,
-    "code": 13,
-    "label": "h"
+    ascii: 104,
+    code: 13,
+    label: 'h',
   },
   {
-    "ascii": 105,
-    "code": 10,
-    "label": "i"
+    ascii: 105,
+    code: 10,
+    label: 'i',
   },
   {
-    "ascii": 106,
-    "code": 6,
-    "label": "j"
+    ascii: 106,
+    code: 6,
+    label: 'j',
   },
   {
-    "ascii": 107,
-    "code": 25,
-    "label": "k"
+    ascii: 107,
+    code: 25,
+    label: 'k',
   },
   {
-    "ascii": 108,
-    "code": 19,
-    "label": "l"
+    ascii: 108,
+    code: 19,
+    label: 'l',
   },
   {
-    "ascii": 109,
-    "code": 16,
-    "label": "m"
+    ascii: 109,
+    code: 16,
+    label: 'm',
   },
   {
-    "ascii": 110,
-    "code": 15,
-    "label": "n"
+    ascii: 110,
+    code: 15,
+    label: 'n',
   },
   {
-    "ascii": 111,
-    "code": 22,
-    "label": "o"
+    ascii: 111,
+    code: 22,
+    label: 'o',
   },
   {
-    "ascii": 112,
-    "code": 21,
-    "label": "p"
+    ascii: 112,
+    code: 21,
+    label: 'p',
   },
   {
-    "ascii": 113,
-    "code": 27,
-    "label": "q"
+    ascii: 113,
+    code: 27,
+    label: 'q',
   },
   {
-    "ascii": 114,
-    "code": 18,
-    "label": "r"
+    ascii: 114,
+    code: 18,
+    label: 'r',
   },
   {
-    "ascii": 115,
-    "code": 51,
-    "label": "s"
+    ascii: 115,
+    code: 51,
+    label: 's',
   },
   {
-    "ascii": 116,
-    "code": 14,
-    "label": "t"
+    ascii: 116,
+    code: 14,
+    label: 't',
   },
   {
-    "ascii": 117,
-    "code": 9,
-    "label": "u"
+    ascii: 117,
+    code: 9,
+    label: 'u',
   },
   {
-    "ascii": 118,
-    "code": 55,
-    "label": "v"
+    ascii: 118,
+    code: 55,
+    label: 'v',
   },
   {
-    "ascii": 119,
-    "code": 54,
-    "label": "w"
+    ascii: 119,
+    code: 54,
+    label: 'w',
   },
   {
-    "ascii": 120,
-    "code": 5,
-    "label": "x"
+    ascii: 120,
+    code: 5,
+    label: 'x',
   },
   {
-    "ascii": 121,
-    "code": 23,
-    "label": "y"
+    ascii: 121,
+    code: 23,
+    label: 'y',
   },
   {
-    "ascii": 122,
-    "code": 56,
-    "label": "z"
+    ascii: 122,
+    code: 56,
+    label: 'z',
   },
   {
-    "ascii": 123,
-    "code": 45,
-    "label": "["
+    ascii: 123,
+    code: 45,
+    label: '[',
   },
   {
-    "ascii": 124,
-    "code": 49,
-    "label": "(backslash)"
+    ascii: 124,
+    code: 49,
+    label: '(backslash)',
   },
   {
-    "ascii": 125,
-    "code": 46,
-    "label": "]"
+    ascii: 125,
+    code: 46,
+    label: ']',
   },
   {
-    "ascii": 126,
-    "code": 53,
-    "label": "`"
+    ascii: 126,
+    code: 53,
+    label: '`',
   },
   {
-    "ascii": 127,
-    "code": 76,
-    "label": "del"
-  }
+    ascii: 127,
+    code: 76,
+    label: 'del',
+  },
 ];
-    

--- a/src/services/labellang/AsciiLabelDvorak_fr.ts
+++ b/src/services/labellang/AsciiLabelDvorak_fr.ts
@@ -1,645 +1,644 @@
 import { AsciiLabel } from './AsciiLabel';
-        
+
 export const AsciiLabelDvorak_fr: AsciiLabel[] = [
   {
-    "ascii": 0,
-    "code": 0,
-    "label": ""
+    ascii: 0,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 1,
-    "code": 0,
-    "label": ""
+    ascii: 1,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 2,
-    "code": 0,
-    "label": ""
+    ascii: 2,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 3,
-    "code": 0,
-    "label": ""
+    ascii: 3,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 4,
-    "code": 0,
-    "label": ""
+    ascii: 4,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 5,
-    "code": 0,
-    "label": ""
+    ascii: 5,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 6,
-    "code": 0,
-    "label": ""
+    ascii: 6,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 7,
-    "code": 0,
-    "label": ""
+    ascii: 7,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 8,
-    "code": 42,
-    "label": "back space"
+    ascii: 8,
+    code: 42,
+    label: 'back space',
   },
   {
-    "ascii": 9,
-    "code": 43,
-    "label": "tab"
+    ascii: 9,
+    code: 43,
+    label: 'tab',
   },
   {
-    "ascii": 10,
-    "code": 40,
-    "label": "enter"
+    ascii: 10,
+    code: 40,
+    label: 'enter',
   },
   {
-    "ascii": 11,
-    "code": 0,
-    "label": ""
+    ascii: 11,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 12,
-    "code": 0,
-    "label": ""
+    ascii: 12,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 13,
-    "code": 0,
-    "label": ""
+    ascii: 13,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 14,
-    "code": 0,
-    "label": ""
+    ascii: 14,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 15,
-    "code": 0,
-    "label": ""
+    ascii: 15,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 16,
-    "code": 0,
-    "label": ""
+    ascii: 16,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 17,
-    "code": 0,
-    "label": ""
+    ascii: 17,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 18,
-    "code": 0,
-    "label": ""
+    ascii: 18,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 19,
-    "code": 0,
-    "label": ""
+    ascii: 19,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 20,
-    "code": 0,
-    "label": ""
+    ascii: 20,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 21,
-    "code": 0,
-    "label": ""
+    ascii: 21,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 22,
-    "code": 0,
-    "label": ""
+    ascii: 22,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 23,
-    "code": 0,
-    "label": ""
+    ascii: 23,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 24,
-    "code": 0,
-    "label": ""
+    ascii: 24,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 25,
-    "code": 0,
-    "label": ""
+    ascii: 25,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 26,
-    "code": 0,
-    "label": ""
+    ascii: 26,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 27,
-    "code": 41,
-    "label": "esc"
+    ascii: 27,
+    code: 41,
+    label: 'esc',
   },
   {
-    "ascii": 28,
-    "code": 0,
-    "label": ""
+    ascii: 28,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 29,
-    "code": 0,
-    "label": ""
+    ascii: 29,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 30,
-    "code": 0,
-    "label": ""
+    ascii: 30,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 31,
-    "code": 0,
-    "label": ""
+    ascii: 31,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 32,
-    "code": 44,
-    "label": "space"
+    ascii: 32,
+    code: 44,
+    label: 'space',
   },
   {
-    "ascii": 33,
-    "code": 535,
-    "label": "!"
+    ascii: 33,
+    code: 535,
+    label: '!',
   },
   {
-    "ascii": 34,
-    "code": 0,
-    "label": ""
+    ascii: 34,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 35,
-    "code": 562,
-    "label": "#"
+    ascii: 35,
+    code: 562,
+    label: '#',
   },
   {
-    "ascii": 36,
-    "code": 0,
-    "label": ""
+    ascii: 36,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 37,
-    "code": 558,
-    "label": "%"
+    ascii: 37,
+    code: 558,
+    label: '%',
   },
   {
-    "ascii": 38,
-    "code": 0,
-    "label": ""
+    ascii: 38,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 39,
-    "code": 26,
-    "label": "'"
+    ascii: 39,
+    code: 26,
+    label: "'",
   },
   {
-    "ascii": 40,
-    "code": 36,
-    "label": "("
+    ascii: 40,
+    code: 36,
+    label: '(',
   },
   {
-    "ascii": 41,
-    "code": 38,
-    "label": ")"
+    ascii: 41,
+    code: 38,
+    label: ')',
   },
   {
-    "ascii": 42,
-    "code": 565,
-    "label": "*"
+    ascii: 42,
+    code: 565,
+    label: '*',
   },
   {
-    "ascii": 43,
-    "code": 557,
-    "label": "+"
+    ascii: 43,
+    code: 557,
+    label: '+',
   },
   {
-    "ascii": 44,
-    "code": 6,
-    "label": ","
+    ascii: 44,
+    code: 6,
+    label: ',',
   },
   {
-    "ascii": 45,
-    "code": 32,
-    "label": "-"
+    ascii: 45,
+    code: 32,
+    label: '-',
   },
   {
-    "ascii": 46,
-    "code": 23,
-    "label": "."
+    ascii: 46,
+    code: 23,
+    label: '.',
   },
   {
-    "ascii": 47,
-    "code": 31,
-    "label": "/"
+    ascii: 47,
+    code: 31,
+    label: '/',
   },
   {
-    "ascii": 48,
-    "code": 551,
-    "label": "0"
+    ascii: 48,
+    code: 551,
+    label: '0',
   },
   {
-    "ascii": 49,
-    "code": 542,
-    "label": "1"
+    ascii: 49,
+    code: 542,
+    label: '1',
   },
   {
-    "ascii": 50,
-    "code": 543,
-    "label": "2"
+    ascii: 50,
+    code: 543,
+    label: '2',
   },
   {
-    "ascii": 51,
-    "code": 544,
-    "label": "3"
+    ascii: 51,
+    code: 544,
+    label: '3',
   },
   {
-    "ascii": 52,
-    "code": 545,
-    "label": "4"
+    ascii: 52,
+    code: 545,
+    label: '4',
   },
   {
-    "ascii": 53,
-    "code": 546,
-    "label": "5"
+    ascii: 53,
+    code: 546,
+    label: '5',
   },
   {
-    "ascii": 54,
-    "code": 547,
-    "label": "6"
+    ascii: 54,
+    code: 547,
+    label: '6',
   },
   {
-    "ascii": 55,
-    "code": 548,
-    "label": "7"
+    ascii: 55,
+    code: 548,
+    label: '7',
   },
   {
-    "ascii": 56,
-    "code": 549,
-    "label": "8"
+    ascii: 56,
+    code: 549,
+    label: '8',
   },
   {
-    "ascii": 57,
-    "code": 550,
-    "label": "9"
+    ascii: 57,
+    code: 550,
+    label: '9',
   },
   {
-    "ascii": 58,
-    "code": 20,
-    "label": ":"
+    ascii: 58,
+    code: 20,
+    label: ':',
   },
   {
-    "ascii": 59,
-    "code": 29,
-    "label": ";"
+    ascii: 59,
+    code: 29,
+    label: ';',
   },
   {
-    "ascii": 60,
-    "code": 538,
-    "label": "<"
+    ascii: 60,
+    code: 538,
+    label: '<',
   },
   {
-    "ascii": 61,
-    "code": 560,
-    "label": "="
+    ascii: 61,
+    code: 560,
+    label: '=',
   },
   {
-    "ascii": 62,
-    "code": 520,
-    "label": ">"
+    ascii: 62,
+    code: 520,
+    label: '>',
   },
   {
-    "ascii": 63,
-    "code": 532,
-    "label": "?"
+    ascii: 63,
+    code: 532,
+    label: '?',
   },
   {
-    "ascii": 64,
-    "code": 518,
-    "label": "@"
+    ascii: 64,
+    code: 518,
+    label: '@',
   },
   {
-    "ascii": 65,
-    "code": 534,
-    "label": "A"
+    ascii: 65,
+    code: 534,
+    label: 'A',
   },
   {
-    "ascii": 66,
-    "code": 522,
-    "label": "B"
+    ascii: 66,
+    code: 522,
+    label: 'B',
   },
   {
-    "ascii": 67,
-    "code": 524,
-    "label": "C"
+    ascii: 67,
+    code: 524,
+    label: 'C',
   },
   {
-    "ascii": 68,
-    "code": 563,
-    "label": "D"
+    ascii: 68,
+    code: 563,
+    label: 'D',
   },
   {
-    "ascii": 69,
-    "code": 521,
-    "label": "E"
+    ascii: 69,
+    code: 521,
+    label: 'E',
   },
   {
-    "ascii": 70,
-    "code": 523,
-    "label": "F"
+    ascii: 70,
+    code: 523,
+    label: 'F',
   },
   {
-    "ascii": 71,
-    "code": 533,
-    "label": "G"
+    ascii: 71,
+    code: 533,
+    label: 'G',
   },
   {
-    "ascii": 72,
-    "code": 540,
-    "label": "H"
+    ascii: 72,
+    code: 540,
+    label: 'H',
   },
   {
-    "ascii": 73,
-    "code": 537,
-    "label": "I"
+    ascii: 73,
+    code: 537,
+    label: 'I',
   },
   {
-    "ascii": 74,
-    "code": 568,
-    "label": "J"
+    ascii: 74,
+    code: 568,
+    label: 'J',
   },
   {
-    "ascii": 75,
-    "code": 531,
-    "label": "K"
+    ascii: 75,
+    code: 531,
+    label: 'K',
   },
   {
-    "ascii": 76,
-    "code": 566,
-    "label": "L"
+    ascii: 76,
+    code: 566,
+    label: 'L',
   },
   {
-    "ascii": 77,
-    "code": 530,
-    "label": "M"
+    ascii: 77,
+    code: 530,
+    label: 'M',
   },
   {
-    "ascii": 78,
-    "code": 527,
-    "label": "N"
+    ascii: 78,
+    code: 527,
+    label: 'N',
   },
   {
-    "ascii": 79,
-    "code": 516,
-    "label": "O"
+    ascii: 79,
+    code: 516,
+    label: 'O',
   },
   {
-    "ascii": 80,
-    "code": 567,
-    "label": "P"
+    ascii: 80,
+    code: 567,
+    label: 'P',
   },
   {
-    "ascii": 81,
-    "code": 539,
-    "label": "Q"
+    ascii: 81,
+    code: 539,
+    label: 'Q',
   },
   {
-    "ascii": 82,
-    "code": 528,
-    "label": "R"
+    ascii: 82,
+    code: 528,
+    label: 'R',
   },
   {
-    "ascii": 83,
-    "code": 525,
-    "label": "S"
+    ascii: 83,
+    code: 525,
+    label: 'S',
   },
   {
-    "ascii": 84,
-    "code": 526,
-    "label": "T"
+    ascii: 84,
+    code: 526,
+    label: 'T',
   },
   {
-    "ascii": 85,
-    "code": 519,
-    "label": "U"
+    ascii: 85,
+    code: 519,
+    label: 'U',
   },
   {
-    "ascii": 86,
-    "code": 536,
-    "label": "V"
+    ascii: 86,
+    code: 536,
+    label: 'V',
   },
   {
-    "ascii": 87,
-    "code": 564,
-    "label": "W"
+    ascii: 87,
+    code: 564,
+    label: 'W',
   },
   {
-    "ascii": 88,
-    "code": 529,
-    "label": "X"
+    ascii: 88,
+    code: 529,
+    label: 'X',
   },
   {
-    "ascii": 89,
-    "code": 517,
-    "label": "Y"
+    ascii: 89,
+    code: 517,
+    label: 'Y',
   },
   {
-    "ascii": 90,
-    "code": 559,
-    "label": "Z"
+    ascii: 90,
+    code: 559,
+    label: 'Z',
   },
   {
-    "ascii": 91,
-    "code": 45,
-    "label": "["
+    ascii: 91,
+    code: 45,
+    label: '[',
   },
   {
-    "ascii": 92,
-    "code": 34,
-    "label": "(backslash)"
+    ascii: 92,
+    code: 34,
+    label: '(backslash)',
   },
   {
-    "ascii": 93,
-    "code": 46,
-    "label": "]"
+    ascii: 93,
+    code: 46,
+    label: ']',
   },
   {
-    "ascii": 94,
-    "code": 35,
-    "label": "^ (dead)"
+    ascii: 94,
+    code: 35,
+    label: '^ (dead)',
   },
   {
-    "ascii": 95,
-    "code": 39,
-    "label": "_"
+    ascii: 95,
+    code: 39,
+    label: '_',
   },
   {
-    "ascii": 96,
-    "code": 37,
-    "label": "` (dead)"
+    ascii: 96,
+    code: 37,
+    label: '` (dead)',
   },
   {
-    "ascii": 97,
-    "code": 22,
-    "label": "a"
+    ascii: 97,
+    code: 22,
+    label: 'a',
   },
   {
-    "ascii": 98,
-    "code": 10,
-    "label": "b"
+    ascii: 98,
+    code: 10,
+    label: 'b',
   },
   {
-    "ascii": 99,
-    "code": 12,
-    "label": "c"
+    ascii: 99,
+    code: 12,
+    label: 'c',
   },
   {
-    "ascii": 100,
-    "code": 51,
-    "label": "d"
+    ascii: 100,
+    code: 51,
+    label: 'd',
   },
   {
-    "ascii": 101,
-    "code": 9,
-    "label": "e"
+    ascii: 101,
+    code: 9,
+    label: 'e',
   },
   {
-    "ascii": 102,
-    "code": 11,
-    "label": "f"
+    ascii: 102,
+    code: 11,
+    label: 'f',
   },
   {
-    "ascii": 103,
-    "code": 21,
-    "label": "g"
+    ascii: 103,
+    code: 21,
+    label: 'g',
   },
   {
-    "ascii": 104,
-    "code": 28,
-    "label": "h"
+    ascii: 104,
+    code: 28,
+    label: 'h',
   },
   {
-    "ascii": 105,
-    "code": 25,
-    "label": "i"
+    ascii: 105,
+    code: 25,
+    label: 'i',
   },
   {
-    "ascii": 106,
-    "code": 56,
-    "label": "j"
+    ascii: 106,
+    code: 56,
+    label: 'j',
   },
   {
-    "ascii": 107,
-    "code": 19,
-    "label": "k"
+    ascii: 107,
+    code: 19,
+    label: 'k',
   },
   {
-    "ascii": 108,
-    "code": 54,
-    "label": "l"
+    ascii: 108,
+    code: 54,
+    label: 'l',
   },
   {
-    "ascii": 109,
-    "code": 18,
-    "label": "m"
+    ascii: 109,
+    code: 18,
+    label: 'm',
   },
   {
-    "ascii": 110,
-    "code": 15,
-    "label": "n"
+    ascii: 110,
+    code: 15,
+    label: 'n',
   },
   {
-    "ascii": 111,
-    "code": 4,
-    "label": "o"
+    ascii: 111,
+    code: 4,
+    label: 'o',
   },
   {
-    "ascii": 112,
-    "code": 55,
-    "label": "p"
+    ascii: 112,
+    code: 55,
+    label: 'p',
   },
   {
-    "ascii": 113,
-    "code": 27,
-    "label": "q"
+    ascii: 113,
+    code: 27,
+    label: 'q',
   },
   {
-    "ascii": 114,
-    "code": 16,
-    "label": "r"
+    ascii: 114,
+    code: 16,
+    label: 'r',
   },
   {
-    "ascii": 115,
-    "code": 13,
-    "label": "s"
+    ascii: 115,
+    code: 13,
+    label: 's',
   },
   {
-    "ascii": 116,
-    "code": 14,
-    "label": "t"
+    ascii: 116,
+    code: 14,
+    label: 't',
   },
   {
-    "ascii": 117,
-    "code": 7,
-    "label": "u"
+    ascii: 117,
+    code: 7,
+    label: 'u',
   },
   {
-    "ascii": 118,
-    "code": 24,
-    "label": "v"
+    ascii: 118,
+    code: 24,
+    label: 'v',
   },
   {
-    "ascii": 119,
-    "code": 52,
-    "label": "w"
+    ascii: 119,
+    code: 52,
+    label: 'w',
   },
   {
-    "ascii": 120,
-    "code": 17,
-    "label": "x"
+    ascii: 120,
+    code: 17,
+    label: 'x',
   },
   {
-    "ascii": 121,
-    "code": 5,
-    "label": "y"
+    ascii: 121,
+    code: 5,
+    label: 'y',
   },
   {
-    "ascii": 122,
-    "code": 47,
-    "label": "z"
+    ascii: 122,
+    code: 47,
+    label: 'z',
   },
   {
-    "ascii": 123,
-    "code": 0,
-    "label": ""
+    ascii: 123,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 124,
-    "code": 541,
-    "label": "|"
+    ascii: 124,
+    code: 541,
+    label: '|',
   },
   {
-    "ascii": 125,
-    "code": 0,
-    "label": ""
+    ascii: 125,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 126,
-    "code": 50,
-    "label": "~ (dead)"
+    ascii: 126,
+    code: 50,
+    label: '~ (dead)',
   },
   {
-    "ascii": 127,
-    "code": 76,
-    "label": "del"
-  }
+    ascii: 127,
+    code: 76,
+    label: 'del',
+  },
 ];
-    

--- a/src/services/labellang/AsciiLabelDvp.ts
+++ b/src/services/labellang/AsciiLabelDvp.ts
@@ -1,645 +1,644 @@
 import { AsciiLabel } from './AsciiLabel';
-        
+
 export const AsciiLabelDvp: AsciiLabel[] = [
   {
-    "ascii": 0,
-    "code": 0,
-    "label": ""
+    ascii: 0,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 1,
-    "code": 0,
-    "label": ""
+    ascii: 1,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 2,
-    "code": 0,
-    "label": ""
+    ascii: 2,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 3,
-    "code": 0,
-    "label": ""
+    ascii: 3,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 4,
-    "code": 0,
-    "label": ""
+    ascii: 4,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 5,
-    "code": 0,
-    "label": ""
+    ascii: 5,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 6,
-    "code": 0,
-    "label": ""
+    ascii: 6,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 7,
-    "code": 0,
-    "label": ""
+    ascii: 7,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 8,
-    "code": 42,
-    "label": "back space"
+    ascii: 8,
+    code: 42,
+    label: 'back space',
   },
   {
-    "ascii": 9,
-    "code": 43,
-    "label": "tab"
+    ascii: 9,
+    code: 43,
+    label: 'tab',
   },
   {
-    "ascii": 10,
-    "code": 40,
-    "label": "enter"
+    ascii: 10,
+    code: 40,
+    label: 'enter',
   },
   {
-    "ascii": 11,
-    "code": 0,
-    "label": ""
+    ascii: 11,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 12,
-    "code": 0,
-    "label": ""
+    ascii: 12,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 13,
-    "code": 0,
-    "label": ""
+    ascii: 13,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 14,
-    "code": 0,
-    "label": ""
+    ascii: 14,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 15,
-    "code": 0,
-    "label": ""
+    ascii: 15,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 16,
-    "code": 0,
-    "label": ""
+    ascii: 16,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 17,
-    "code": 0,
-    "label": ""
+    ascii: 17,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 18,
-    "code": 0,
-    "label": ""
+    ascii: 18,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 19,
-    "code": 0,
-    "label": ""
+    ascii: 19,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 20,
-    "code": 0,
-    "label": ""
+    ascii: 20,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 21,
-    "code": 0,
-    "label": ""
+    ascii: 21,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 22,
-    "code": 0,
-    "label": ""
+    ascii: 22,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 23,
-    "code": 0,
-    "label": ""
+    ascii: 23,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 24,
-    "code": 0,
-    "label": ""
+    ascii: 24,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 25,
-    "code": 0,
-    "label": ""
+    ascii: 25,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 26,
-    "code": 0,
-    "label": ""
+    ascii: 26,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 27,
-    "code": 41,
-    "label": "esc"
+    ascii: 27,
+    code: 41,
+    label: 'esc',
   },
   {
-    "ascii": 28,
-    "code": 0,
-    "label": ""
+    ascii: 28,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 29,
-    "code": 0,
-    "label": ""
+    ascii: 29,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 30,
-    "code": 0,
-    "label": ""
+    ascii: 30,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 31,
-    "code": 0,
-    "label": ""
+    ascii: 31,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 32,
-    "code": 44,
-    "label": "space"
+    ascii: 32,
+    code: 44,
+    label: 'space',
   },
   {
-    "ascii": 33,
-    "code": 45,
-    "label": "!"
+    ascii: 33,
+    code: 45,
+    label: '!',
   },
   {
-    "ascii": 34,
-    "code": 541,
-    "label": "\""
+    ascii: 34,
+    code: 541,
+    label: '"',
   },
   {
-    "ascii": 35,
-    "code": 46,
-    "label": "#"
+    ascii: 35,
+    code: 46,
+    label: '#',
   },
   {
-    "ascii": 36,
-    "code": 53,
-    "label": "$"
+    ascii: 36,
+    code: 53,
+    label: '$',
   },
   {
-    "ascii": 37,
-    "code": 542,
-    "label": "%"
+    ascii: 37,
+    code: 542,
+    label: '%',
   },
   {
-    "ascii": 38,
-    "code": 30,
-    "label": "&"
+    ascii: 38,
+    code: 30,
+    label: '&',
   },
   {
-    "ascii": 39,
-    "code": 29,
-    "label": "'"
+    ascii: 39,
+    code: 29,
+    label: "'",
   },
   {
-    "ascii": 40,
-    "code": 34,
-    "label": "("
+    ascii: 40,
+    code: 34,
+    label: '(',
   },
   {
-    "ascii": 41,
-    "code": 37,
-    "label": ")"
+    ascii: 41,
+    code: 37,
+    label: ')',
   },
   {
-    "ascii": 42,
-    "code": 36,
-    "label": "*"
+    ascii: 42,
+    code: 36,
+    label: '*',
   },
   {
-    "ascii": 43,
-    "code": 38,
-    "label": "+"
+    ascii: 43,
+    code: 38,
+    label: '+',
   },
   {
-    "ascii": 44,
-    "code": 26,
-    "label": ","
+    ascii: 44,
+    code: 26,
+    label: ',',
   },
   {
-    "ascii": 45,
-    "code": 52,
-    "label": "-"
+    ascii: 45,
+    code: 52,
+    label: '-',
   },
   {
-    "ascii": 46,
-    "code": 8,
-    "label": "."
+    ascii: 46,
+    code: 8,
+    label: '.',
   },
   {
-    "ascii": 47,
-    "code": 47,
-    "label": "/"
+    ascii: 47,
+    code: 47,
+    label: '/',
   },
   {
-    "ascii": 48,
-    "code": 548,
-    "label": "0"
+    ascii: 48,
+    code: 548,
+    label: '0',
   },
   {
-    "ascii": 49,
-    "code": 546,
-    "label": "1"
+    ascii: 49,
+    code: 546,
+    label: '1',
   },
   {
-    "ascii": 50,
-    "code": 549,
-    "label": "2"
+    ascii: 50,
+    code: 549,
+    label: '2',
   },
   {
-    "ascii": 51,
-    "code": 545,
-    "label": "3"
+    ascii: 51,
+    code: 545,
+    label: '3',
   },
   {
-    "ascii": 52,
-    "code": 550,
-    "label": "4"
+    ascii: 52,
+    code: 550,
+    label: '4',
   },
   {
-    "ascii": 53,
-    "code": 544,
-    "label": "5"
+    ascii: 53,
+    code: 544,
+    label: '5',
   },
   {
-    "ascii": 54,
-    "code": 551,
-    "label": "6"
+    ascii: 54,
+    code: 551,
+    label: '6',
   },
   {
-    "ascii": 55,
-    "code": 543,
-    "label": "7"
+    ascii: 55,
+    code: 543,
+    label: '7',
   },
   {
-    "ascii": 56,
-    "code": 557,
-    "label": "8"
+    ascii: 56,
+    code: 557,
+    label: '8',
   },
   {
-    "ascii": 57,
-    "code": 547,
-    "label": "9"
+    ascii: 57,
+    code: 547,
+    label: '9',
   },
   {
-    "ascii": 58,
-    "code": 532,
-    "label": ":"
+    ascii: 58,
+    code: 532,
+    label: ':',
   },
   {
-    "ascii": 59,
-    "code": 20,
-    "label": ";"
+    ascii: 59,
+    code: 20,
+    label: ';',
   },
   {
-    "ascii": 60,
-    "code": 538,
-    "label": "<"
+    ascii: 60,
+    code: 538,
+    label: '<',
   },
   {
-    "ascii": 61,
-    "code": 35,
-    "label": "="
+    ascii: 61,
+    code: 35,
+    label: '=',
   },
   {
-    "ascii": 62,
-    "code": 520,
-    "label": ">"
+    ascii: 62,
+    code: 520,
+    label: '>',
   },
   {
-    "ascii": 63,
-    "code": 559,
-    "label": "?"
+    ascii: 63,
+    code: 559,
+    label: '?',
   },
   {
-    "ascii": 64,
-    "code": 48,
-    "label": "@"
+    ascii: 64,
+    code: 48,
+    label: '@',
   },
   {
-    "ascii": 65,
-    "code": 516,
-    "label": "A"
+    ascii: 65,
+    code: 516,
+    label: 'A',
   },
   {
-    "ascii": 66,
-    "code": 529,
-    "label": "B"
+    ascii: 66,
+    code: 529,
+    label: 'B',
   },
   {
-    "ascii": 67,
-    "code": 524,
-    "label": "C"
+    ascii: 67,
+    code: 524,
+    label: 'C',
   },
   {
-    "ascii": 68,
-    "code": 523,
-    "label": "D"
+    ascii: 68,
+    code: 523,
+    label: 'D',
   },
   {
-    "ascii": 69,
-    "code": 519,
-    "label": "E"
+    ascii: 69,
+    code: 519,
+    label: 'E',
   },
   {
-    "ascii": 70,
-    "code": 540,
-    "label": "F"
+    ascii: 70,
+    code: 540,
+    label: 'F',
   },
   {
-    "ascii": 71,
-    "code": 536,
-    "label": "G"
+    ascii: 71,
+    code: 536,
+    label: 'G',
   },
   {
-    "ascii": 72,
-    "code": 525,
-    "label": "H"
+    ascii: 72,
+    code: 525,
+    label: 'H',
   },
   {
-    "ascii": 73,
-    "code": 522,
-    "label": "I"
+    ascii: 73,
+    code: 522,
+    label: 'I',
   },
   {
-    "ascii": 74,
-    "code": 518,
-    "label": "J"
+    ascii: 74,
+    code: 518,
+    label: 'J',
   },
   {
-    "ascii": 75,
-    "code": 537,
-    "label": "K"
+    ascii: 75,
+    code: 537,
+    label: 'K',
   },
   {
-    "ascii": 76,
-    "code": 531,
-    "label": "L"
+    ascii: 76,
+    code: 531,
+    label: 'L',
   },
   {
-    "ascii": 77,
-    "code": 528,
-    "label": "M"
+    ascii: 77,
+    code: 528,
+    label: 'M',
   },
   {
-    "ascii": 78,
-    "code": 527,
-    "label": "N"
+    ascii: 78,
+    code: 527,
+    label: 'N',
   },
   {
-    "ascii": 79,
-    "code": 534,
-    "label": "O"
+    ascii: 79,
+    code: 534,
+    label: 'O',
   },
   {
-    "ascii": 80,
-    "code": 533,
-    "label": "P"
+    ascii: 80,
+    code: 533,
+    label: 'P',
   },
   {
-    "ascii": 81,
-    "code": 539,
-    "label": "Q"
+    ascii: 81,
+    code: 539,
+    label: 'Q',
   },
   {
-    "ascii": 82,
-    "code": 530,
-    "label": "R"
+    ascii: 82,
+    code: 530,
+    label: 'R',
   },
   {
-    "ascii": 83,
-    "code": 563,
-    "label": "S"
+    ascii: 83,
+    code: 563,
+    label: 'S',
   },
   {
-    "ascii": 84,
-    "code": 526,
-    "label": "T"
+    ascii: 84,
+    code: 526,
+    label: 'T',
   },
   {
-    "ascii": 85,
-    "code": 521,
-    "label": "U"
+    ascii: 85,
+    code: 521,
+    label: 'U',
   },
   {
-    "ascii": 86,
-    "code": 567,
-    "label": "V"
+    ascii: 86,
+    code: 567,
+    label: 'V',
   },
   {
-    "ascii": 87,
-    "code": 566,
-    "label": "W"
+    ascii: 87,
+    code: 566,
+    label: 'W',
   },
   {
-    "ascii": 88,
-    "code": 517,
-    "label": "X"
+    ascii: 88,
+    code: 517,
+    label: 'X',
   },
   {
-    "ascii": 89,
-    "code": 535,
-    "label": "Y"
+    ascii: 89,
+    code: 535,
+    label: 'Y',
   },
   {
-    "ascii": 90,
-    "code": 568,
-    "label": "Z"
+    ascii: 90,
+    code: 568,
+    label: 'Z',
   },
   {
-    "ascii": 91,
-    "code": 31,
-    "label": "["
+    ascii: 91,
+    code: 31,
+    label: '[',
   },
   {
-    "ascii": 92,
-    "code": 49,
-    "label": "(backslash)"
+    ascii: 92,
+    code: 49,
+    label: '(backslash)',
   },
   {
-    "ascii": 93,
-    "code": 39,
-    "label": "]"
+    ascii: 93,
+    code: 39,
+    label: ']',
   },
   {
-    "ascii": 94,
-    "code": 560,
-    "label": "^"
+    ascii: 94,
+    code: 560,
+    label: '^',
   },
   {
-    "ascii": 95,
-    "code": 564,
-    "label": "_"
+    ascii: 95,
+    code: 564,
+    label: '_',
   },
   {
-    "ascii": 96,
-    "code": 558,
-    "label": "`"
+    ascii: 96,
+    code: 558,
+    label: '`',
   },
   {
-    "ascii": 97,
-    "code": 4,
-    "label": "a"
+    ascii: 97,
+    code: 4,
+    label: 'a',
   },
   {
-    "ascii": 98,
-    "code": 17,
-    "label": "b"
+    ascii: 98,
+    code: 17,
+    label: 'b',
   },
   {
-    "ascii": 99,
-    "code": 12,
-    "label": "c"
+    ascii: 99,
+    code: 12,
+    label: 'c',
   },
   {
-    "ascii": 100,
-    "code": 11,
-    "label": "d"
+    ascii: 100,
+    code: 11,
+    label: 'd',
   },
   {
-    "ascii": 101,
-    "code": 7,
-    "label": "e"
+    ascii: 101,
+    code: 7,
+    label: 'e',
   },
   {
-    "ascii": 102,
-    "code": 28,
-    "label": "f"
+    ascii: 102,
+    code: 28,
+    label: 'f',
   },
   {
-    "ascii": 103,
-    "code": 24,
-    "label": "g"
+    ascii: 103,
+    code: 24,
+    label: 'g',
   },
   {
-    "ascii": 104,
-    "code": 13,
-    "label": "h"
+    ascii: 104,
+    code: 13,
+    label: 'h',
   },
   {
-    "ascii": 105,
-    "code": 10,
-    "label": "i"
+    ascii: 105,
+    code: 10,
+    label: 'i',
   },
   {
-    "ascii": 106,
-    "code": 6,
-    "label": "j"
+    ascii: 106,
+    code: 6,
+    label: 'j',
   },
   {
-    "ascii": 107,
-    "code": 25,
-    "label": "k"
+    ascii: 107,
+    code: 25,
+    label: 'k',
   },
   {
-    "ascii": 108,
-    "code": 19,
-    "label": "l"
+    ascii: 108,
+    code: 19,
+    label: 'l',
   },
   {
-    "ascii": 109,
-    "code": 16,
-    "label": "m"
+    ascii: 109,
+    code: 16,
+    label: 'm',
   },
   {
-    "ascii": 110,
-    "code": 15,
-    "label": "n"
+    ascii: 110,
+    code: 15,
+    label: 'n',
   },
   {
-    "ascii": 111,
-    "code": 22,
-    "label": "o"
+    ascii: 111,
+    code: 22,
+    label: 'o',
   },
   {
-    "ascii": 112,
-    "code": 21,
-    "label": "p"
+    ascii: 112,
+    code: 21,
+    label: 'p',
   },
   {
-    "ascii": 113,
-    "code": 27,
-    "label": "q"
+    ascii: 113,
+    code: 27,
+    label: 'q',
   },
   {
-    "ascii": 114,
-    "code": 18,
-    "label": "r"
+    ascii: 114,
+    code: 18,
+    label: 'r',
   },
   {
-    "ascii": 115,
-    "code": 51,
-    "label": "s"
+    ascii: 115,
+    code: 51,
+    label: 's',
   },
   {
-    "ascii": 116,
-    "code": 14,
-    "label": "t"
+    ascii: 116,
+    code: 14,
+    label: 't',
   },
   {
-    "ascii": 117,
-    "code": 9,
-    "label": "u"
+    ascii: 117,
+    code: 9,
+    label: 'u',
   },
   {
-    "ascii": 118,
-    "code": 55,
-    "label": "v"
+    ascii: 118,
+    code: 55,
+    label: 'v',
   },
   {
-    "ascii": 119,
-    "code": 54,
-    "label": "w"
+    ascii: 119,
+    code: 54,
+    label: 'w',
   },
   {
-    "ascii": 120,
-    "code": 5,
-    "label": "x"
+    ascii: 120,
+    code: 5,
+    label: 'x',
   },
   {
-    "ascii": 121,
-    "code": 23,
-    "label": "y"
+    ascii: 121,
+    code: 23,
+    label: 'y',
   },
   {
-    "ascii": 122,
-    "code": 56,
-    "label": "z"
+    ascii: 122,
+    code: 56,
+    label: 'z',
   },
   {
-    "ascii": 123,
-    "code": 32,
-    "label": "{"
+    ascii: 123,
+    code: 32,
+    label: '{',
   },
   {
-    "ascii": 124,
-    "code": 561,
-    "label": "|"
+    ascii: 124,
+    code: 561,
+    label: '|',
   },
   {
-    "ascii": 125,
-    "code": 33,
-    "label": "}"
+    ascii: 125,
+    code: 33,
+    label: '}',
   },
   {
-    "ascii": 126,
-    "code": 565,
-    "label": "~"
+    ascii: 126,
+    code: 565,
+    label: '~',
   },
   {
-    "ascii": 127,
-    "code": 76,
-    "label": "del"
-  }
+    ascii: 127,
+    code: 76,
+    label: 'del',
+  },
 ];
-    

--- a/src/services/labellang/AsciiLabelEstonian.ts
+++ b/src/services/labellang/AsciiLabelEstonian.ts
@@ -1,645 +1,644 @@
 import { AsciiLabel } from './AsciiLabel';
-        
+
 export const AsciiLabelEstonian: AsciiLabel[] = [
   {
-    "ascii": 0,
-    "code": 0,
-    "label": ""
+    ascii: 0,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 1,
-    "code": 0,
-    "label": ""
+    ascii: 1,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 2,
-    "code": 0,
-    "label": ""
+    ascii: 2,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 3,
-    "code": 0,
-    "label": ""
+    ascii: 3,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 4,
-    "code": 0,
-    "label": ""
+    ascii: 4,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 5,
-    "code": 0,
-    "label": ""
+    ascii: 5,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 6,
-    "code": 0,
-    "label": ""
+    ascii: 6,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 7,
-    "code": 0,
-    "label": ""
+    ascii: 7,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 8,
-    "code": 42,
-    "label": "back space"
+    ascii: 8,
+    code: 42,
+    label: 'back space',
   },
   {
-    "ascii": 9,
-    "code": 43,
-    "label": "tab"
+    ascii: 9,
+    code: 43,
+    label: 'tab',
   },
   {
-    "ascii": 10,
-    "code": 40,
-    "label": "enter"
+    ascii: 10,
+    code: 40,
+    label: 'enter',
   },
   {
-    "ascii": 11,
-    "code": 0,
-    "label": ""
+    ascii: 11,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 12,
-    "code": 0,
-    "label": ""
+    ascii: 12,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 13,
-    "code": 0,
-    "label": ""
+    ascii: 13,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 14,
-    "code": 0,
-    "label": ""
+    ascii: 14,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 15,
-    "code": 0,
-    "label": ""
+    ascii: 15,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 16,
-    "code": 0,
-    "label": ""
+    ascii: 16,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 17,
-    "code": 0,
-    "label": ""
+    ascii: 17,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 18,
-    "code": 0,
-    "label": ""
+    ascii: 18,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 19,
-    "code": 0,
-    "label": ""
+    ascii: 19,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 20,
-    "code": 0,
-    "label": ""
+    ascii: 20,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 21,
-    "code": 0,
-    "label": ""
+    ascii: 21,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 22,
-    "code": 0,
-    "label": ""
+    ascii: 22,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 23,
-    "code": 0,
-    "label": ""
+    ascii: 23,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 24,
-    "code": 0,
-    "label": ""
+    ascii: 24,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 25,
-    "code": 0,
-    "label": ""
+    ascii: 25,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 26,
-    "code": 0,
-    "label": ""
+    ascii: 26,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 27,
-    "code": 41,
-    "label": "esc"
+    ascii: 27,
+    code: 41,
+    label: 'esc',
   },
   {
-    "ascii": 28,
-    "code": 0,
-    "label": ""
+    ascii: 28,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 29,
-    "code": 0,
-    "label": ""
+    ascii: 29,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 30,
-    "code": 0,
-    "label": ""
+    ascii: 30,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 31,
-    "code": 0,
-    "label": ""
+    ascii: 31,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 32,
-    "code": 44,
-    "label": "space"
+    ascii: 32,
+    code: 44,
+    label: 'space',
   },
   {
-    "ascii": 33,
-    "code": 542,
-    "label": "!"
+    ascii: 33,
+    code: 542,
+    label: '!',
   },
   {
-    "ascii": 34,
-    "code": 543,
-    "label": "\""
+    ascii: 34,
+    code: 543,
+    label: '"',
   },
   {
-    "ascii": 35,
-    "code": 544,
-    "label": "#"
+    ascii: 35,
+    code: 544,
+    label: '#',
   },
   {
-    "ascii": 36,
-    "code": 33,
-    "label": "4"
+    ascii: 36,
+    code: 33,
+    label: '4',
   },
   {
-    "ascii": 37,
-    "code": 546,
-    "label": "%"
+    ascii: 37,
+    code: 546,
+    label: '%',
   },
   {
-    "ascii": 38,
-    "code": 547,
-    "label": "&"
+    ascii: 38,
+    code: 547,
+    label: '&',
   },
   {
-    "ascii": 39,
-    "code": 50,
-    "label": "'"
+    ascii: 39,
+    code: 50,
+    label: "'",
   },
   {
-    "ascii": 40,
-    "code": 549,
-    "label": "("
+    ascii: 40,
+    code: 549,
+    label: '(',
   },
   {
-    "ascii": 41,
-    "code": 550,
-    "label": ")"
+    ascii: 41,
+    code: 550,
+    label: ')',
   },
   {
-    "ascii": 42,
-    "code": 562,
-    "label": "*"
+    ascii: 42,
+    code: 562,
+    label: '*',
   },
   {
-    "ascii": 43,
-    "code": 45,
-    "label": "+"
+    ascii: 43,
+    code: 45,
+    label: '+',
   },
   {
-    "ascii": 44,
-    "code": 54,
-    "label": ","
+    ascii: 44,
+    code: 54,
+    label: ',',
   },
   {
-    "ascii": 45,
-    "code": 56,
-    "label": "-"
+    ascii: 45,
+    code: 56,
+    label: '-',
   },
   {
-    "ascii": 46,
-    "code": 55,
-    "label": "."
+    ascii: 46,
+    code: 55,
+    label: '.',
   },
   {
-    "ascii": 47,
-    "code": 548,
-    "label": "/"
+    ascii: 47,
+    code: 548,
+    label: '/',
   },
   {
-    "ascii": 48,
-    "code": 39,
-    "label": "0"
+    ascii: 48,
+    code: 39,
+    label: '0',
   },
   {
-    "ascii": 49,
-    "code": 30,
-    "label": "1"
+    ascii: 49,
+    code: 30,
+    label: '1',
   },
   {
-    "ascii": 50,
-    "code": 31,
-    "label": "2"
+    ascii: 50,
+    code: 31,
+    label: '2',
   },
   {
-    "ascii": 51,
-    "code": 32,
-    "label": "3"
+    ascii: 51,
+    code: 32,
+    label: '3',
   },
   {
-    "ascii": 52,
-    "code": 33,
-    "label": "4"
+    ascii: 52,
+    code: 33,
+    label: '4',
   },
   {
-    "ascii": 53,
-    "code": 34,
-    "label": "5"
+    ascii: 53,
+    code: 34,
+    label: '5',
   },
   {
-    "ascii": 54,
-    "code": 35,
-    "label": "6"
+    ascii: 54,
+    code: 35,
+    label: '6',
   },
   {
-    "ascii": 55,
-    "code": 36,
-    "label": "7"
+    ascii: 55,
+    code: 36,
+    label: '7',
   },
   {
-    "ascii": 56,
-    "code": 37,
-    "label": "8"
+    ascii: 56,
+    code: 37,
+    label: '8',
   },
   {
-    "ascii": 57,
-    "code": 38,
-    "label": "9"
+    ascii: 57,
+    code: 38,
+    label: '9',
   },
   {
-    "ascii": 58,
-    "code": 567,
-    "label": ":"
+    ascii: 58,
+    code: 567,
+    label: ':',
   },
   {
-    "ascii": 59,
-    "code": 566,
-    "label": ";"
+    ascii: 59,
+    code: 566,
+    label: ';',
   },
   {
-    "ascii": 60,
-    "code": 100,
-    "label": "<"
+    ascii: 60,
+    code: 100,
+    label: '<',
   },
   {
-    "ascii": 61,
-    "code": 551,
-    "label": "="
+    ascii: 61,
+    code: 551,
+    label: '=',
   },
   {
-    "ascii": 62,
-    "code": 612,
-    "label": ">"
+    ascii: 62,
+    code: 612,
+    label: '>',
   },
   {
-    "ascii": 63,
-    "code": 557,
-    "label": "?"
+    ascii: 63,
+    code: 557,
+    label: '?',
   },
   {
-    "ascii": 64,
-    "code": 31,
-    "label": "2"
+    ascii: 64,
+    code: 31,
+    label: '2',
   },
   {
-    "ascii": 65,
-    "code": 516,
-    "label": "A"
+    ascii: 65,
+    code: 516,
+    label: 'A',
   },
   {
-    "ascii": 66,
-    "code": 517,
-    "label": "B"
+    ascii: 66,
+    code: 517,
+    label: 'B',
   },
   {
-    "ascii": 67,
-    "code": 518,
-    "label": "C"
+    ascii: 67,
+    code: 518,
+    label: 'C',
   },
   {
-    "ascii": 68,
-    "code": 519,
-    "label": "D"
+    ascii: 68,
+    code: 519,
+    label: 'D',
   },
   {
-    "ascii": 69,
-    "code": 520,
-    "label": "E"
+    ascii: 69,
+    code: 520,
+    label: 'E',
   },
   {
-    "ascii": 70,
-    "code": 521,
-    "label": "F"
+    ascii: 70,
+    code: 521,
+    label: 'F',
   },
   {
-    "ascii": 71,
-    "code": 522,
-    "label": "G"
+    ascii: 71,
+    code: 522,
+    label: 'G',
   },
   {
-    "ascii": 72,
-    "code": 523,
-    "label": "H"
+    ascii: 72,
+    code: 523,
+    label: 'H',
   },
   {
-    "ascii": 73,
-    "code": 524,
-    "label": "I"
+    ascii: 73,
+    code: 524,
+    label: 'I',
   },
   {
-    "ascii": 74,
-    "code": 525,
-    "label": "J"
+    ascii: 74,
+    code: 525,
+    label: 'J',
   },
   {
-    "ascii": 75,
-    "code": 526,
-    "label": "K"
+    ascii: 75,
+    code: 526,
+    label: 'K',
   },
   {
-    "ascii": 76,
-    "code": 527,
-    "label": "L"
+    ascii: 76,
+    code: 527,
+    label: 'L',
   },
   {
-    "ascii": 77,
-    "code": 528,
-    "label": "M"
+    ascii: 77,
+    code: 528,
+    label: 'M',
   },
   {
-    "ascii": 78,
-    "code": 529,
-    "label": "N"
+    ascii: 78,
+    code: 529,
+    label: 'N',
   },
   {
-    "ascii": 79,
-    "code": 530,
-    "label": "O"
+    ascii: 79,
+    code: 530,
+    label: 'O',
   },
   {
-    "ascii": 80,
-    "code": 531,
-    "label": "P"
+    ascii: 80,
+    code: 531,
+    label: 'P',
   },
   {
-    "ascii": 81,
-    "code": 532,
-    "label": "Q"
+    ascii: 81,
+    code: 532,
+    label: 'Q',
   },
   {
-    "ascii": 82,
-    "code": 533,
-    "label": "R"
+    ascii: 82,
+    code: 533,
+    label: 'R',
   },
   {
-    "ascii": 83,
-    "code": 534,
-    "label": "S"
+    ascii: 83,
+    code: 534,
+    label: 'S',
   },
   {
-    "ascii": 84,
-    "code": 535,
-    "label": "T"
+    ascii: 84,
+    code: 535,
+    label: 'T',
   },
   {
-    "ascii": 85,
-    "code": 536,
-    "label": "U"
+    ascii: 85,
+    code: 536,
+    label: 'U',
   },
   {
-    "ascii": 86,
-    "code": 537,
-    "label": "V"
+    ascii: 86,
+    code: 537,
+    label: 'V',
   },
   {
-    "ascii": 87,
-    "code": 538,
-    "label": "W"
+    ascii: 87,
+    code: 538,
+    label: 'W',
   },
   {
-    "ascii": 88,
-    "code": 539,
-    "label": "X"
+    ascii: 88,
+    code: 539,
+    label: 'X',
   },
   {
-    "ascii": 89,
-    "code": 540,
-    "label": "Y"
+    ascii: 89,
+    code: 540,
+    label: 'Y',
   },
   {
-    "ascii": 90,
-    "code": 541,
-    "label": "Z"
+    ascii: 90,
+    code: 541,
+    label: 'Z',
   },
   {
-    "ascii": 91,
-    "code": 37,
-    "label": "8"
+    ascii: 91,
+    code: 37,
+    label: '8',
   },
   {
-    "ascii": 92,
-    "code": 45,
-    "label": "+"
+    ascii: 92,
+    code: 45,
+    label: '+',
   },
   {
-    "ascii": 93,
-    "code": 38,
-    "label": "9"
+    ascii: 93,
+    code: 38,
+    label: '9',
   },
   {
-    "ascii": 94,
-    "code": 52,
-    "label": "Ä"
+    ascii: 94,
+    code: 52,
+    label: 'Ä',
   },
   {
-    "ascii": 95,
-    "code": 568,
-    "label": "_"
+    ascii: 95,
+    code: 568,
+    label: '_',
   },
   {
-    "ascii": 96,
-    "code": 558,
-    "label": "` (dead)"
+    ascii: 96,
+    code: 558,
+    label: '` (dead)',
   },
   {
-    "ascii": 97,
-    "code": 4,
-    "label": "a"
+    ascii: 97,
+    code: 4,
+    label: 'a',
   },
   {
-    "ascii": 98,
-    "code": 5,
-    "label": "b"
+    ascii: 98,
+    code: 5,
+    label: 'b',
   },
   {
-    "ascii": 99,
-    "code": 6,
-    "label": "c"
+    ascii: 99,
+    code: 6,
+    label: 'c',
   },
   {
-    "ascii": 100,
-    "code": 7,
-    "label": "d"
+    ascii: 100,
+    code: 7,
+    label: 'd',
   },
   {
-    "ascii": 101,
-    "code": 8,
-    "label": "e"
+    ascii: 101,
+    code: 8,
+    label: 'e',
   },
   {
-    "ascii": 102,
-    "code": 9,
-    "label": "f"
+    ascii: 102,
+    code: 9,
+    label: 'f',
   },
   {
-    "ascii": 103,
-    "code": 10,
-    "label": "g"
+    ascii: 103,
+    code: 10,
+    label: 'g',
   },
   {
-    "ascii": 104,
-    "code": 11,
-    "label": "h"
+    ascii: 104,
+    code: 11,
+    label: 'h',
   },
   {
-    "ascii": 105,
-    "code": 12,
-    "label": "i"
+    ascii: 105,
+    code: 12,
+    label: 'i',
   },
   {
-    "ascii": 106,
-    "code": 13,
-    "label": "j"
+    ascii: 106,
+    code: 13,
+    label: 'j',
   },
   {
-    "ascii": 107,
-    "code": 14,
-    "label": "k"
+    ascii: 107,
+    code: 14,
+    label: 'k',
   },
   {
-    "ascii": 108,
-    "code": 15,
-    "label": "l"
+    ascii: 108,
+    code: 15,
+    label: 'l',
   },
   {
-    "ascii": 109,
-    "code": 16,
-    "label": "m"
+    ascii: 109,
+    code: 16,
+    label: 'm',
   },
   {
-    "ascii": 110,
-    "code": 17,
-    "label": "n"
+    ascii: 110,
+    code: 17,
+    label: 'n',
   },
   {
-    "ascii": 111,
-    "code": 18,
-    "label": "o"
+    ascii: 111,
+    code: 18,
+    label: 'o',
   },
   {
-    "ascii": 112,
-    "code": 19,
-    "label": "p"
+    ascii: 112,
+    code: 19,
+    label: 'p',
   },
   {
-    "ascii": 113,
-    "code": 20,
-    "label": "q"
+    ascii: 113,
+    code: 20,
+    label: 'q',
   },
   {
-    "ascii": 114,
-    "code": 21,
-    "label": "r"
+    ascii: 114,
+    code: 21,
+    label: 'r',
   },
   {
-    "ascii": 115,
-    "code": 22,
-    "label": "s"
+    ascii: 115,
+    code: 22,
+    label: 's',
   },
   {
-    "ascii": 116,
-    "code": 23,
-    "label": "t"
+    ascii: 116,
+    code: 23,
+    label: 't',
   },
   {
-    "ascii": 117,
-    "code": 24,
-    "label": "u"
+    ascii: 117,
+    code: 24,
+    label: 'u',
   },
   {
-    "ascii": 118,
-    "code": 25,
-    "label": "v"
+    ascii: 118,
+    code: 25,
+    label: 'v',
   },
   {
-    "ascii": 119,
-    "code": 26,
-    "label": "w"
+    ascii: 119,
+    code: 26,
+    label: 'w',
   },
   {
-    "ascii": 120,
-    "code": 27,
-    "label": "x"
+    ascii: 120,
+    code: 27,
+    label: 'x',
   },
   {
-    "ascii": 121,
-    "code": 28,
-    "label": "y"
+    ascii: 121,
+    code: 28,
+    label: 'y',
   },
   {
-    "ascii": 122,
-    "code": 29,
-    "label": "z"
+    ascii: 122,
+    code: 29,
+    label: 'z',
   },
   {
-    "ascii": 123,
-    "code": 36,
-    "label": "7"
+    ascii: 123,
+    code: 36,
+    label: '7',
   },
   {
-    "ascii": 124,
-    "code": 100,
-    "label": "<"
+    ascii: 124,
+    code: 100,
+    label: '<',
   },
   {
-    "ascii": 125,
-    "code": 39,
-    "label": "0"
+    ascii: 125,
+    code: 39,
+    label: '0',
   },
   {
-    "ascii": 126,
-    "code": 53,
-    "label": "ˇ (dead)"
+    ascii: 126,
+    code: 53,
+    label: 'ˇ (dead)',
   },
   {
-    "ascii": 127,
-    "code": 76,
-    "label": "del"
-  }
+    ascii: 127,
+    code: 76,
+    label: 'del',
+  },
 ];
-    

--- a/src/services/labellang/AsciiLabelFinnish.ts
+++ b/src/services/labellang/AsciiLabelFinnish.ts
@@ -1,645 +1,644 @@
 import { AsciiLabel } from './AsciiLabel';
-        
+
 export const AsciiLabelFinnish: AsciiLabel[] = [
   {
-    "ascii": 0,
-    "code": 0,
-    "label": ""
+    ascii: 0,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 1,
-    "code": 0,
-    "label": ""
+    ascii: 1,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 2,
-    "code": 0,
-    "label": ""
+    ascii: 2,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 3,
-    "code": 0,
-    "label": ""
+    ascii: 3,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 4,
-    "code": 0,
-    "label": ""
+    ascii: 4,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 5,
-    "code": 0,
-    "label": ""
+    ascii: 5,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 6,
-    "code": 0,
-    "label": ""
+    ascii: 6,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 7,
-    "code": 0,
-    "label": ""
+    ascii: 7,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 8,
-    "code": 42,
-    "label": "back space"
+    ascii: 8,
+    code: 42,
+    label: 'back space',
   },
   {
-    "ascii": 9,
-    "code": 43,
-    "label": "tab"
+    ascii: 9,
+    code: 43,
+    label: 'tab',
   },
   {
-    "ascii": 10,
-    "code": 40,
-    "label": "enter"
+    ascii: 10,
+    code: 40,
+    label: 'enter',
   },
   {
-    "ascii": 11,
-    "code": 0,
-    "label": ""
+    ascii: 11,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 12,
-    "code": 0,
-    "label": ""
+    ascii: 12,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 13,
-    "code": 0,
-    "label": ""
+    ascii: 13,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 14,
-    "code": 0,
-    "label": ""
+    ascii: 14,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 15,
-    "code": 0,
-    "label": ""
+    ascii: 15,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 16,
-    "code": 0,
-    "label": ""
+    ascii: 16,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 17,
-    "code": 0,
-    "label": ""
+    ascii: 17,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 18,
-    "code": 0,
-    "label": ""
+    ascii: 18,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 19,
-    "code": 0,
-    "label": ""
+    ascii: 19,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 20,
-    "code": 0,
-    "label": ""
+    ascii: 20,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 21,
-    "code": 0,
-    "label": ""
+    ascii: 21,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 22,
-    "code": 0,
-    "label": ""
+    ascii: 22,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 23,
-    "code": 0,
-    "label": ""
+    ascii: 23,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 24,
-    "code": 0,
-    "label": ""
+    ascii: 24,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 25,
-    "code": 0,
-    "label": ""
+    ascii: 25,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 26,
-    "code": 0,
-    "label": ""
+    ascii: 26,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 27,
-    "code": 41,
-    "label": "esc"
+    ascii: 27,
+    code: 41,
+    label: 'esc',
   },
   {
-    "ascii": 28,
-    "code": 0,
-    "label": ""
+    ascii: 28,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 29,
-    "code": 0,
-    "label": ""
+    ascii: 29,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 30,
-    "code": 0,
-    "label": ""
+    ascii: 30,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 31,
-    "code": 0,
-    "label": ""
+    ascii: 31,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 32,
-    "code": 44,
-    "label": "space"
+    ascii: 32,
+    code: 44,
+    label: 'space',
   },
   {
-    "ascii": 33,
-    "code": 542,
-    "label": "!"
+    ascii: 33,
+    code: 542,
+    label: '!',
   },
   {
-    "ascii": 34,
-    "code": 543,
-    "label": "\""
+    ascii: 34,
+    code: 543,
+    label: '"',
   },
   {
-    "ascii": 35,
-    "code": 544,
-    "label": "#"
+    ascii: 35,
+    code: 544,
+    label: '#',
   },
   {
-    "ascii": 36,
-    "code": 33,
-    "label": "4"
+    ascii: 36,
+    code: 33,
+    label: '4',
   },
   {
-    "ascii": 37,
-    "code": 546,
-    "label": "%"
+    ascii: 37,
+    code: 546,
+    label: '%',
   },
   {
-    "ascii": 38,
-    "code": 547,
-    "label": "&"
+    ascii: 38,
+    code: 547,
+    label: '&',
   },
   {
-    "ascii": 39,
-    "code": 50,
-    "label": "'"
+    ascii: 39,
+    code: 50,
+    label: "'",
   },
   {
-    "ascii": 40,
-    "code": 549,
-    "label": "("
+    ascii: 40,
+    code: 549,
+    label: '(',
   },
   {
-    "ascii": 41,
-    "code": 550,
-    "label": ")"
+    ascii: 41,
+    code: 550,
+    label: ')',
   },
   {
-    "ascii": 42,
-    "code": 562,
-    "label": "*"
+    ascii: 42,
+    code: 562,
+    label: '*',
   },
   {
-    "ascii": 43,
-    "code": 45,
-    "label": "+"
+    ascii: 43,
+    code: 45,
+    label: '+',
   },
   {
-    "ascii": 44,
-    "code": 54,
-    "label": ","
+    ascii: 44,
+    code: 54,
+    label: ',',
   },
   {
-    "ascii": 45,
-    "code": 56,
-    "label": "-"
+    ascii: 45,
+    code: 56,
+    label: '-',
   },
   {
-    "ascii": 46,
-    "code": 55,
-    "label": "."
+    ascii: 46,
+    code: 55,
+    label: '.',
   },
   {
-    "ascii": 47,
-    "code": 548,
-    "label": "/"
+    ascii: 47,
+    code: 548,
+    label: '/',
   },
   {
-    "ascii": 48,
-    "code": 39,
-    "label": "0"
+    ascii: 48,
+    code: 39,
+    label: '0',
   },
   {
-    "ascii": 49,
-    "code": 30,
-    "label": "1"
+    ascii: 49,
+    code: 30,
+    label: '1',
   },
   {
-    "ascii": 50,
-    "code": 31,
-    "label": "2"
+    ascii: 50,
+    code: 31,
+    label: '2',
   },
   {
-    "ascii": 51,
-    "code": 32,
-    "label": "3"
+    ascii: 51,
+    code: 32,
+    label: '3',
   },
   {
-    "ascii": 52,
-    "code": 33,
-    "label": "4"
+    ascii: 52,
+    code: 33,
+    label: '4',
   },
   {
-    "ascii": 53,
-    "code": 34,
-    "label": "5"
+    ascii: 53,
+    code: 34,
+    label: '5',
   },
   {
-    "ascii": 54,
-    "code": 35,
-    "label": "6"
+    ascii: 54,
+    code: 35,
+    label: '6',
   },
   {
-    "ascii": 55,
-    "code": 36,
-    "label": "7"
+    ascii: 55,
+    code: 36,
+    label: '7',
   },
   {
-    "ascii": 56,
-    "code": 37,
-    "label": "8"
+    ascii: 56,
+    code: 37,
+    label: '8',
   },
   {
-    "ascii": 57,
-    "code": 38,
-    "label": "9"
+    ascii: 57,
+    code: 38,
+    label: '9',
   },
   {
-    "ascii": 58,
-    "code": 567,
-    "label": ":"
+    ascii: 58,
+    code: 567,
+    label: ':',
   },
   {
-    "ascii": 59,
-    "code": 566,
-    "label": ";"
+    ascii: 59,
+    code: 566,
+    label: ';',
   },
   {
-    "ascii": 60,
-    "code": 100,
-    "label": "<"
+    ascii: 60,
+    code: 100,
+    label: '<',
   },
   {
-    "ascii": 61,
-    "code": 551,
-    "label": "="
+    ascii: 61,
+    code: 551,
+    label: '=',
   },
   {
-    "ascii": 62,
-    "code": 612,
-    "label": ">"
+    ascii: 62,
+    code: 612,
+    label: '>',
   },
   {
-    "ascii": 63,
-    "code": 557,
-    "label": "?"
+    ascii: 63,
+    code: 557,
+    label: '?',
   },
   {
-    "ascii": 64,
-    "code": 31,
-    "label": "2"
+    ascii: 64,
+    code: 31,
+    label: '2',
   },
   {
-    "ascii": 65,
-    "code": 516,
-    "label": "A"
+    ascii: 65,
+    code: 516,
+    label: 'A',
   },
   {
-    "ascii": 66,
-    "code": 517,
-    "label": "B"
+    ascii: 66,
+    code: 517,
+    label: 'B',
   },
   {
-    "ascii": 67,
-    "code": 518,
-    "label": "C"
+    ascii: 67,
+    code: 518,
+    label: 'C',
   },
   {
-    "ascii": 68,
-    "code": 519,
-    "label": "D"
+    ascii: 68,
+    code: 519,
+    label: 'D',
   },
   {
-    "ascii": 69,
-    "code": 520,
-    "label": "E"
+    ascii: 69,
+    code: 520,
+    label: 'E',
   },
   {
-    "ascii": 70,
-    "code": 521,
-    "label": "F"
+    ascii: 70,
+    code: 521,
+    label: 'F',
   },
   {
-    "ascii": 71,
-    "code": 522,
-    "label": "G"
+    ascii: 71,
+    code: 522,
+    label: 'G',
   },
   {
-    "ascii": 72,
-    "code": 523,
-    "label": "H"
+    ascii: 72,
+    code: 523,
+    label: 'H',
   },
   {
-    "ascii": 73,
-    "code": 524,
-    "label": "I"
+    ascii: 73,
+    code: 524,
+    label: 'I',
   },
   {
-    "ascii": 74,
-    "code": 525,
-    "label": "J"
+    ascii: 74,
+    code: 525,
+    label: 'J',
   },
   {
-    "ascii": 75,
-    "code": 526,
-    "label": "K"
+    ascii: 75,
+    code: 526,
+    label: 'K',
   },
   {
-    "ascii": 76,
-    "code": 527,
-    "label": "L"
+    ascii: 76,
+    code: 527,
+    label: 'L',
   },
   {
-    "ascii": 77,
-    "code": 528,
-    "label": "M"
+    ascii: 77,
+    code: 528,
+    label: 'M',
   },
   {
-    "ascii": 78,
-    "code": 529,
-    "label": "N"
+    ascii: 78,
+    code: 529,
+    label: 'N',
   },
   {
-    "ascii": 79,
-    "code": 530,
-    "label": "O"
+    ascii: 79,
+    code: 530,
+    label: 'O',
   },
   {
-    "ascii": 80,
-    "code": 531,
-    "label": "P"
+    ascii: 80,
+    code: 531,
+    label: 'P',
   },
   {
-    "ascii": 81,
-    "code": 532,
-    "label": "Q"
+    ascii: 81,
+    code: 532,
+    label: 'Q',
   },
   {
-    "ascii": 82,
-    "code": 533,
-    "label": "R"
+    ascii: 82,
+    code: 533,
+    label: 'R',
   },
   {
-    "ascii": 83,
-    "code": 534,
-    "label": "S"
+    ascii: 83,
+    code: 534,
+    label: 'S',
   },
   {
-    "ascii": 84,
-    "code": 535,
-    "label": "T"
+    ascii: 84,
+    code: 535,
+    label: 'T',
   },
   {
-    "ascii": 85,
-    "code": 536,
-    "label": "U"
+    ascii: 85,
+    code: 536,
+    label: 'U',
   },
   {
-    "ascii": 86,
-    "code": 537,
-    "label": "V"
+    ascii: 86,
+    code: 537,
+    label: 'V',
   },
   {
-    "ascii": 87,
-    "code": 538,
-    "label": "W"
+    ascii: 87,
+    code: 538,
+    label: 'W',
   },
   {
-    "ascii": 88,
-    "code": 539,
-    "label": "X"
+    ascii: 88,
+    code: 539,
+    label: 'X',
   },
   {
-    "ascii": 89,
-    "code": 540,
-    "label": "Y"
+    ascii: 89,
+    code: 540,
+    label: 'Y',
   },
   {
-    "ascii": 90,
-    "code": 541,
-    "label": "Z"
+    ascii: 90,
+    code: 541,
+    label: 'Z',
   },
   {
-    "ascii": 91,
-    "code": 37,
-    "label": "8"
+    ascii: 91,
+    code: 37,
+    label: '8',
   },
   {
-    "ascii": 92,
-    "code": 45,
-    "label": "+"
+    ascii: 92,
+    code: 45,
+    label: '+',
   },
   {
-    "ascii": 93,
-    "code": 38,
-    "label": "9"
+    ascii: 93,
+    code: 38,
+    label: '9',
   },
   {
-    "ascii": 94,
-    "code": 560,
-    "label": "^ (dead)"
+    ascii: 94,
+    code: 560,
+    label: '^ (dead)',
   },
   {
-    "ascii": 95,
-    "code": 568,
-    "label": "_"
+    ascii: 95,
+    code: 568,
+    label: '_',
   },
   {
-    "ascii": 96,
-    "code": 558,
-    "label": "` (dead)"
+    ascii: 96,
+    code: 558,
+    label: '` (dead)',
   },
   {
-    "ascii": 97,
-    "code": 4,
-    "label": "a"
+    ascii: 97,
+    code: 4,
+    label: 'a',
   },
   {
-    "ascii": 98,
-    "code": 5,
-    "label": "b"
+    ascii: 98,
+    code: 5,
+    label: 'b',
   },
   {
-    "ascii": 99,
-    "code": 6,
-    "label": "c"
+    ascii: 99,
+    code: 6,
+    label: 'c',
   },
   {
-    "ascii": 100,
-    "code": 7,
-    "label": "d"
+    ascii: 100,
+    code: 7,
+    label: 'd',
   },
   {
-    "ascii": 101,
-    "code": 8,
-    "label": "e"
+    ascii: 101,
+    code: 8,
+    label: 'e',
   },
   {
-    "ascii": 102,
-    "code": 9,
-    "label": "f"
+    ascii: 102,
+    code: 9,
+    label: 'f',
   },
   {
-    "ascii": 103,
-    "code": 10,
-    "label": "g"
+    ascii: 103,
+    code: 10,
+    label: 'g',
   },
   {
-    "ascii": 104,
-    "code": 11,
-    "label": "h"
+    ascii: 104,
+    code: 11,
+    label: 'h',
   },
   {
-    "ascii": 105,
-    "code": 12,
-    "label": "i"
+    ascii: 105,
+    code: 12,
+    label: 'i',
   },
   {
-    "ascii": 106,
-    "code": 13,
-    "label": "j"
+    ascii: 106,
+    code: 13,
+    label: 'j',
   },
   {
-    "ascii": 107,
-    "code": 14,
-    "label": "k"
+    ascii: 107,
+    code: 14,
+    label: 'k',
   },
   {
-    "ascii": 108,
-    "code": 15,
-    "label": "l"
+    ascii: 108,
+    code: 15,
+    label: 'l',
   },
   {
-    "ascii": 109,
-    "code": 16,
-    "label": "m"
+    ascii: 109,
+    code: 16,
+    label: 'm',
   },
   {
-    "ascii": 110,
-    "code": 17,
-    "label": "n"
+    ascii: 110,
+    code: 17,
+    label: 'n',
   },
   {
-    "ascii": 111,
-    "code": 18,
-    "label": "o"
+    ascii: 111,
+    code: 18,
+    label: 'o',
   },
   {
-    "ascii": 112,
-    "code": 19,
-    "label": "p"
+    ascii: 112,
+    code: 19,
+    label: 'p',
   },
   {
-    "ascii": 113,
-    "code": 20,
-    "label": "q"
+    ascii: 113,
+    code: 20,
+    label: 'q',
   },
   {
-    "ascii": 114,
-    "code": 21,
-    "label": "r"
+    ascii: 114,
+    code: 21,
+    label: 'r',
   },
   {
-    "ascii": 115,
-    "code": 22,
-    "label": "s"
+    ascii: 115,
+    code: 22,
+    label: 's',
   },
   {
-    "ascii": 116,
-    "code": 23,
-    "label": "t"
+    ascii: 116,
+    code: 23,
+    label: 't',
   },
   {
-    "ascii": 117,
-    "code": 24,
-    "label": "u"
+    ascii: 117,
+    code: 24,
+    label: 'u',
   },
   {
-    "ascii": 118,
-    "code": 25,
-    "label": "v"
+    ascii: 118,
+    code: 25,
+    label: 'v',
   },
   {
-    "ascii": 119,
-    "code": 26,
-    "label": "w"
+    ascii: 119,
+    code: 26,
+    label: 'w',
   },
   {
-    "ascii": 120,
-    "code": 27,
-    "label": "x"
+    ascii: 120,
+    code: 27,
+    label: 'x',
   },
   {
-    "ascii": 121,
-    "code": 28,
-    "label": "y"
+    ascii: 121,
+    code: 28,
+    label: 'y',
   },
   {
-    "ascii": 122,
-    "code": 29,
-    "label": "z"
+    ascii: 122,
+    code: 29,
+    label: 'z',
   },
   {
-    "ascii": 123,
-    "code": 36,
-    "label": "7"
+    ascii: 123,
+    code: 36,
+    label: '7',
   },
   {
-    "ascii": 124,
-    "code": 100,
-    "label": "<"
+    ascii: 124,
+    code: 100,
+    label: '<',
   },
   {
-    "ascii": 125,
-    "code": 39,
-    "label": "0"
+    ascii: 125,
+    code: 39,
+    label: '0',
   },
   {
-    "ascii": 126,
-    "code": 48,
-    "label": "¨ (dead)"
+    ascii: 126,
+    code: 48,
+    label: '¨ (dead)',
   },
   {
-    "ascii": 127,
-    "code": 76,
-    "label": "del"
-  }
+    ascii: 127,
+    code: 76,
+    label: 'del',
+  },
 ];
-    

--- a/src/services/labellang/AsciiLabelFr_ch.ts
+++ b/src/services/labellang/AsciiLabelFr_ch.ts
@@ -1,645 +1,644 @@
 import { AsciiLabel } from './AsciiLabel';
-        
+
 export const AsciiLabelFr_ch: AsciiLabel[] = [
   {
-    "ascii": 0,
-    "code": 0,
-    "label": ""
+    ascii: 0,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 1,
-    "code": 0,
-    "label": ""
+    ascii: 1,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 2,
-    "code": 0,
-    "label": ""
+    ascii: 2,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 3,
-    "code": 0,
-    "label": ""
+    ascii: 3,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 4,
-    "code": 0,
-    "label": ""
+    ascii: 4,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 5,
-    "code": 0,
-    "label": ""
+    ascii: 5,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 6,
-    "code": 0,
-    "label": ""
+    ascii: 6,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 7,
-    "code": 0,
-    "label": ""
+    ascii: 7,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 8,
-    "code": 42,
-    "label": "back space"
+    ascii: 8,
+    code: 42,
+    label: 'back space',
   },
   {
-    "ascii": 9,
-    "code": 43,
-    "label": "tab"
+    ascii: 9,
+    code: 43,
+    label: 'tab',
   },
   {
-    "ascii": 10,
-    "code": 40,
-    "label": "enter"
+    ascii: 10,
+    code: 40,
+    label: 'enter',
   },
   {
-    "ascii": 11,
-    "code": 0,
-    "label": ""
+    ascii: 11,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 12,
-    "code": 0,
-    "label": ""
+    ascii: 12,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 13,
-    "code": 0,
-    "label": ""
+    ascii: 13,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 14,
-    "code": 0,
-    "label": ""
+    ascii: 14,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 15,
-    "code": 0,
-    "label": ""
+    ascii: 15,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 16,
-    "code": 0,
-    "label": ""
+    ascii: 16,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 17,
-    "code": 0,
-    "label": ""
+    ascii: 17,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 18,
-    "code": 0,
-    "label": ""
+    ascii: 18,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 19,
-    "code": 0,
-    "label": ""
+    ascii: 19,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 20,
-    "code": 0,
-    "label": ""
+    ascii: 20,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 21,
-    "code": 0,
-    "label": ""
+    ascii: 21,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 22,
-    "code": 0,
-    "label": ""
+    ascii: 22,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 23,
-    "code": 0,
-    "label": ""
+    ascii: 23,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 24,
-    "code": 0,
-    "label": ""
+    ascii: 24,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 25,
-    "code": 0,
-    "label": ""
+    ascii: 25,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 26,
-    "code": 0,
-    "label": ""
+    ascii: 26,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 27,
-    "code": 41,
-    "label": "esc"
+    ascii: 27,
+    code: 41,
+    label: 'esc',
   },
   {
-    "ascii": 28,
-    "code": 0,
-    "label": ""
+    ascii: 28,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 29,
-    "code": 0,
-    "label": ""
+    ascii: 29,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 30,
-    "code": 0,
-    "label": ""
+    ascii: 30,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 31,
-    "code": 0,
-    "label": ""
+    ascii: 31,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 32,
-    "code": 44,
-    "label": "space"
+    ascii: 32,
+    code: 44,
+    label: 'space',
   },
   {
-    "ascii": 33,
-    "code": 560,
-    "label": "!"
+    ascii: 33,
+    code: 560,
+    label: '!',
   },
   {
-    "ascii": 34,
-    "code": 543,
-    "label": "\""
+    ascii: 34,
+    code: 543,
+    label: '"',
   },
   {
-    "ascii": 35,
-    "code": 32,
-    "label": "3"
+    ascii: 35,
+    code: 32,
+    label: '3',
   },
   {
-    "ascii": 36,
-    "code": 50,
-    "label": "$"
+    ascii: 36,
+    code: 50,
+    label: '$',
   },
   {
-    "ascii": 37,
-    "code": 546,
-    "label": "%"
+    ascii: 37,
+    code: 546,
+    label: '%',
   },
   {
-    "ascii": 38,
-    "code": 547,
-    "label": "&"
+    ascii: 38,
+    code: 547,
+    label: '&',
   },
   {
-    "ascii": 39,
-    "code": 45,
-    "label": "'"
+    ascii: 39,
+    code: 45,
+    label: "'",
   },
   {
-    "ascii": 40,
-    "code": 549,
-    "label": "("
+    ascii: 40,
+    code: 549,
+    label: '(',
   },
   {
-    "ascii": 41,
-    "code": 550,
-    "label": ")"
+    ascii: 41,
+    code: 550,
+    label: ')',
   },
   {
-    "ascii": 42,
-    "code": 544,
-    "label": "*"
+    ascii: 42,
+    code: 544,
+    label: '*',
   },
   {
-    "ascii": 43,
-    "code": 551,
-    "label": "="
+    ascii: 43,
+    code: 551,
+    label: '=',
   },
   {
-    "ascii": 44,
-    "code": 54,
-    "label": ","
+    ascii: 44,
+    code: 54,
+    label: ',',
   },
   {
-    "ascii": 45,
-    "code": 56,
-    "label": "-"
+    ascii: 45,
+    code: 56,
+    label: '-',
   },
   {
-    "ascii": 46,
-    "code": 55,
-    "label": "."
+    ascii: 46,
+    code: 55,
+    label: '.',
   },
   {
-    "ascii": 47,
-    "code": 548,
-    "label": "/"
+    ascii: 47,
+    code: 548,
+    label: '/',
   },
   {
-    "ascii": 48,
-    "code": 39,
-    "label": "0"
+    ascii: 48,
+    code: 39,
+    label: '0',
   },
   {
-    "ascii": 49,
-    "code": 30,
-    "label": "1"
+    ascii: 49,
+    code: 30,
+    label: '1',
   },
   {
-    "ascii": 50,
-    "code": 31,
-    "label": "2"
+    ascii: 50,
+    code: 31,
+    label: '2',
   },
   {
-    "ascii": 51,
-    "code": 32,
-    "label": "3"
+    ascii: 51,
+    code: 32,
+    label: '3',
   },
   {
-    "ascii": 52,
-    "code": 33,
-    "label": "4"
+    ascii: 52,
+    code: 33,
+    label: '4',
   },
   {
-    "ascii": 53,
-    "code": 34,
-    "label": "5"
+    ascii: 53,
+    code: 34,
+    label: '5',
   },
   {
-    "ascii": 54,
-    "code": 35,
-    "label": "6"
+    ascii: 54,
+    code: 35,
+    label: '6',
   },
   {
-    "ascii": 55,
-    "code": 36,
-    "label": "7"
+    ascii: 55,
+    code: 36,
+    label: '7',
   },
   {
-    "ascii": 56,
-    "code": 37,
-    "label": "8"
+    ascii: 56,
+    code: 37,
+    label: '8',
   },
   {
-    "ascii": 57,
-    "code": 38,
-    "label": "9"
+    ascii: 57,
+    code: 38,
+    label: '9',
   },
   {
-    "ascii": 58,
-    "code": 567,
-    "label": ":"
+    ascii: 58,
+    code: 567,
+    label: ':',
   },
   {
-    "ascii": 59,
-    "code": 566,
-    "label": ";"
+    ascii: 59,
+    code: 566,
+    label: ';',
   },
   {
-    "ascii": 60,
-    "code": 100,
-    "label": "<"
+    ascii: 60,
+    code: 100,
+    label: '<',
   },
   {
-    "ascii": 61,
-    "code": 551,
-    "label": "="
+    ascii: 61,
+    code: 551,
+    label: '=',
   },
   {
-    "ascii": 62,
-    "code": 612,
-    "label": ">"
+    ascii: 62,
+    code: 612,
+    label: '>',
   },
   {
-    "ascii": 63,
-    "code": 557,
-    "label": "?"
+    ascii: 63,
+    code: 557,
+    label: '?',
   },
   {
-    "ascii": 64,
-    "code": 31,
-    "label": "2"
+    ascii: 64,
+    code: 31,
+    label: '2',
   },
   {
-    "ascii": 65,
-    "code": 4,
-    "label": "a"
+    ascii: 65,
+    code: 4,
+    label: 'a',
   },
   {
-    "ascii": 66,
-    "code": 5,
-    "label": "b"
+    ascii: 66,
+    code: 5,
+    label: 'b',
   },
   {
-    "ascii": 67,
-    "code": 6,
-    "label": "c"
+    ascii: 67,
+    code: 6,
+    label: 'c',
   },
   {
-    "ascii": 68,
-    "code": 7,
-    "label": "d"
+    ascii: 68,
+    code: 7,
+    label: 'd',
   },
   {
-    "ascii": 69,
-    "code": 8,
-    "label": "e"
+    ascii: 69,
+    code: 8,
+    label: 'e',
   },
   {
-    "ascii": 70,
-    "code": 9,
-    "label": "f"
+    ascii: 70,
+    code: 9,
+    label: 'f',
   },
   {
-    "ascii": 71,
-    "code": 10,
-    "label": "g"
+    ascii: 71,
+    code: 10,
+    label: 'g',
   },
   {
-    "ascii": 72,
-    "code": 11,
-    "label": "h"
+    ascii: 72,
+    code: 11,
+    label: 'h',
   },
   {
-    "ascii": 73,
-    "code": 12,
-    "label": "i"
+    ascii: 73,
+    code: 12,
+    label: 'i',
   },
   {
-    "ascii": 74,
-    "code": 13,
-    "label": "j"
+    ascii: 74,
+    code: 13,
+    label: 'j',
   },
   {
-    "ascii": 75,
-    "code": 14,
-    "label": "k"
+    ascii: 75,
+    code: 14,
+    label: 'k',
   },
   {
-    "ascii": 76,
-    "code": 15,
-    "label": "l"
+    ascii: 76,
+    code: 15,
+    label: 'l',
   },
   {
-    "ascii": 77,
-    "code": 16,
-    "label": "m"
+    ascii: 77,
+    code: 16,
+    label: 'm',
   },
   {
-    "ascii": 78,
-    "code": 17,
-    "label": "n"
+    ascii: 78,
+    code: 17,
+    label: 'n',
   },
   {
-    "ascii": 79,
-    "code": 18,
-    "label": "o"
+    ascii: 79,
+    code: 18,
+    label: 'o',
   },
   {
-    "ascii": 80,
-    "code": 19,
-    "label": "p"
+    ascii: 80,
+    code: 19,
+    label: 'p',
   },
   {
-    "ascii": 81,
-    "code": 20,
-    "label": "q"
+    ascii: 81,
+    code: 20,
+    label: 'q',
   },
   {
-    "ascii": 82,
-    "code": 21,
-    "label": "r"
+    ascii: 82,
+    code: 21,
+    label: 'r',
   },
   {
-    "ascii": 83,
-    "code": 22,
-    "label": "s"
+    ascii: 83,
+    code: 22,
+    label: 's',
   },
   {
-    "ascii": 84,
-    "code": 23,
-    "label": "t"
+    ascii: 84,
+    code: 23,
+    label: 't',
   },
   {
-    "ascii": 85,
-    "code": 24,
-    "label": "u"
+    ascii: 85,
+    code: 24,
+    label: 'u',
   },
   {
-    "ascii": 86,
-    "code": 25,
-    "label": "v"
+    ascii: 86,
+    code: 25,
+    label: 'v',
   },
   {
-    "ascii": 87,
-    "code": 26,
-    "label": "w"
+    ascii: 87,
+    code: 26,
+    label: 'w',
   },
   {
-    "ascii": 88,
-    "code": 27,
-    "label": "x"
+    ascii: 88,
+    code: 27,
+    label: 'x',
   },
   {
-    "ascii": 89,
-    "code": 29,
-    "label": "y"
+    ascii: 89,
+    code: 29,
+    label: 'y',
   },
   {
-    "ascii": 90,
-    "code": 28,
-    "label": "z"
+    ascii: 90,
+    code: 28,
+    label: 'z',
   },
   {
-    "ascii": 91,
-    "code": 47,
-    "label": "è"
+    ascii: 91,
+    code: 47,
+    label: 'è',
   },
   {
-    "ascii": 92,
-    "code": 100,
-    "label": "<"
+    ascii: 92,
+    code: 100,
+    label: '<',
   },
   {
-    "ascii": 93,
-    "code": 48,
-    "label": "¨ (dead)"
+    ascii: 93,
+    code: 48,
+    label: '¨ (dead)',
   },
   {
-    "ascii": 94,
-    "code": 46,
-    "label": "^ (dead)"
+    ascii: 94,
+    code: 46,
+    label: '^ (dead)',
   },
   {
-    "ascii": 95,
-    "code": 568,
-    "label": "_"
+    ascii: 95,
+    code: 568,
+    label: '_',
   },
   {
-    "ascii": 96,
-    "code": 558,
-    "label": "` (dead)"
+    ascii: 96,
+    code: 558,
+    label: '` (dead)',
   },
   {
-    "ascii": 97,
-    "code": 4,
-    "label": "a"
+    ascii: 97,
+    code: 4,
+    label: 'a',
   },
   {
-    "ascii": 98,
-    "code": 5,
-    "label": "b"
+    ascii: 98,
+    code: 5,
+    label: 'b',
   },
   {
-    "ascii": 99,
-    "code": 6,
-    "label": "c"
+    ascii: 99,
+    code: 6,
+    label: 'c',
   },
   {
-    "ascii": 100,
-    "code": 7,
-    "label": "d"
+    ascii: 100,
+    code: 7,
+    label: 'd',
   },
   {
-    "ascii": 101,
-    "code": 8,
-    "label": "e"
+    ascii: 101,
+    code: 8,
+    label: 'e',
   },
   {
-    "ascii": 102,
-    "code": 9,
-    "label": "f"
+    ascii: 102,
+    code: 9,
+    label: 'f',
   },
   {
-    "ascii": 103,
-    "code": 10,
-    "label": "g"
+    ascii: 103,
+    code: 10,
+    label: 'g',
   },
   {
-    "ascii": 104,
-    "code": 11,
-    "label": "h"
+    ascii: 104,
+    code: 11,
+    label: 'h',
   },
   {
-    "ascii": 105,
-    "code": 12,
-    "label": "i"
+    ascii: 105,
+    code: 12,
+    label: 'i',
   },
   {
-    "ascii": 106,
-    "code": 13,
-    "label": "j"
+    ascii: 106,
+    code: 13,
+    label: 'j',
   },
   {
-    "ascii": 107,
-    "code": 14,
-    "label": "k"
+    ascii: 107,
+    code: 14,
+    label: 'k',
   },
   {
-    "ascii": 108,
-    "code": 15,
-    "label": "l"
+    ascii: 108,
+    code: 15,
+    label: 'l',
   },
   {
-    "ascii": 109,
-    "code": 16,
-    "label": "m"
+    ascii: 109,
+    code: 16,
+    label: 'm',
   },
   {
-    "ascii": 110,
-    "code": 17,
-    "label": "n"
+    ascii: 110,
+    code: 17,
+    label: 'n',
   },
   {
-    "ascii": 111,
-    "code": 18,
-    "label": "o"
+    ascii: 111,
+    code: 18,
+    label: 'o',
   },
   {
-    "ascii": 112,
-    "code": 19,
-    "label": "p"
+    ascii: 112,
+    code: 19,
+    label: 'p',
   },
   {
-    "ascii": 113,
-    "code": 20,
-    "label": "q"
+    ascii: 113,
+    code: 20,
+    label: 'q',
   },
   {
-    "ascii": 114,
-    "code": 21,
-    "label": "r"
+    ascii: 114,
+    code: 21,
+    label: 'r',
   },
   {
-    "ascii": 115,
-    "code": 22,
-    "label": "s"
+    ascii: 115,
+    code: 22,
+    label: 's',
   },
   {
-    "ascii": 116,
-    "code": 23,
-    "label": "t"
+    ascii: 116,
+    code: 23,
+    label: 't',
   },
   {
-    "ascii": 117,
-    "code": 24,
-    "label": "u"
+    ascii: 117,
+    code: 24,
+    label: 'u',
   },
   {
-    "ascii": 118,
-    "code": 25,
-    "label": "v"
+    ascii: 118,
+    code: 25,
+    label: 'v',
   },
   {
-    "ascii": 119,
-    "code": 26,
-    "label": "w"
+    ascii: 119,
+    code: 26,
+    label: 'w',
   },
   {
-    "ascii": 120,
-    "code": 27,
-    "label": "x"
+    ascii: 120,
+    code: 27,
+    label: 'x',
   },
   {
-    "ascii": 121,
-    "code": 29,
-    "label": "y"
+    ascii: 121,
+    code: 29,
+    label: 'y',
   },
   {
-    "ascii": 122,
-    "code": 28,
-    "label": "z"
+    ascii: 122,
+    code: 28,
+    label: 'z',
   },
   {
-    "ascii": 123,
-    "code": 52,
-    "label": "à"
+    ascii: 123,
+    code: 52,
+    label: 'à',
   },
   {
-    "ascii": 124,
-    "code": 36,
-    "label": "7"
+    ascii: 124,
+    code: 36,
+    label: '7',
   },
   {
-    "ascii": 125,
-    "code": 50,
-    "label": "$"
+    ascii: 125,
+    code: 50,
+    label: '$',
   },
   {
-    "ascii": 126,
-    "code": 46,
-    "label": "^ (dead)"
+    ascii: 126,
+    code: 46,
+    label: '^ (dead)',
   },
   {
-    "ascii": 127,
-    "code": 76,
-    "label": "del"
-  }
+    ascii: 127,
+    code: 76,
+    label: 'del',
+  },
 ];
-    

--- a/src/services/labellang/AsciiLabelFrench.ts
+++ b/src/services/labellang/AsciiLabelFrench.ts
@@ -1,645 +1,644 @@
 import { AsciiLabel } from './AsciiLabel';
-        
+
 export const AsciiLabelFrench: AsciiLabel[] = [
   {
-    "ascii": 0,
-    "code": 0,
-    "label": ""
+    ascii: 0,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 1,
-    "code": 0,
-    "label": ""
+    ascii: 1,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 2,
-    "code": 0,
-    "label": ""
+    ascii: 2,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 3,
-    "code": 0,
-    "label": ""
+    ascii: 3,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 4,
-    "code": 0,
-    "label": ""
+    ascii: 4,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 5,
-    "code": 0,
-    "label": ""
+    ascii: 5,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 6,
-    "code": 0,
-    "label": ""
+    ascii: 6,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 7,
-    "code": 0,
-    "label": ""
+    ascii: 7,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 8,
-    "code": 42,
-    "label": "back space"
+    ascii: 8,
+    code: 42,
+    label: 'back space',
   },
   {
-    "ascii": 9,
-    "code": 43,
-    "label": "tab"
+    ascii: 9,
+    code: 43,
+    label: 'tab',
   },
   {
-    "ascii": 10,
-    "code": 40,
-    "label": "enter"
+    ascii: 10,
+    code: 40,
+    label: 'enter',
   },
   {
-    "ascii": 11,
-    "code": 0,
-    "label": ""
+    ascii: 11,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 12,
-    "code": 0,
-    "label": ""
+    ascii: 12,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 13,
-    "code": 0,
-    "label": ""
+    ascii: 13,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 14,
-    "code": 0,
-    "label": ""
+    ascii: 14,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 15,
-    "code": 0,
-    "label": ""
+    ascii: 15,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 16,
-    "code": 0,
-    "label": ""
+    ascii: 16,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 17,
-    "code": 0,
-    "label": ""
+    ascii: 17,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 18,
-    "code": 0,
-    "label": ""
+    ascii: 18,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 19,
-    "code": 0,
-    "label": ""
+    ascii: 19,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 20,
-    "code": 0,
-    "label": ""
+    ascii: 20,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 21,
-    "code": 0,
-    "label": ""
+    ascii: 21,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 22,
-    "code": 0,
-    "label": ""
+    ascii: 22,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 23,
-    "code": 0,
-    "label": ""
+    ascii: 23,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 24,
-    "code": 0,
-    "label": ""
+    ascii: 24,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 25,
-    "code": 0,
-    "label": ""
+    ascii: 25,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 26,
-    "code": 0,
-    "label": ""
+    ascii: 26,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 27,
-    "code": 41,
-    "label": "esc"
+    ascii: 27,
+    code: 41,
+    label: 'esc',
   },
   {
-    "ascii": 28,
-    "code": 0,
-    "label": ""
+    ascii: 28,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 29,
-    "code": 0,
-    "label": ""
+    ascii: 29,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 30,
-    "code": 0,
-    "label": ""
+    ascii: 30,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 31,
-    "code": 0,
-    "label": ""
+    ascii: 31,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 32,
-    "code": 44,
-    "label": "space"
+    ascii: 32,
+    code: 44,
+    label: 'space',
   },
   {
-    "ascii": 33,
-    "code": 56,
-    "label": "!"
+    ascii: 33,
+    code: 56,
+    label: '!',
   },
   {
-    "ascii": 34,
-    "code": 32,
-    "label": "\""
+    ascii: 34,
+    code: 32,
+    label: '"',
   },
   {
-    "ascii": 35,
-    "code": 32,
-    "label": "\""
+    ascii: 35,
+    code: 32,
+    label: '"',
   },
   {
-    "ascii": 36,
-    "code": 48,
-    "label": "$"
+    ascii: 36,
+    code: 48,
+    label: '$',
   },
   {
-    "ascii": 37,
-    "code": 564,
-    "label": "%"
+    ascii: 37,
+    code: 564,
+    label: '%',
   },
   {
-    "ascii": 38,
-    "code": 30,
-    "label": "&"
+    ascii: 38,
+    code: 30,
+    label: '&',
   },
   {
-    "ascii": 39,
-    "code": 33,
-    "label": "'"
+    ascii: 39,
+    code: 33,
+    label: "'",
   },
   {
-    "ascii": 40,
-    "code": 34,
-    "label": "("
+    ascii: 40,
+    code: 34,
+    label: '(',
   },
   {
-    "ascii": 41,
-    "code": 45,
-    "label": ")"
+    ascii: 41,
+    code: 45,
+    label: ')',
   },
   {
-    "ascii": 42,
-    "code": 50,
-    "label": "*"
+    ascii: 42,
+    code: 50,
+    label: '*',
   },
   {
-    "ascii": 43,
-    "code": 558,
-    "label": "+"
+    ascii: 43,
+    code: 558,
+    label: '+',
   },
   {
-    "ascii": 44,
-    "code": 16,
-    "label": ","
+    ascii: 44,
+    code: 16,
+    label: ',',
   },
   {
-    "ascii": 45,
-    "code": 35,
-    "label": "-"
+    ascii: 45,
+    code: 35,
+    label: '-',
   },
   {
-    "ascii": 46,
-    "code": 566,
-    "label": "."
+    ascii: 46,
+    code: 566,
+    label: '.',
   },
   {
-    "ascii": 47,
-    "code": 567,
-    "label": "/"
+    ascii: 47,
+    code: 567,
+    label: '/',
   },
   {
-    "ascii": 48,
-    "code": 551,
-    "label": "0"
+    ascii: 48,
+    code: 551,
+    label: '0',
   },
   {
-    "ascii": 49,
-    "code": 542,
-    "label": "1"
+    ascii: 49,
+    code: 542,
+    label: '1',
   },
   {
-    "ascii": 50,
-    "code": 543,
-    "label": "2"
+    ascii: 50,
+    code: 543,
+    label: '2',
   },
   {
-    "ascii": 51,
-    "code": 544,
-    "label": "3"
+    ascii: 51,
+    code: 544,
+    label: '3',
   },
   {
-    "ascii": 52,
-    "code": 545,
-    "label": "4"
+    ascii: 52,
+    code: 545,
+    label: '4',
   },
   {
-    "ascii": 53,
-    "code": 546,
-    "label": "5"
+    ascii: 53,
+    code: 546,
+    label: '5',
   },
   {
-    "ascii": 54,
-    "code": 547,
-    "label": "6"
+    ascii: 54,
+    code: 547,
+    label: '6',
   },
   {
-    "ascii": 55,
-    "code": 548,
-    "label": "7"
+    ascii: 55,
+    code: 548,
+    label: '7',
   },
   {
-    "ascii": 56,
-    "code": 549,
-    "label": "8"
+    ascii: 56,
+    code: 549,
+    label: '8',
   },
   {
-    "ascii": 57,
-    "code": 550,
-    "label": "9"
+    ascii: 57,
+    code: 550,
+    label: '9',
   },
   {
-    "ascii": 58,
-    "code": 55,
-    "label": ":"
+    ascii: 58,
+    code: 55,
+    label: ':',
   },
   {
-    "ascii": 59,
-    "code": 54,
-    "label": ";"
+    ascii: 59,
+    code: 54,
+    label: ';',
   },
   {
-    "ascii": 60,
-    "code": 100,
-    "label": "<"
+    ascii: 60,
+    code: 100,
+    label: '<',
   },
   {
-    "ascii": 61,
-    "code": 46,
-    "label": "="
+    ascii: 61,
+    code: 46,
+    label: '=',
   },
   {
-    "ascii": 62,
-    "code": 612,
-    "label": ">"
+    ascii: 62,
+    code: 612,
+    label: '>',
   },
   {
-    "ascii": 63,
-    "code": 528,
-    "label": "?"
+    ascii: 63,
+    code: 528,
+    label: '?',
   },
   {
-    "ascii": 64,
-    "code": 39,
-    "label": "à"
+    ascii: 64,
+    code: 39,
+    label: 'à',
   },
   {
-    "ascii": 65,
-    "code": 532,
-    "label": "A"
+    ascii: 65,
+    code: 532,
+    label: 'A',
   },
   {
-    "ascii": 66,
-    "code": 517,
-    "label": "B"
+    ascii: 66,
+    code: 517,
+    label: 'B',
   },
   {
-    "ascii": 67,
-    "code": 518,
-    "label": "C"
+    ascii: 67,
+    code: 518,
+    label: 'C',
   },
   {
-    "ascii": 68,
-    "code": 519,
-    "label": "D"
+    ascii: 68,
+    code: 519,
+    label: 'D',
   },
   {
-    "ascii": 69,
-    "code": 520,
-    "label": "E"
+    ascii: 69,
+    code: 520,
+    label: 'E',
   },
   {
-    "ascii": 70,
-    "code": 521,
-    "label": "F"
+    ascii: 70,
+    code: 521,
+    label: 'F',
   },
   {
-    "ascii": 71,
-    "code": 522,
-    "label": "G"
+    ascii: 71,
+    code: 522,
+    label: 'G',
   },
   {
-    "ascii": 72,
-    "code": 523,
-    "label": "H"
+    ascii: 72,
+    code: 523,
+    label: 'H',
   },
   {
-    "ascii": 73,
-    "code": 524,
-    "label": "I"
+    ascii: 73,
+    code: 524,
+    label: 'I',
   },
   {
-    "ascii": 74,
-    "code": 525,
-    "label": "J"
+    ascii: 74,
+    code: 525,
+    label: 'J',
   },
   {
-    "ascii": 75,
-    "code": 526,
-    "label": "K"
+    ascii: 75,
+    code: 526,
+    label: 'K',
   },
   {
-    "ascii": 76,
-    "code": 527,
-    "label": "L"
+    ascii: 76,
+    code: 527,
+    label: 'L',
   },
   {
-    "ascii": 77,
-    "code": 563,
-    "label": "M"
+    ascii: 77,
+    code: 563,
+    label: 'M',
   },
   {
-    "ascii": 78,
-    "code": 529,
-    "label": "N"
+    ascii: 78,
+    code: 529,
+    label: 'N',
   },
   {
-    "ascii": 79,
-    "code": 530,
-    "label": "O"
+    ascii: 79,
+    code: 530,
+    label: 'O',
   },
   {
-    "ascii": 80,
-    "code": 531,
-    "label": "P"
+    ascii: 80,
+    code: 531,
+    label: 'P',
   },
   {
-    "ascii": 81,
-    "code": 516,
-    "label": "Q"
+    ascii: 81,
+    code: 516,
+    label: 'Q',
   },
   {
-    "ascii": 82,
-    "code": 533,
-    "label": "R"
+    ascii: 82,
+    code: 533,
+    label: 'R',
   },
   {
-    "ascii": 83,
-    "code": 534,
-    "label": "S"
+    ascii: 83,
+    code: 534,
+    label: 'S',
   },
   {
-    "ascii": 84,
-    "code": 535,
-    "label": "T"
+    ascii: 84,
+    code: 535,
+    label: 'T',
   },
   {
-    "ascii": 85,
-    "code": 536,
-    "label": "U"
+    ascii: 85,
+    code: 536,
+    label: 'U',
   },
   {
-    "ascii": 86,
-    "code": 537,
-    "label": "V"
+    ascii: 86,
+    code: 537,
+    label: 'V',
   },
   {
-    "ascii": 87,
-    "code": 541,
-    "label": "W"
+    ascii: 87,
+    code: 541,
+    label: 'W',
   },
   {
-    "ascii": 88,
-    "code": 539,
-    "label": "X"
+    ascii: 88,
+    code: 539,
+    label: 'X',
   },
   {
-    "ascii": 89,
-    "code": 540,
-    "label": "Y"
+    ascii: 89,
+    code: 540,
+    label: 'Y',
   },
   {
-    "ascii": 90,
-    "code": 538,
-    "label": "Z"
+    ascii: 90,
+    code: 538,
+    label: 'Z',
   },
   {
-    "ascii": 91,
-    "code": 34,
-    "label": "("
+    ascii: 91,
+    code: 34,
+    label: '(',
   },
   {
-    "ascii": 92,
-    "code": 37,
-    "label": "_"
+    ascii: 92,
+    code: 37,
+    label: '_',
   },
   {
-    "ascii": 93,
-    "code": 45,
-    "label": ")"
+    ascii: 93,
+    code: 45,
+    label: ')',
   },
   {
-    "ascii": 94,
-    "code": 38,
-    "label": "ç"
+    ascii: 94,
+    code: 38,
+    label: 'ç',
   },
   {
-    "ascii": 95,
-    "code": 37,
-    "label": "_"
+    ascii: 95,
+    code: 37,
+    label: '_',
   },
   {
-    "ascii": 96,
-    "code": 36,
-    "label": "è"
+    ascii: 96,
+    code: 36,
+    label: 'è',
   },
   {
-    "ascii": 97,
-    "code": 20,
-    "label": "a"
+    ascii: 97,
+    code: 20,
+    label: 'a',
   },
   {
-    "ascii": 98,
-    "code": 5,
-    "label": "b"
+    ascii: 98,
+    code: 5,
+    label: 'b',
   },
   {
-    "ascii": 99,
-    "code": 6,
-    "label": "c"
+    ascii: 99,
+    code: 6,
+    label: 'c',
   },
   {
-    "ascii": 100,
-    "code": 7,
-    "label": "d"
+    ascii: 100,
+    code: 7,
+    label: 'd',
   },
   {
-    "ascii": 101,
-    "code": 8,
-    "label": "e"
+    ascii: 101,
+    code: 8,
+    label: 'e',
   },
   {
-    "ascii": 102,
-    "code": 9,
-    "label": "f"
+    ascii: 102,
+    code: 9,
+    label: 'f',
   },
   {
-    "ascii": 103,
-    "code": 10,
-    "label": "g"
+    ascii: 103,
+    code: 10,
+    label: 'g',
   },
   {
-    "ascii": 104,
-    "code": 11,
-    "label": "h"
+    ascii: 104,
+    code: 11,
+    label: 'h',
   },
   {
-    "ascii": 105,
-    "code": 12,
-    "label": "i"
+    ascii: 105,
+    code: 12,
+    label: 'i',
   },
   {
-    "ascii": 106,
-    "code": 13,
-    "label": "j"
+    ascii: 106,
+    code: 13,
+    label: 'j',
   },
   {
-    "ascii": 107,
-    "code": 14,
-    "label": "k"
+    ascii: 107,
+    code: 14,
+    label: 'k',
   },
   {
-    "ascii": 108,
-    "code": 15,
-    "label": "l"
+    ascii: 108,
+    code: 15,
+    label: 'l',
   },
   {
-    "ascii": 109,
-    "code": 51,
-    "label": "m"
+    ascii: 109,
+    code: 51,
+    label: 'm',
   },
   {
-    "ascii": 110,
-    "code": 17,
-    "label": "n"
+    ascii: 110,
+    code: 17,
+    label: 'n',
   },
   {
-    "ascii": 111,
-    "code": 18,
-    "label": "o"
+    ascii: 111,
+    code: 18,
+    label: 'o',
   },
   {
-    "ascii": 112,
-    "code": 19,
-    "label": "p"
+    ascii: 112,
+    code: 19,
+    label: 'p',
   },
   {
-    "ascii": 113,
-    "code": 4,
-    "label": "q"
+    ascii: 113,
+    code: 4,
+    label: 'q',
   },
   {
-    "ascii": 114,
-    "code": 21,
-    "label": "r"
+    ascii: 114,
+    code: 21,
+    label: 'r',
   },
   {
-    "ascii": 115,
-    "code": 22,
-    "label": "s"
+    ascii: 115,
+    code: 22,
+    label: 's',
   },
   {
-    "ascii": 116,
-    "code": 23,
-    "label": "t"
+    ascii: 116,
+    code: 23,
+    label: 't',
   },
   {
-    "ascii": 117,
-    "code": 24,
-    "label": "u"
+    ascii: 117,
+    code: 24,
+    label: 'u',
   },
   {
-    "ascii": 118,
-    "code": 25,
-    "label": "v"
+    ascii: 118,
+    code: 25,
+    label: 'v',
   },
   {
-    "ascii": 119,
-    "code": 29,
-    "label": "w"
+    ascii: 119,
+    code: 29,
+    label: 'w',
   },
   {
-    "ascii": 120,
-    "code": 27,
-    "label": "x"
+    ascii: 120,
+    code: 27,
+    label: 'x',
   },
   {
-    "ascii": 121,
-    "code": 28,
-    "label": "y"
+    ascii: 121,
+    code: 28,
+    label: 'y',
   },
   {
-    "ascii": 122,
-    "code": 26,
-    "label": "z"
+    ascii: 122,
+    code: 26,
+    label: 'z',
   },
   {
-    "ascii": 123,
-    "code": 33,
-    "label": "'"
+    ascii: 123,
+    code: 33,
+    label: "'",
   },
   {
-    "ascii": 124,
-    "code": 35,
-    "label": "-"
+    ascii: 124,
+    code: 35,
+    label: '-',
   },
   {
-    "ascii": 125,
-    "code": 46,
-    "label": "="
+    ascii: 125,
+    code: 46,
+    label: '=',
   },
   {
-    "ascii": 126,
-    "code": 31,
-    "label": "é"
+    ascii: 126,
+    code: 31,
+    label: 'é',
   },
   {
-    "ascii": 127,
-    "code": 76,
-    "label": "del"
-  }
+    ascii: 127,
+    code: 76,
+    label: 'del',
+  },
 ];
-    

--- a/src/services/labellang/AsciiLabelFrench_afnor.ts
+++ b/src/services/labellang/AsciiLabelFrench_afnor.ts
@@ -1,645 +1,644 @@
 import { AsciiLabel } from './AsciiLabel';
-        
+
 export const AsciiLabelFrench_afnor: AsciiLabel[] = [
   {
-    "ascii": 0,
-    "code": 0,
-    "label": ""
+    ascii: 0,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 1,
-    "code": 0,
-    "label": ""
+    ascii: 1,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 2,
-    "code": 0,
-    "label": ""
+    ascii: 2,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 3,
-    "code": 0,
-    "label": ""
+    ascii: 3,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 4,
-    "code": 0,
-    "label": ""
+    ascii: 4,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 5,
-    "code": 0,
-    "label": ""
+    ascii: 5,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 6,
-    "code": 0,
-    "label": ""
+    ascii: 6,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 7,
-    "code": 0,
-    "label": ""
+    ascii: 7,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 8,
-    "code": 42,
-    "label": "back space"
+    ascii: 8,
+    code: 42,
+    label: 'back space',
   },
   {
-    "ascii": 9,
-    "code": 43,
-    "label": "tab"
+    ascii: 9,
+    code: 43,
+    label: 'tab',
   },
   {
-    "ascii": 10,
-    "code": 40,
-    "label": "enter"
+    ascii: 10,
+    code: 40,
+    label: 'enter',
   },
   {
-    "ascii": 11,
-    "code": 0,
-    "label": ""
+    ascii: 11,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 12,
-    "code": 0,
-    "label": ""
+    ascii: 12,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 13,
-    "code": 0,
-    "label": ""
+    ascii: 13,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 14,
-    "code": 0,
-    "label": ""
+    ascii: 14,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 15,
-    "code": 0,
-    "label": ""
+    ascii: 15,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 16,
-    "code": 0,
-    "label": ""
+    ascii: 16,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 17,
-    "code": 0,
-    "label": ""
+    ascii: 17,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 18,
-    "code": 0,
-    "label": ""
+    ascii: 18,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 19,
-    "code": 0,
-    "label": ""
+    ascii: 19,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 20,
-    "code": 0,
-    "label": ""
+    ascii: 20,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 21,
-    "code": 0,
-    "label": ""
+    ascii: 21,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 22,
-    "code": 0,
-    "label": ""
+    ascii: 22,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 23,
-    "code": 0,
-    "label": ""
+    ascii: 23,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 24,
-    "code": 0,
-    "label": ""
+    ascii: 24,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 25,
-    "code": 0,
-    "label": ""
+    ascii: 25,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 26,
-    "code": 0,
-    "label": ""
+    ascii: 26,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 27,
-    "code": 41,
-    "label": "esc"
+    ascii: 27,
+    code: 41,
+    label: 'esc',
   },
   {
-    "ascii": 28,
-    "code": 0,
-    "label": ""
+    ascii: 28,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 29,
-    "code": 0,
-    "label": ""
+    ascii: 29,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 30,
-    "code": 0,
-    "label": ""
+    ascii: 30,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 31,
-    "code": 0,
-    "label": ""
+    ascii: 31,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 32,
-    "code": 44,
-    "label": "space"
+    ascii: 32,
+    code: 44,
+    label: 'space',
   },
   {
-    "ascii": 33,
-    "code": 566,
-    "label": "!"
+    ascii: 33,
+    code: 566,
+    label: '!',
   },
   {
-    "ascii": 34,
-    "code": 557,
-    "label": "\""
+    ascii: 34,
+    code: 557,
+    label: '"',
   },
   {
-    "ascii": 35,
-    "code": 565,
-    "label": "#"
+    ascii: 35,
+    code: 565,
+    label: '#',
   },
   {
-    "ascii": 36,
-    "code": 7,
-    "label": "d"
+    ascii: 36,
+    code: 7,
+    label: 'd',
   },
   {
-    "ascii": 37,
-    "code": 19,
-    "label": "p"
+    ascii: 37,
+    code: 19,
+    label: 'p',
   },
   {
-    "ascii": 38,
-    "code": 33,
-    "label": "ê"
+    ascii: 38,
+    code: 33,
+    label: 'ê',
   },
   {
-    "ascii": 39,
-    "code": 45,
-    "label": "'"
+    ascii: 39,
+    code: 45,
+    label: "'",
   },
   {
-    "ascii": 40,
-    "code": 34,
-    "label": "("
+    ascii: 40,
+    code: 34,
+    label: '(',
   },
   {
-    "ascii": 41,
-    "code": 35,
-    "label": ")"
+    ascii: 41,
+    code: 35,
+    label: ')',
   },
   {
-    "ascii": 42,
-    "code": 50,
-    "label": "*"
+    ascii: 42,
+    code: 50,
+    label: '*',
   },
   {
-    "ascii": 43,
-    "code": 48,
-    "label": "+"
+    ascii: 43,
+    code: 48,
+    label: '+',
   },
   {
-    "ascii": 44,
-    "code": 54,
-    "label": ","
+    ascii: 44,
+    code: 54,
+    label: ',',
   },
   {
-    "ascii": 45,
-    "code": 47,
-    "label": "-"
+    ascii: 45,
+    code: 47,
+    label: '-',
   },
   {
-    "ascii": 46,
-    "code": 16,
-    "label": "."
+    ascii: 46,
+    code: 16,
+    label: '.',
   },
   {
-    "ascii": 47,
-    "code": 52,
-    "label": "/"
+    ascii: 47,
+    code: 52,
+    label: '/',
   },
   {
-    "ascii": 48,
-    "code": 551,
-    "label": "0"
+    ascii: 48,
+    code: 551,
+    label: '0',
   },
   {
-    "ascii": 49,
-    "code": 542,
-    "label": "1"
+    ascii: 49,
+    code: 542,
+    label: '1',
   },
   {
-    "ascii": 50,
-    "code": 543,
-    "label": "2"
+    ascii: 50,
+    code: 543,
+    label: '2',
   },
   {
-    "ascii": 51,
-    "code": 544,
-    "label": "3"
+    ascii: 51,
+    code: 544,
+    label: '3',
   },
   {
-    "ascii": 52,
-    "code": 545,
-    "label": "4"
+    ascii: 52,
+    code: 545,
+    label: '4',
   },
   {
-    "ascii": 53,
-    "code": 546,
-    "label": "5"
+    ascii: 53,
+    code: 546,
+    label: '5',
   },
   {
-    "ascii": 54,
-    "code": 547,
-    "label": "6"
+    ascii: 54,
+    code: 547,
+    label: '6',
   },
   {
-    "ascii": 55,
-    "code": 548,
-    "label": "7"
+    ascii: 55,
+    code: 548,
+    label: '7',
   },
   {
-    "ascii": 56,
-    "code": 549,
-    "label": "8"
+    ascii: 56,
+    code: 549,
+    label: '8',
   },
   {
-    "ascii": 57,
-    "code": 550,
-    "label": "9"
+    ascii: 57,
+    code: 550,
+    label: '9',
   },
   {
-    "ascii": 58,
-    "code": 55,
-    "label": ":"
+    ascii: 58,
+    code: 55,
+    label: ':',
   },
   {
-    "ascii": 59,
-    "code": 56,
-    "label": ";"
+    ascii: 59,
+    code: 56,
+    label: ';',
   },
   {
-    "ascii": 60,
-    "code": 100,
-    "label": "<"
+    ascii: 60,
+    code: 100,
+    label: '<',
   },
   {
-    "ascii": 61,
-    "code": 568,
-    "label": "="
+    ascii: 61,
+    code: 568,
+    label: '=',
   },
   {
-    "ascii": 62,
-    "code": 612,
-    "label": ">"
+    ascii: 62,
+    code: 612,
+    label: '>',
   },
   {
-    "ascii": 63,
-    "code": 528,
-    "label": "?"
+    ascii: 63,
+    code: 528,
+    label: '?',
   },
   {
-    "ascii": 64,
-    "code": 53,
-    "label": "@"
+    ascii: 64,
+    code: 53,
+    label: '@',
   },
   {
-    "ascii": 65,
-    "code": 532,
-    "label": "A"
+    ascii: 65,
+    code: 532,
+    label: 'A',
   },
   {
-    "ascii": 66,
-    "code": 517,
-    "label": "B"
+    ascii: 66,
+    code: 517,
+    label: 'B',
   },
   {
-    "ascii": 67,
-    "code": 518,
-    "label": "C"
+    ascii: 67,
+    code: 518,
+    label: 'C',
   },
   {
-    "ascii": 68,
-    "code": 519,
-    "label": "D"
+    ascii: 68,
+    code: 519,
+    label: 'D',
   },
   {
-    "ascii": 69,
-    "code": 520,
-    "label": "E"
+    ascii: 69,
+    code: 520,
+    label: 'E',
   },
   {
-    "ascii": 70,
-    "code": 521,
-    "label": "F"
+    ascii: 70,
+    code: 521,
+    label: 'F',
   },
   {
-    "ascii": 71,
-    "code": 522,
-    "label": "G"
+    ascii: 71,
+    code: 522,
+    label: 'G',
   },
   {
-    "ascii": 72,
-    "code": 523,
-    "label": "H"
+    ascii: 72,
+    code: 523,
+    label: 'H',
   },
   {
-    "ascii": 73,
-    "code": 524,
-    "label": "I"
+    ascii: 73,
+    code: 524,
+    label: 'I',
   },
   {
-    "ascii": 74,
-    "code": 525,
-    "label": "J"
+    ascii: 74,
+    code: 525,
+    label: 'J',
   },
   {
-    "ascii": 75,
-    "code": 526,
-    "label": "K"
+    ascii: 75,
+    code: 526,
+    label: 'K',
   },
   {
-    "ascii": 76,
-    "code": 527,
-    "label": "L"
+    ascii: 76,
+    code: 527,
+    label: 'L',
   },
   {
-    "ascii": 77,
-    "code": 563,
-    "label": "M"
+    ascii: 77,
+    code: 563,
+    label: 'M',
   },
   {
-    "ascii": 78,
-    "code": 529,
-    "label": "N"
+    ascii: 78,
+    code: 529,
+    label: 'N',
   },
   {
-    "ascii": 79,
-    "code": 530,
-    "label": "O"
+    ascii: 79,
+    code: 530,
+    label: 'O',
   },
   {
-    "ascii": 80,
-    "code": 531,
-    "label": "P"
+    ascii: 80,
+    code: 531,
+    label: 'P',
   },
   {
-    "ascii": 81,
-    "code": 516,
-    "label": "Q"
+    ascii: 81,
+    code: 516,
+    label: 'Q',
   },
   {
-    "ascii": 82,
-    "code": 533,
-    "label": "R"
+    ascii: 82,
+    code: 533,
+    label: 'R',
   },
   {
-    "ascii": 83,
-    "code": 534,
-    "label": "S"
+    ascii: 83,
+    code: 534,
+    label: 'S',
   },
   {
-    "ascii": 84,
-    "code": 535,
-    "label": "T"
+    ascii: 84,
+    code: 535,
+    label: 'T',
   },
   {
-    "ascii": 85,
-    "code": 536,
-    "label": "U"
+    ascii: 85,
+    code: 536,
+    label: 'U',
   },
   {
-    "ascii": 86,
-    "code": 537,
-    "label": "V"
+    ascii: 86,
+    code: 537,
+    label: 'V',
   },
   {
-    "ascii": 87,
-    "code": 541,
-    "label": "W"
+    ascii: 87,
+    code: 541,
+    label: 'W',
   },
   {
-    "ascii": 88,
-    "code": 539,
-    "label": "X"
+    ascii: 88,
+    code: 539,
+    label: 'X',
   },
   {
-    "ascii": 89,
-    "code": 540,
-    "label": "Y"
+    ascii: 89,
+    code: 540,
+    label: 'Y',
   },
   {
-    "ascii": 90,
-    "code": 538,
-    "label": "Z"
+    ascii: 90,
+    code: 538,
+    label: 'Z',
   },
   {
-    "ascii": 91,
-    "code": 34,
-    "label": "("
+    ascii: 91,
+    code: 34,
+    label: '(',
   },
   {
-    "ascii": 92,
-    "code": 564,
-    "label": "(backslash)"
+    ascii: 92,
+    code: 564,
+    label: '(backslash)',
   },
   {
-    "ascii": 93,
-    "code": 35,
-    "label": ")"
+    ascii: 93,
+    code: 35,
+    label: ')',
   },
   {
-    "ascii": 94,
-    "code": 46,
-    "label": "^ (dead)"
+    ascii: 94,
+    code: 46,
+    label: '^ (dead)',
   },
   {
-    "ascii": 95,
-    "code": 37,
-    "label": "’"
+    ascii: 95,
+    code: 37,
+    label: '’',
   },
   {
-    "ascii": 96,
-    "code": 32,
-    "label": "è"
+    ascii: 96,
+    code: 32,
+    label: 'è',
   },
   {
-    "ascii": 97,
-    "code": 20,
-    "label": "a"
+    ascii: 97,
+    code: 20,
+    label: 'a',
   },
   {
-    "ascii": 98,
-    "code": 5,
-    "label": "b"
+    ascii: 98,
+    code: 5,
+    label: 'b',
   },
   {
-    "ascii": 99,
-    "code": 6,
-    "label": "c"
+    ascii: 99,
+    code: 6,
+    label: 'c',
   },
   {
-    "ascii": 100,
-    "code": 7,
-    "label": "d"
+    ascii: 100,
+    code: 7,
+    label: 'd',
   },
   {
-    "ascii": 101,
-    "code": 8,
-    "label": "e"
+    ascii: 101,
+    code: 8,
+    label: 'e',
   },
   {
-    "ascii": 102,
-    "code": 9,
-    "label": "f"
+    ascii: 102,
+    code: 9,
+    label: 'f',
   },
   {
-    "ascii": 103,
-    "code": 10,
-    "label": "g"
+    ascii: 103,
+    code: 10,
+    label: 'g',
   },
   {
-    "ascii": 104,
-    "code": 11,
-    "label": "h"
+    ascii: 104,
+    code: 11,
+    label: 'h',
   },
   {
-    "ascii": 105,
-    "code": 12,
-    "label": "i"
+    ascii: 105,
+    code: 12,
+    label: 'i',
   },
   {
-    "ascii": 106,
-    "code": 13,
-    "label": "j"
+    ascii: 106,
+    code: 13,
+    label: 'j',
   },
   {
-    "ascii": 107,
-    "code": 14,
-    "label": "k"
+    ascii: 107,
+    code: 14,
+    label: 'k',
   },
   {
-    "ascii": 108,
-    "code": 15,
-    "label": "l"
+    ascii: 108,
+    code: 15,
+    label: 'l',
   },
   {
-    "ascii": 109,
-    "code": 51,
-    "label": "m"
+    ascii: 109,
+    code: 51,
+    label: 'm',
   },
   {
-    "ascii": 110,
-    "code": 17,
-    "label": "n"
+    ascii: 110,
+    code: 17,
+    label: 'n',
   },
   {
-    "ascii": 111,
-    "code": 18,
-    "label": "o"
+    ascii: 111,
+    code: 18,
+    label: 'o',
   },
   {
-    "ascii": 112,
-    "code": 19,
-    "label": "p"
+    ascii: 112,
+    code: 19,
+    label: 'p',
   },
   {
-    "ascii": 113,
-    "code": 4,
-    "label": "q"
+    ascii: 113,
+    code: 4,
+    label: 'q',
   },
   {
-    "ascii": 114,
-    "code": 21,
-    "label": "r"
+    ascii: 114,
+    code: 21,
+    label: 'r',
   },
   {
-    "ascii": 115,
-    "code": 22,
-    "label": "s"
+    ascii: 115,
+    code: 22,
+    label: 's',
   },
   {
-    "ascii": 116,
-    "code": 23,
-    "label": "t"
+    ascii: 116,
+    code: 23,
+    label: 't',
   },
   {
-    "ascii": 117,
-    "code": 24,
-    "label": "u"
+    ascii: 117,
+    code: 24,
+    label: 'u',
   },
   {
-    "ascii": 118,
-    "code": 25,
-    "label": "v"
+    ascii: 118,
+    code: 25,
+    label: 'v',
   },
   {
-    "ascii": 119,
-    "code": 29,
-    "label": "w"
+    ascii: 119,
+    code: 29,
+    label: 'w',
   },
   {
-    "ascii": 120,
-    "code": 27,
-    "label": "x"
+    ascii: 120,
+    code: 27,
+    label: 'x',
   },
   {
-    "ascii": 121,
-    "code": 28,
-    "label": "y"
+    ascii: 121,
+    code: 28,
+    label: 'y',
   },
   {
-    "ascii": 122,
-    "code": 26,
-    "label": "z"
+    ascii: 122,
+    code: 26,
+    label: 'z',
   },
   {
-    "ascii": 123,
-    "code": 23,
-    "label": "t"
+    ascii: 123,
+    code: 23,
+    label: 't',
   },
   {
-    "ascii": 124,
-    "code": 15,
-    "label": "l"
+    ascii: 124,
+    code: 15,
+    label: 'l',
   },
   {
-    "ascii": 125,
-    "code": 28,
-    "label": "y"
+    ascii: 125,
+    code: 28,
+    label: 'y',
   },
   {
-    "ascii": 126,
-    "code": 17,
-    "label": "n"
+    ascii: 126,
+    code: 17,
+    label: 'n',
   },
   {
-    "ascii": 127,
-    "code": 76,
-    "label": "del"
-  }
+    ascii: 127,
+    code: 76,
+    label: 'del',
+  },
 ];
-    

--- a/src/services/labellang/AsciiLabelFrench_osx.ts
+++ b/src/services/labellang/AsciiLabelFrench_osx.ts
@@ -1,645 +1,644 @@
 import { AsciiLabel } from './AsciiLabel';
-        
+
 export const AsciiLabelFrench_osx: AsciiLabel[] = [
   {
-    "ascii": 0,
-    "code": 0,
-    "label": ""
+    ascii: 0,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 1,
-    "code": 0,
-    "label": ""
+    ascii: 1,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 2,
-    "code": 0,
-    "label": ""
+    ascii: 2,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 3,
-    "code": 0,
-    "label": ""
+    ascii: 3,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 4,
-    "code": 0,
-    "label": ""
+    ascii: 4,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 5,
-    "code": 0,
-    "label": ""
+    ascii: 5,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 6,
-    "code": 0,
-    "label": ""
+    ascii: 6,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 7,
-    "code": 0,
-    "label": ""
+    ascii: 7,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 8,
-    "code": 42,
-    "label": "back space"
+    ascii: 8,
+    code: 42,
+    label: 'back space',
   },
   {
-    "ascii": 9,
-    "code": 43,
-    "label": "tab"
+    ascii: 9,
+    code: 43,
+    label: 'tab',
   },
   {
-    "ascii": 10,
-    "code": 40,
-    "label": "enter"
+    ascii: 10,
+    code: 40,
+    label: 'enter',
   },
   {
-    "ascii": 11,
-    "code": 0,
-    "label": ""
+    ascii: 11,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 12,
-    "code": 0,
-    "label": ""
+    ascii: 12,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 13,
-    "code": 0,
-    "label": ""
+    ascii: 13,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 14,
-    "code": 0,
-    "label": ""
+    ascii: 14,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 15,
-    "code": 0,
-    "label": ""
+    ascii: 15,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 16,
-    "code": 0,
-    "label": ""
+    ascii: 16,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 17,
-    "code": 0,
-    "label": ""
+    ascii: 17,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 18,
-    "code": 0,
-    "label": ""
+    ascii: 18,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 19,
-    "code": 0,
-    "label": ""
+    ascii: 19,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 20,
-    "code": 0,
-    "label": ""
+    ascii: 20,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 21,
-    "code": 0,
-    "label": ""
+    ascii: 21,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 22,
-    "code": 0,
-    "label": ""
+    ascii: 22,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 23,
-    "code": 0,
-    "label": ""
+    ascii: 23,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 24,
-    "code": 0,
-    "label": ""
+    ascii: 24,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 25,
-    "code": 0,
-    "label": ""
+    ascii: 25,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 26,
-    "code": 0,
-    "label": ""
+    ascii: 26,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 27,
-    "code": 41,
-    "label": "esc"
+    ascii: 27,
+    code: 41,
+    label: 'esc',
   },
   {
-    "ascii": 28,
-    "code": 0,
-    "label": ""
+    ascii: 28,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 29,
-    "code": 0,
-    "label": ""
+    ascii: 29,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 30,
-    "code": 0,
-    "label": ""
+    ascii: 30,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 31,
-    "code": 0,
-    "label": ""
+    ascii: 31,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 32,
-    "code": 44,
-    "label": "space"
+    ascii: 32,
+    code: 44,
+    label: 'space',
   },
   {
-    "ascii": 33,
-    "code": 37,
-    "label": "!"
+    ascii: 33,
+    code: 37,
+    label: '!',
   },
   {
-    "ascii": 34,
-    "code": 32,
-    "label": "\""
+    ascii: 34,
+    code: 32,
+    label: '"',
   },
   {
-    "ascii": 35,
-    "code": 565,
-    "label": "#"
+    ascii: 35,
+    code: 565,
+    label: '#',
   },
   {
-    "ascii": 36,
-    "code": 48,
-    "label": "$"
+    ascii: 36,
+    code: 48,
+    label: '$',
   },
   {
-    "ascii": 37,
-    "code": 564,
-    "label": "%"
+    ascii: 37,
+    code: 564,
+    label: '%',
   },
   {
-    "ascii": 38,
-    "code": 30,
-    "label": "&"
+    ascii: 38,
+    code: 30,
+    label: '&',
   },
   {
-    "ascii": 39,
-    "code": 33,
-    "label": "'"
+    ascii: 39,
+    code: 33,
+    label: "'",
   },
   {
-    "ascii": 40,
-    "code": 34,
-    "label": "("
+    ascii: 40,
+    code: 34,
+    label: '(',
   },
   {
-    "ascii": 41,
-    "code": 45,
-    "label": ")"
+    ascii: 41,
+    code: 45,
+    label: ')',
   },
   {
-    "ascii": 42,
-    "code": 560,
-    "label": "*"
+    ascii: 42,
+    code: 560,
+    label: '*',
   },
   {
-    "ascii": 43,
-    "code": 568,
-    "label": "+"
+    ascii: 43,
+    code: 568,
+    label: '+',
   },
   {
-    "ascii": 44,
-    "code": 16,
-    "label": ","
+    ascii: 44,
+    code: 16,
+    label: ',',
   },
   {
-    "ascii": 45,
-    "code": 46,
-    "label": "-"
+    ascii: 45,
+    code: 46,
+    label: '-',
   },
   {
-    "ascii": 46,
-    "code": 566,
-    "label": "."
+    ascii: 46,
+    code: 566,
+    label: '.',
   },
   {
-    "ascii": 47,
-    "code": 567,
-    "label": "/"
+    ascii: 47,
+    code: 567,
+    label: '/',
   },
   {
-    "ascii": 48,
-    "code": 551,
-    "label": "0"
+    ascii: 48,
+    code: 551,
+    label: '0',
   },
   {
-    "ascii": 49,
-    "code": 542,
-    "label": "1"
+    ascii: 49,
+    code: 542,
+    label: '1',
   },
   {
-    "ascii": 50,
-    "code": 543,
-    "label": "2"
+    ascii: 50,
+    code: 543,
+    label: '2',
   },
   {
-    "ascii": 51,
-    "code": 544,
-    "label": "3"
+    ascii: 51,
+    code: 544,
+    label: '3',
   },
   {
-    "ascii": 52,
-    "code": 545,
-    "label": "4"
+    ascii: 52,
+    code: 545,
+    label: '4',
   },
   {
-    "ascii": 53,
-    "code": 546,
-    "label": "5"
+    ascii: 53,
+    code: 546,
+    label: '5',
   },
   {
-    "ascii": 54,
-    "code": 547,
-    "label": "6"
+    ascii: 54,
+    code: 547,
+    label: '6',
   },
   {
-    "ascii": 55,
-    "code": 548,
-    "label": "7"
+    ascii: 55,
+    code: 548,
+    label: '7',
   },
   {
-    "ascii": 56,
-    "code": 549,
-    "label": "8"
+    ascii: 56,
+    code: 549,
+    label: '8',
   },
   {
-    "ascii": 57,
-    "code": 550,
-    "label": "9"
+    ascii: 57,
+    code: 550,
+    label: '9',
   },
   {
-    "ascii": 58,
-    "code": 55,
-    "label": ":"
+    ascii: 58,
+    code: 55,
+    label: ':',
   },
   {
-    "ascii": 59,
-    "code": 54,
-    "label": ";"
+    ascii: 59,
+    code: 54,
+    label: ';',
   },
   {
-    "ascii": 60,
-    "code": 100,
-    "label": "<"
+    ascii: 60,
+    code: 100,
+    label: '<',
   },
   {
-    "ascii": 61,
-    "code": 56,
-    "label": "="
+    ascii: 61,
+    code: 56,
+    label: '=',
   },
   {
-    "ascii": 62,
-    "code": 612,
-    "label": ">"
+    ascii: 62,
+    code: 612,
+    label: '>',
   },
   {
-    "ascii": 63,
-    "code": 528,
-    "label": "?"
+    ascii: 63,
+    code: 528,
+    label: '?',
   },
   {
-    "ascii": 64,
-    "code": 53,
-    "label": "@"
+    ascii: 64,
+    code: 53,
+    label: '@',
   },
   {
-    "ascii": 65,
-    "code": 532,
-    "label": "A"
+    ascii: 65,
+    code: 532,
+    label: 'A',
   },
   {
-    "ascii": 66,
-    "code": 517,
-    "label": "B"
+    ascii: 66,
+    code: 517,
+    label: 'B',
   },
   {
-    "ascii": 67,
-    "code": 518,
-    "label": "C"
+    ascii: 67,
+    code: 518,
+    label: 'C',
   },
   {
-    "ascii": 68,
-    "code": 519,
-    "label": "D"
+    ascii: 68,
+    code: 519,
+    label: 'D',
   },
   {
-    "ascii": 69,
-    "code": 520,
-    "label": "E"
+    ascii: 69,
+    code: 520,
+    label: 'E',
   },
   {
-    "ascii": 70,
-    "code": 521,
-    "label": "F"
+    ascii: 70,
+    code: 521,
+    label: 'F',
   },
   {
-    "ascii": 71,
-    "code": 522,
-    "label": "G"
+    ascii: 71,
+    code: 522,
+    label: 'G',
   },
   {
-    "ascii": 72,
-    "code": 523,
-    "label": "H"
+    ascii: 72,
+    code: 523,
+    label: 'H',
   },
   {
-    "ascii": 73,
-    "code": 524,
-    "label": "I"
+    ascii: 73,
+    code: 524,
+    label: 'I',
   },
   {
-    "ascii": 74,
-    "code": 525,
-    "label": "J"
+    ascii: 74,
+    code: 525,
+    label: 'J',
   },
   {
-    "ascii": 75,
-    "code": 526,
-    "label": "K"
+    ascii: 75,
+    code: 526,
+    label: 'K',
   },
   {
-    "ascii": 76,
-    "code": 527,
-    "label": "L"
+    ascii: 76,
+    code: 527,
+    label: 'L',
   },
   {
-    "ascii": 77,
-    "code": 563,
-    "label": "M"
+    ascii: 77,
+    code: 563,
+    label: 'M',
   },
   {
-    "ascii": 78,
-    "code": 529,
-    "label": "N"
+    ascii: 78,
+    code: 529,
+    label: 'N',
   },
   {
-    "ascii": 79,
-    "code": 530,
-    "label": "O"
+    ascii: 79,
+    code: 530,
+    label: 'O',
   },
   {
-    "ascii": 80,
-    "code": 531,
-    "label": "P"
+    ascii: 80,
+    code: 531,
+    label: 'P',
   },
   {
-    "ascii": 81,
-    "code": 516,
-    "label": "Q"
+    ascii: 81,
+    code: 516,
+    label: 'Q',
   },
   {
-    "ascii": 82,
-    "code": 533,
-    "label": "R"
+    ascii: 82,
+    code: 533,
+    label: 'R',
   },
   {
-    "ascii": 83,
-    "code": 534,
-    "label": "S"
+    ascii: 83,
+    code: 534,
+    label: 'S',
   },
   {
-    "ascii": 84,
-    "code": 535,
-    "label": "T"
+    ascii: 84,
+    code: 535,
+    label: 'T',
   },
   {
-    "ascii": 85,
-    "code": 536,
-    "label": "U"
+    ascii: 85,
+    code: 536,
+    label: 'U',
   },
   {
-    "ascii": 86,
-    "code": 537,
-    "label": "V"
+    ascii: 86,
+    code: 537,
+    label: 'V',
   },
   {
-    "ascii": 87,
-    "code": 541,
-    "label": "W"
+    ascii: 87,
+    code: 541,
+    label: 'W',
   },
   {
-    "ascii": 88,
-    "code": 539,
-    "label": "X"
+    ascii: 88,
+    code: 539,
+    label: 'X',
   },
   {
-    "ascii": 89,
-    "code": 540,
-    "label": "Y"
+    ascii: 89,
+    code: 540,
+    label: 'Y',
   },
   {
-    "ascii": 90,
-    "code": 538,
-    "label": "Z"
+    ascii: 90,
+    code: 538,
+    label: 'Z',
   },
   {
-    "ascii": 91,
-    "code": 546,
-    "label": "5"
+    ascii: 91,
+    code: 546,
+    label: '5',
   },
   {
-    "ascii": 92,
-    "code": 567,
-    "label": "/"
+    ascii: 92,
+    code: 567,
+    label: '/',
   },
   {
-    "ascii": 93,
-    "code": 557,
-    "label": "°"
+    ascii: 93,
+    code: 557,
+    label: '°',
   },
   {
-    "ascii": 94,
-    "code": 47,
-    "label": "^"
+    ascii: 94,
+    code: 47,
+    label: '^',
   },
   {
-    "ascii": 95,
-    "code": 558,
-    "label": "_"
+    ascii: 95,
+    code: 558,
+    label: '_',
   },
   {
-    "ascii": 96,
-    "code": 50,
-    "label": "`"
+    ascii: 96,
+    code: 50,
+    label: '`',
   },
   {
-    "ascii": 97,
-    "code": 20,
-    "label": "a"
+    ascii: 97,
+    code: 20,
+    label: 'a',
   },
   {
-    "ascii": 98,
-    "code": 5,
-    "label": "b"
+    ascii: 98,
+    code: 5,
+    label: 'b',
   },
   {
-    "ascii": 99,
-    "code": 6,
-    "label": "c"
+    ascii: 99,
+    code: 6,
+    label: 'c',
   },
   {
-    "ascii": 100,
-    "code": 7,
-    "label": "d"
+    ascii: 100,
+    code: 7,
+    label: 'd',
   },
   {
-    "ascii": 101,
-    "code": 8,
-    "label": "e"
+    ascii: 101,
+    code: 8,
+    label: 'e',
   },
   {
-    "ascii": 102,
-    "code": 9,
-    "label": "f"
+    ascii: 102,
+    code: 9,
+    label: 'f',
   },
   {
-    "ascii": 103,
-    "code": 10,
-    "label": "g"
+    ascii: 103,
+    code: 10,
+    label: 'g',
   },
   {
-    "ascii": 104,
-    "code": 11,
-    "label": "h"
+    ascii: 104,
+    code: 11,
+    label: 'h',
   },
   {
-    "ascii": 105,
-    "code": 12,
-    "label": "i"
+    ascii: 105,
+    code: 12,
+    label: 'i',
   },
   {
-    "ascii": 106,
-    "code": 13,
-    "label": "j"
+    ascii: 106,
+    code: 13,
+    label: 'j',
   },
   {
-    "ascii": 107,
-    "code": 14,
-    "label": "k"
+    ascii: 107,
+    code: 14,
+    label: 'k',
   },
   {
-    "ascii": 108,
-    "code": 15,
-    "label": "l"
+    ascii: 108,
+    code: 15,
+    label: 'l',
   },
   {
-    "ascii": 109,
-    "code": 51,
-    "label": "m"
+    ascii: 109,
+    code: 51,
+    label: 'm',
   },
   {
-    "ascii": 110,
-    "code": 17,
-    "label": "n"
+    ascii: 110,
+    code: 17,
+    label: 'n',
   },
   {
-    "ascii": 111,
-    "code": 18,
-    "label": "o"
+    ascii: 111,
+    code: 18,
+    label: 'o',
   },
   {
-    "ascii": 112,
-    "code": 19,
-    "label": "p"
+    ascii: 112,
+    code: 19,
+    label: 'p',
   },
   {
-    "ascii": 113,
-    "code": 4,
-    "label": "q"
+    ascii: 113,
+    code: 4,
+    label: 'q',
   },
   {
-    "ascii": 114,
-    "code": 21,
-    "label": "r"
+    ascii: 114,
+    code: 21,
+    label: 'r',
   },
   {
-    "ascii": 115,
-    "code": 22,
-    "label": "s"
+    ascii: 115,
+    code: 22,
+    label: 's',
   },
   {
-    "ascii": 116,
-    "code": 23,
-    "label": "t"
+    ascii: 116,
+    code: 23,
+    label: 't',
   },
   {
-    "ascii": 117,
-    "code": 24,
-    "label": "u"
+    ascii: 117,
+    code: 24,
+    label: 'u',
   },
   {
-    "ascii": 118,
-    "code": 25,
-    "label": "v"
+    ascii: 118,
+    code: 25,
+    label: 'v',
   },
   {
-    "ascii": 119,
-    "code": 29,
-    "label": "w"
+    ascii: 119,
+    code: 29,
+    label: 'w',
   },
   {
-    "ascii": 120,
-    "code": 27,
-    "label": "x"
+    ascii: 120,
+    code: 27,
+    label: 'x',
   },
   {
-    "ascii": 121,
-    "code": 28,
-    "label": "y"
+    ascii: 121,
+    code: 28,
+    label: 'y',
   },
   {
-    "ascii": 122,
-    "code": 26,
-    "label": "z"
+    ascii: 122,
+    code: 26,
+    label: 'z',
   },
   {
-    "ascii": 123,
-    "code": 34,
-    "label": "("
+    ascii: 123,
+    code: 34,
+    label: '(',
   },
   {
-    "ascii": 124,
-    "code": 527,
-    "label": "L"
+    ascii: 124,
+    code: 527,
+    label: 'L',
   },
   {
-    "ascii": 125,
-    "code": 45,
-    "label": ")"
+    ascii: 125,
+    code: 45,
+    label: ')',
   },
   {
-    "ascii": 126,
-    "code": 17,
-    "label": "n"
+    ascii: 126,
+    code: 17,
+    label: 'n',
   },
   {
-    "ascii": 127,
-    "code": 76,
-    "label": "del"
-  }
+    ascii: 127,
+    code: 76,
+    label: 'del',
+  },
 ];
-    

--- a/src/services/labellang/AsciiLabelGerman.ts
+++ b/src/services/labellang/AsciiLabelGerman.ts
@@ -1,645 +1,644 @@
 import { AsciiLabel } from './AsciiLabel';
-        
+
 export const AsciiLabelGerman: AsciiLabel[] = [
   {
-    "ascii": 0,
-    "code": 0,
-    "label": ""
+    ascii: 0,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 1,
-    "code": 0,
-    "label": ""
+    ascii: 1,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 2,
-    "code": 0,
-    "label": ""
+    ascii: 2,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 3,
-    "code": 0,
-    "label": ""
+    ascii: 3,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 4,
-    "code": 0,
-    "label": ""
+    ascii: 4,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 5,
-    "code": 0,
-    "label": ""
+    ascii: 5,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 6,
-    "code": 0,
-    "label": ""
+    ascii: 6,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 7,
-    "code": 0,
-    "label": ""
+    ascii: 7,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 8,
-    "code": 42,
-    "label": "back space"
+    ascii: 8,
+    code: 42,
+    label: 'back space',
   },
   {
-    "ascii": 9,
-    "code": 43,
-    "label": "tab"
+    ascii: 9,
+    code: 43,
+    label: 'tab',
   },
   {
-    "ascii": 10,
-    "code": 40,
-    "label": "enter"
+    ascii: 10,
+    code: 40,
+    label: 'enter',
   },
   {
-    "ascii": 11,
-    "code": 0,
-    "label": ""
+    ascii: 11,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 12,
-    "code": 0,
-    "label": ""
+    ascii: 12,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 13,
-    "code": 0,
-    "label": ""
+    ascii: 13,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 14,
-    "code": 0,
-    "label": ""
+    ascii: 14,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 15,
-    "code": 0,
-    "label": ""
+    ascii: 15,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 16,
-    "code": 0,
-    "label": ""
+    ascii: 16,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 17,
-    "code": 0,
-    "label": ""
+    ascii: 17,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 18,
-    "code": 0,
-    "label": ""
+    ascii: 18,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 19,
-    "code": 0,
-    "label": ""
+    ascii: 19,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 20,
-    "code": 0,
-    "label": ""
+    ascii: 20,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 21,
-    "code": 0,
-    "label": ""
+    ascii: 21,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 22,
-    "code": 0,
-    "label": ""
+    ascii: 22,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 23,
-    "code": 0,
-    "label": ""
+    ascii: 23,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 24,
-    "code": 0,
-    "label": ""
+    ascii: 24,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 25,
-    "code": 0,
-    "label": ""
+    ascii: 25,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 26,
-    "code": 0,
-    "label": ""
+    ascii: 26,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 27,
-    "code": 41,
-    "label": "esc"
+    ascii: 27,
+    code: 41,
+    label: 'esc',
   },
   {
-    "ascii": 28,
-    "code": 0,
-    "label": ""
+    ascii: 28,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 29,
-    "code": 0,
-    "label": ""
+    ascii: 29,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 30,
-    "code": 0,
-    "label": ""
+    ascii: 30,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 31,
-    "code": 0,
-    "label": ""
+    ascii: 31,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 32,
-    "code": 44,
-    "label": "space"
+    ascii: 32,
+    code: 44,
+    label: 'space',
   },
   {
-    "ascii": 33,
-    "code": 542,
-    "label": "!"
+    ascii: 33,
+    code: 542,
+    label: '!',
   },
   {
-    "ascii": 34,
-    "code": 543,
-    "label": "\""
+    ascii: 34,
+    code: 543,
+    label: '"',
   },
   {
-    "ascii": 35,
-    "code": 50,
-    "label": "#"
+    ascii: 35,
+    code: 50,
+    label: '#',
   },
   {
-    "ascii": 36,
-    "code": 545,
-    "label": "$"
+    ascii: 36,
+    code: 545,
+    label: '$',
   },
   {
-    "ascii": 37,
-    "code": 546,
-    "label": "%"
+    ascii: 37,
+    code: 546,
+    label: '%',
   },
   {
-    "ascii": 38,
-    "code": 547,
-    "label": "&"
+    ascii: 38,
+    code: 547,
+    label: '&',
   },
   {
-    "ascii": 39,
-    "code": 562,
-    "label": "'"
+    ascii: 39,
+    code: 562,
+    label: "'",
   },
   {
-    "ascii": 40,
-    "code": 549,
-    "label": "("
+    ascii: 40,
+    code: 549,
+    label: '(',
   },
   {
-    "ascii": 41,
-    "code": 550,
-    "label": ")"
+    ascii: 41,
+    code: 550,
+    label: ')',
   },
   {
-    "ascii": 42,
-    "code": 560,
-    "label": "*"
+    ascii: 42,
+    code: 560,
+    label: '*',
   },
   {
-    "ascii": 43,
-    "code": 48,
-    "label": "+"
+    ascii: 43,
+    code: 48,
+    label: '+',
   },
   {
-    "ascii": 44,
-    "code": 54,
-    "label": ","
+    ascii: 44,
+    code: 54,
+    label: ',',
   },
   {
-    "ascii": 45,
-    "code": 56,
-    "label": "-"
+    ascii: 45,
+    code: 56,
+    label: '-',
   },
   {
-    "ascii": 46,
-    "code": 55,
-    "label": "."
+    ascii: 46,
+    code: 55,
+    label: '.',
   },
   {
-    "ascii": 47,
-    "code": 548,
-    "label": "/"
+    ascii: 47,
+    code: 548,
+    label: '/',
   },
   {
-    "ascii": 48,
-    "code": 39,
-    "label": "0"
+    ascii: 48,
+    code: 39,
+    label: '0',
   },
   {
-    "ascii": 49,
-    "code": 30,
-    "label": "1"
+    ascii: 49,
+    code: 30,
+    label: '1',
   },
   {
-    "ascii": 50,
-    "code": 31,
-    "label": "2"
+    ascii: 50,
+    code: 31,
+    label: '2',
   },
   {
-    "ascii": 51,
-    "code": 32,
-    "label": "3"
+    ascii: 51,
+    code: 32,
+    label: '3',
   },
   {
-    "ascii": 52,
-    "code": 33,
-    "label": "4"
+    ascii: 52,
+    code: 33,
+    label: '4',
   },
   {
-    "ascii": 53,
-    "code": 34,
-    "label": "5"
+    ascii: 53,
+    code: 34,
+    label: '5',
   },
   {
-    "ascii": 54,
-    "code": 35,
-    "label": "6"
+    ascii: 54,
+    code: 35,
+    label: '6',
   },
   {
-    "ascii": 55,
-    "code": 36,
-    "label": "7"
+    ascii: 55,
+    code: 36,
+    label: '7',
   },
   {
-    "ascii": 56,
-    "code": 37,
-    "label": "8"
+    ascii: 56,
+    code: 37,
+    label: '8',
   },
   {
-    "ascii": 57,
-    "code": 38,
-    "label": "9"
+    ascii: 57,
+    code: 38,
+    label: '9',
   },
   {
-    "ascii": 58,
-    "code": 567,
-    "label": ":"
+    ascii: 58,
+    code: 567,
+    label: ':',
   },
   {
-    "ascii": 59,
-    "code": 566,
-    "label": ";"
+    ascii: 59,
+    code: 566,
+    label: ';',
   },
   {
-    "ascii": 60,
-    "code": 100,
-    "label": "<"
+    ascii: 60,
+    code: 100,
+    label: '<',
   },
   {
-    "ascii": 61,
-    "code": 551,
-    "label": "="
+    ascii: 61,
+    code: 551,
+    label: '=',
   },
   {
-    "ascii": 62,
-    "code": 612,
-    "label": ">"
+    ascii: 62,
+    code: 612,
+    label: '>',
   },
   {
-    "ascii": 63,
-    "code": 557,
-    "label": "?"
+    ascii: 63,
+    code: 557,
+    label: '?',
   },
   {
-    "ascii": 64,
-    "code": 20,
-    "label": "q"
+    ascii: 64,
+    code: 20,
+    label: 'q',
   },
   {
-    "ascii": 65,
-    "code": 516,
-    "label": "A"
+    ascii: 65,
+    code: 516,
+    label: 'A',
   },
   {
-    "ascii": 66,
-    "code": 517,
-    "label": "B"
+    ascii: 66,
+    code: 517,
+    label: 'B',
   },
   {
-    "ascii": 67,
-    "code": 518,
-    "label": "C"
+    ascii: 67,
+    code: 518,
+    label: 'C',
   },
   {
-    "ascii": 68,
-    "code": 519,
-    "label": "D"
+    ascii: 68,
+    code: 519,
+    label: 'D',
   },
   {
-    "ascii": 69,
-    "code": 520,
-    "label": "E"
+    ascii: 69,
+    code: 520,
+    label: 'E',
   },
   {
-    "ascii": 70,
-    "code": 521,
-    "label": "F"
+    ascii: 70,
+    code: 521,
+    label: 'F',
   },
   {
-    "ascii": 71,
-    "code": 522,
-    "label": "G"
+    ascii: 71,
+    code: 522,
+    label: 'G',
   },
   {
-    "ascii": 72,
-    "code": 523,
-    "label": "H"
+    ascii: 72,
+    code: 523,
+    label: 'H',
   },
   {
-    "ascii": 73,
-    "code": 524,
-    "label": "I"
+    ascii: 73,
+    code: 524,
+    label: 'I',
   },
   {
-    "ascii": 74,
-    "code": 525,
-    "label": "J"
+    ascii: 74,
+    code: 525,
+    label: 'J',
   },
   {
-    "ascii": 75,
-    "code": 526,
-    "label": "K"
+    ascii: 75,
+    code: 526,
+    label: 'K',
   },
   {
-    "ascii": 76,
-    "code": 527,
-    "label": "L"
+    ascii: 76,
+    code: 527,
+    label: 'L',
   },
   {
-    "ascii": 77,
-    "code": 528,
-    "label": "M"
+    ascii: 77,
+    code: 528,
+    label: 'M',
   },
   {
-    "ascii": 78,
-    "code": 529,
-    "label": "N"
+    ascii: 78,
+    code: 529,
+    label: 'N',
   },
   {
-    "ascii": 79,
-    "code": 530,
-    "label": "O"
+    ascii: 79,
+    code: 530,
+    label: 'O',
   },
   {
-    "ascii": 80,
-    "code": 531,
-    "label": "P"
+    ascii: 80,
+    code: 531,
+    label: 'P',
   },
   {
-    "ascii": 81,
-    "code": 532,
-    "label": "Q"
+    ascii: 81,
+    code: 532,
+    label: 'Q',
   },
   {
-    "ascii": 82,
-    "code": 533,
-    "label": "R"
+    ascii: 82,
+    code: 533,
+    label: 'R',
   },
   {
-    "ascii": 83,
-    "code": 534,
-    "label": "S"
+    ascii: 83,
+    code: 534,
+    label: 'S',
   },
   {
-    "ascii": 84,
-    "code": 535,
-    "label": "T"
+    ascii: 84,
+    code: 535,
+    label: 'T',
   },
   {
-    "ascii": 85,
-    "code": 536,
-    "label": "U"
+    ascii: 85,
+    code: 536,
+    label: 'U',
   },
   {
-    "ascii": 86,
-    "code": 537,
-    "label": "V"
+    ascii: 86,
+    code: 537,
+    label: 'V',
   },
   {
-    "ascii": 87,
-    "code": 538,
-    "label": "W"
+    ascii: 87,
+    code: 538,
+    label: 'W',
   },
   {
-    "ascii": 88,
-    "code": 539,
-    "label": "X"
+    ascii: 88,
+    code: 539,
+    label: 'X',
   },
   {
-    "ascii": 89,
-    "code": 541,
-    "label": "Y"
+    ascii: 89,
+    code: 541,
+    label: 'Y',
   },
   {
-    "ascii": 90,
-    "code": 540,
-    "label": "Z"
+    ascii: 90,
+    code: 540,
+    label: 'Z',
   },
   {
-    "ascii": 91,
-    "code": 37,
-    "label": "8"
+    ascii: 91,
+    code: 37,
+    label: '8',
   },
   {
-    "ascii": 92,
-    "code": 45,
-    "label": "ß"
+    ascii: 92,
+    code: 45,
+    label: 'ß',
   },
   {
-    "ascii": 93,
-    "code": 38,
-    "label": "9"
+    ascii: 93,
+    code: 38,
+    label: '9',
   },
   {
-    "ascii": 94,
-    "code": 53,
-    "label": "^ (dead)"
+    ascii: 94,
+    code: 53,
+    label: '^ (dead)',
   },
   {
-    "ascii": 95,
-    "code": 568,
-    "label": "_"
+    ascii: 95,
+    code: 568,
+    label: '_',
   },
   {
-    "ascii": 96,
-    "code": 558,
-    "label": "` (dead)"
+    ascii: 96,
+    code: 558,
+    label: '` (dead)',
   },
   {
-    "ascii": 97,
-    "code": 4,
-    "label": "a"
+    ascii: 97,
+    code: 4,
+    label: 'a',
   },
   {
-    "ascii": 98,
-    "code": 5,
-    "label": "b"
+    ascii: 98,
+    code: 5,
+    label: 'b',
   },
   {
-    "ascii": 99,
-    "code": 6,
-    "label": "c"
+    ascii: 99,
+    code: 6,
+    label: 'c',
   },
   {
-    "ascii": 100,
-    "code": 7,
-    "label": "d"
+    ascii: 100,
+    code: 7,
+    label: 'd',
   },
   {
-    "ascii": 101,
-    "code": 8,
-    "label": "e"
+    ascii: 101,
+    code: 8,
+    label: 'e',
   },
   {
-    "ascii": 102,
-    "code": 9,
-    "label": "f"
+    ascii: 102,
+    code: 9,
+    label: 'f',
   },
   {
-    "ascii": 103,
-    "code": 10,
-    "label": "g"
+    ascii: 103,
+    code: 10,
+    label: 'g',
   },
   {
-    "ascii": 104,
-    "code": 11,
-    "label": "h"
+    ascii: 104,
+    code: 11,
+    label: 'h',
   },
   {
-    "ascii": 105,
-    "code": 12,
-    "label": "i"
+    ascii: 105,
+    code: 12,
+    label: 'i',
   },
   {
-    "ascii": 106,
-    "code": 13,
-    "label": "j"
+    ascii: 106,
+    code: 13,
+    label: 'j',
   },
   {
-    "ascii": 107,
-    "code": 14,
-    "label": "k"
+    ascii: 107,
+    code: 14,
+    label: 'k',
   },
   {
-    "ascii": 108,
-    "code": 15,
-    "label": "l"
+    ascii: 108,
+    code: 15,
+    label: 'l',
   },
   {
-    "ascii": 109,
-    "code": 16,
-    "label": "m"
+    ascii: 109,
+    code: 16,
+    label: 'm',
   },
   {
-    "ascii": 110,
-    "code": 17,
-    "label": "n"
+    ascii: 110,
+    code: 17,
+    label: 'n',
   },
   {
-    "ascii": 111,
-    "code": 18,
-    "label": "o"
+    ascii: 111,
+    code: 18,
+    label: 'o',
   },
   {
-    "ascii": 112,
-    "code": 19,
-    "label": "p"
+    ascii: 112,
+    code: 19,
+    label: 'p',
   },
   {
-    "ascii": 113,
-    "code": 20,
-    "label": "q"
+    ascii: 113,
+    code: 20,
+    label: 'q',
   },
   {
-    "ascii": 114,
-    "code": 21,
-    "label": "r"
+    ascii: 114,
+    code: 21,
+    label: 'r',
   },
   {
-    "ascii": 115,
-    "code": 22,
-    "label": "s"
+    ascii: 115,
+    code: 22,
+    label: 's',
   },
   {
-    "ascii": 116,
-    "code": 23,
-    "label": "t"
+    ascii: 116,
+    code: 23,
+    label: 't',
   },
   {
-    "ascii": 117,
-    "code": 24,
-    "label": "u"
+    ascii: 117,
+    code: 24,
+    label: 'u',
   },
   {
-    "ascii": 118,
-    "code": 25,
-    "label": "v"
+    ascii: 118,
+    code: 25,
+    label: 'v',
   },
   {
-    "ascii": 119,
-    "code": 26,
-    "label": "w"
+    ascii: 119,
+    code: 26,
+    label: 'w',
   },
   {
-    "ascii": 120,
-    "code": 27,
-    "label": "x"
+    ascii: 120,
+    code: 27,
+    label: 'x',
   },
   {
-    "ascii": 121,
-    "code": 29,
-    "label": "y"
+    ascii: 121,
+    code: 29,
+    label: 'y',
   },
   {
-    "ascii": 122,
-    "code": 28,
-    "label": "z"
+    ascii: 122,
+    code: 28,
+    label: 'z',
   },
   {
-    "ascii": 123,
-    "code": 36,
-    "label": "7"
+    ascii: 123,
+    code: 36,
+    label: '7',
   },
   {
-    "ascii": 124,
-    "code": 100,
-    "label": "<"
+    ascii: 124,
+    code: 100,
+    label: '<',
   },
   {
-    "ascii": 125,
-    "code": 39,
-    "label": "0"
+    ascii: 125,
+    code: 39,
+    label: '0',
   },
   {
-    "ascii": 126,
-    "code": 48,
-    "label": "+"
+    ascii: 126,
+    code: 48,
+    label: '+',
   },
   {
-    "ascii": 127,
-    "code": 76,
-    "label": "del"
-  }
+    ascii: 127,
+    code: 76,
+    label: 'del',
+  },
 ];
-    

--- a/src/services/labellang/AsciiLabelGerman_ch.ts
+++ b/src/services/labellang/AsciiLabelGerman_ch.ts
@@ -1,645 +1,644 @@
 import { AsciiLabel } from './AsciiLabel';
-        
+
 export const AsciiLabelGerman_ch: AsciiLabel[] = [
   {
-    "ascii": 0,
-    "code": 0,
-    "label": ""
+    ascii: 0,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 1,
-    "code": 0,
-    "label": ""
+    ascii: 1,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 2,
-    "code": 0,
-    "label": ""
+    ascii: 2,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 3,
-    "code": 0,
-    "label": ""
+    ascii: 3,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 4,
-    "code": 0,
-    "label": ""
+    ascii: 4,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 5,
-    "code": 0,
-    "label": ""
+    ascii: 5,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 6,
-    "code": 0,
-    "label": ""
+    ascii: 6,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 7,
-    "code": 0,
-    "label": ""
+    ascii: 7,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 8,
-    "code": 42,
-    "label": "back space"
+    ascii: 8,
+    code: 42,
+    label: 'back space',
   },
   {
-    "ascii": 9,
-    "code": 43,
-    "label": "tab"
+    ascii: 9,
+    code: 43,
+    label: 'tab',
   },
   {
-    "ascii": 10,
-    "code": 40,
-    "label": "enter"
+    ascii: 10,
+    code: 40,
+    label: 'enter',
   },
   {
-    "ascii": 11,
-    "code": 0,
-    "label": ""
+    ascii: 11,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 12,
-    "code": 0,
-    "label": ""
+    ascii: 12,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 13,
-    "code": 0,
-    "label": ""
+    ascii: 13,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 14,
-    "code": 0,
-    "label": ""
+    ascii: 14,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 15,
-    "code": 0,
-    "label": ""
+    ascii: 15,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 16,
-    "code": 0,
-    "label": ""
+    ascii: 16,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 17,
-    "code": 0,
-    "label": ""
+    ascii: 17,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 18,
-    "code": 0,
-    "label": ""
+    ascii: 18,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 19,
-    "code": 0,
-    "label": ""
+    ascii: 19,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 20,
-    "code": 0,
-    "label": ""
+    ascii: 20,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 21,
-    "code": 0,
-    "label": ""
+    ascii: 21,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 22,
-    "code": 0,
-    "label": ""
+    ascii: 22,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 23,
-    "code": 0,
-    "label": ""
+    ascii: 23,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 24,
-    "code": 0,
-    "label": ""
+    ascii: 24,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 25,
-    "code": 0,
-    "label": ""
+    ascii: 25,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 26,
-    "code": 0,
-    "label": ""
+    ascii: 26,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 27,
-    "code": 41,
-    "label": "esc"
+    ascii: 27,
+    code: 41,
+    label: 'esc',
   },
   {
-    "ascii": 28,
-    "code": 0,
-    "label": ""
+    ascii: 28,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 29,
-    "code": 0,
-    "label": ""
+    ascii: 29,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 30,
-    "code": 0,
-    "label": ""
+    ascii: 30,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 31,
-    "code": 0,
-    "label": ""
+    ascii: 31,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 32,
-    "code": 44,
-    "label": "space"
+    ascii: 32,
+    code: 44,
+    label: 'space',
   },
   {
-    "ascii": 33,
-    "code": 560,
-    "label": "!"
+    ascii: 33,
+    code: 560,
+    label: '!',
   },
   {
-    "ascii": 34,
-    "code": 543,
-    "label": "\""
+    ascii: 34,
+    code: 543,
+    label: '"',
   },
   {
-    "ascii": 35,
-    "code": 32,
-    "label": "3"
+    ascii: 35,
+    code: 32,
+    label: '3',
   },
   {
-    "ascii": 36,
-    "code": 50,
-    "label": "$"
+    ascii: 36,
+    code: 50,
+    label: '$',
   },
   {
-    "ascii": 37,
-    "code": 546,
-    "label": "%"
+    ascii: 37,
+    code: 546,
+    label: '%',
   },
   {
-    "ascii": 38,
-    "code": 547,
-    "label": "&"
+    ascii: 38,
+    code: 547,
+    label: '&',
   },
   {
-    "ascii": 39,
-    "code": 45,
-    "label": "'"
+    ascii: 39,
+    code: 45,
+    label: "'",
   },
   {
-    "ascii": 40,
-    "code": 549,
-    "label": "("
+    ascii: 40,
+    code: 549,
+    label: '(',
   },
   {
-    "ascii": 41,
-    "code": 550,
-    "label": ")"
+    ascii: 41,
+    code: 550,
+    label: ')',
   },
   {
-    "ascii": 42,
-    "code": 544,
-    "label": "*"
+    ascii: 42,
+    code: 544,
+    label: '*',
   },
   {
-    "ascii": 43,
-    "code": 542,
-    "label": "+"
+    ascii: 43,
+    code: 542,
+    label: '+',
   },
   {
-    "ascii": 44,
-    "code": 54,
-    "label": ","
+    ascii: 44,
+    code: 54,
+    label: ',',
   },
   {
-    "ascii": 45,
-    "code": 56,
-    "label": "-"
+    ascii: 45,
+    code: 56,
+    label: '-',
   },
   {
-    "ascii": 46,
-    "code": 55,
-    "label": "."
+    ascii: 46,
+    code: 55,
+    label: '.',
   },
   {
-    "ascii": 47,
-    "code": 548,
-    "label": "/"
+    ascii: 47,
+    code: 548,
+    label: '/',
   },
   {
-    "ascii": 48,
-    "code": 39,
-    "label": "0"
+    ascii: 48,
+    code: 39,
+    label: '0',
   },
   {
-    "ascii": 49,
-    "code": 30,
-    "label": "1"
+    ascii: 49,
+    code: 30,
+    label: '1',
   },
   {
-    "ascii": 50,
-    "code": 31,
-    "label": "2"
+    ascii: 50,
+    code: 31,
+    label: '2',
   },
   {
-    "ascii": 51,
-    "code": 32,
-    "label": "3"
+    ascii: 51,
+    code: 32,
+    label: '3',
   },
   {
-    "ascii": 52,
-    "code": 33,
-    "label": "4"
+    ascii: 52,
+    code: 33,
+    label: '4',
   },
   {
-    "ascii": 53,
-    "code": 34,
-    "label": "5"
+    ascii: 53,
+    code: 34,
+    label: '5',
   },
   {
-    "ascii": 54,
-    "code": 35,
-    "label": "6"
+    ascii: 54,
+    code: 35,
+    label: '6',
   },
   {
-    "ascii": 55,
-    "code": 36,
-    "label": "7"
+    ascii: 55,
+    code: 36,
+    label: '7',
   },
   {
-    "ascii": 56,
-    "code": 37,
-    "label": "8"
+    ascii: 56,
+    code: 37,
+    label: '8',
   },
   {
-    "ascii": 57,
-    "code": 38,
-    "label": "9"
+    ascii: 57,
+    code: 38,
+    label: '9',
   },
   {
-    "ascii": 58,
-    "code": 567,
-    "label": ":"
+    ascii: 58,
+    code: 567,
+    label: ':',
   },
   {
-    "ascii": 59,
-    "code": 566,
-    "label": ";"
+    ascii: 59,
+    code: 566,
+    label: ';',
   },
   {
-    "ascii": 60,
-    "code": 100,
-    "label": "<"
+    ascii: 60,
+    code: 100,
+    label: '<',
   },
   {
-    "ascii": 61,
-    "code": 551,
-    "label": "="
+    ascii: 61,
+    code: 551,
+    label: '=',
   },
   {
-    "ascii": 62,
-    "code": 612,
-    "label": ">"
+    ascii: 62,
+    code: 612,
+    label: '>',
   },
   {
-    "ascii": 63,
-    "code": 557,
-    "label": "?"
+    ascii: 63,
+    code: 557,
+    label: '?',
   },
   {
-    "ascii": 64,
-    "code": 31,
-    "label": "2"
+    ascii: 64,
+    code: 31,
+    label: '2',
   },
   {
-    "ascii": 65,
-    "code": 516,
-    "label": "A"
+    ascii: 65,
+    code: 516,
+    label: 'A',
   },
   {
-    "ascii": 66,
-    "code": 517,
-    "label": "B"
+    ascii: 66,
+    code: 517,
+    label: 'B',
   },
   {
-    "ascii": 67,
-    "code": 518,
-    "label": "C"
+    ascii: 67,
+    code: 518,
+    label: 'C',
   },
   {
-    "ascii": 68,
-    "code": 519,
-    "label": "D"
+    ascii: 68,
+    code: 519,
+    label: 'D',
   },
   {
-    "ascii": 69,
-    "code": 520,
-    "label": "E"
+    ascii: 69,
+    code: 520,
+    label: 'E',
   },
   {
-    "ascii": 70,
-    "code": 521,
-    "label": "F"
+    ascii: 70,
+    code: 521,
+    label: 'F',
   },
   {
-    "ascii": 71,
-    "code": 522,
-    "label": "G"
+    ascii: 71,
+    code: 522,
+    label: 'G',
   },
   {
-    "ascii": 72,
-    "code": 523,
-    "label": "H"
+    ascii: 72,
+    code: 523,
+    label: 'H',
   },
   {
-    "ascii": 73,
-    "code": 524,
-    "label": "I"
+    ascii: 73,
+    code: 524,
+    label: 'I',
   },
   {
-    "ascii": 74,
-    "code": 525,
-    "label": "J"
+    ascii: 74,
+    code: 525,
+    label: 'J',
   },
   {
-    "ascii": 75,
-    "code": 526,
-    "label": "K"
+    ascii: 75,
+    code: 526,
+    label: 'K',
   },
   {
-    "ascii": 76,
-    "code": 527,
-    "label": "L"
+    ascii: 76,
+    code: 527,
+    label: 'L',
   },
   {
-    "ascii": 77,
-    "code": 528,
-    "label": "M"
+    ascii: 77,
+    code: 528,
+    label: 'M',
   },
   {
-    "ascii": 78,
-    "code": 529,
-    "label": "N"
+    ascii: 78,
+    code: 529,
+    label: 'N',
   },
   {
-    "ascii": 79,
-    "code": 530,
-    "label": "O"
+    ascii: 79,
+    code: 530,
+    label: 'O',
   },
   {
-    "ascii": 80,
-    "code": 531,
-    "label": "P"
+    ascii: 80,
+    code: 531,
+    label: 'P',
   },
   {
-    "ascii": 81,
-    "code": 532,
-    "label": "Q"
+    ascii: 81,
+    code: 532,
+    label: 'Q',
   },
   {
-    "ascii": 82,
-    "code": 533,
-    "label": "R"
+    ascii: 82,
+    code: 533,
+    label: 'R',
   },
   {
-    "ascii": 83,
-    "code": 534,
-    "label": "S"
+    ascii: 83,
+    code: 534,
+    label: 'S',
   },
   {
-    "ascii": 84,
-    "code": 535,
-    "label": "T"
+    ascii: 84,
+    code: 535,
+    label: 'T',
   },
   {
-    "ascii": 85,
-    "code": 536,
-    "label": "U"
+    ascii: 85,
+    code: 536,
+    label: 'U',
   },
   {
-    "ascii": 86,
-    "code": 537,
-    "label": "V"
+    ascii: 86,
+    code: 537,
+    label: 'V',
   },
   {
-    "ascii": 87,
-    "code": 538,
-    "label": "W"
+    ascii: 87,
+    code: 538,
+    label: 'W',
   },
   {
-    "ascii": 88,
-    "code": 539,
-    "label": "X"
+    ascii: 88,
+    code: 539,
+    label: 'X',
   },
   {
-    "ascii": 89,
-    "code": 541,
-    "label": "Y"
+    ascii: 89,
+    code: 541,
+    label: 'Y',
   },
   {
-    "ascii": 90,
-    "code": 540,
-    "label": "Z"
+    ascii: 90,
+    code: 540,
+    label: 'Z',
   },
   {
-    "ascii": 91,
-    "code": 47,
-    "label": "ü"
+    ascii: 91,
+    code: 47,
+    label: 'ü',
   },
   {
-    "ascii": 92,
-    "code": 100,
-    "label": "<"
+    ascii: 92,
+    code: 100,
+    label: '<',
   },
   {
-    "ascii": 93,
-    "code": 48,
-    "label": "¨ (dead)"
+    ascii: 93,
+    code: 48,
+    label: '¨ (dead)',
   },
   {
-    "ascii": 94,
-    "code": 46,
-    "label": "^ (dead)"
+    ascii: 94,
+    code: 46,
+    label: '^ (dead)',
   },
   {
-    "ascii": 95,
-    "code": 568,
-    "label": "_"
+    ascii: 95,
+    code: 568,
+    label: '_',
   },
   {
-    "ascii": 96,
-    "code": 558,
-    "label": "` (dead)"
+    ascii: 96,
+    code: 558,
+    label: '` (dead)',
   },
   {
-    "ascii": 97,
-    "code": 4,
-    "label": "a"
+    ascii: 97,
+    code: 4,
+    label: 'a',
   },
   {
-    "ascii": 98,
-    "code": 5,
-    "label": "b"
+    ascii: 98,
+    code: 5,
+    label: 'b',
   },
   {
-    "ascii": 99,
-    "code": 6,
-    "label": "c"
+    ascii: 99,
+    code: 6,
+    label: 'c',
   },
   {
-    "ascii": 100,
-    "code": 7,
-    "label": "d"
+    ascii: 100,
+    code: 7,
+    label: 'd',
   },
   {
-    "ascii": 101,
-    "code": 8,
-    "label": "e"
+    ascii: 101,
+    code: 8,
+    label: 'e',
   },
   {
-    "ascii": 102,
-    "code": 9,
-    "label": "f"
+    ascii: 102,
+    code: 9,
+    label: 'f',
   },
   {
-    "ascii": 103,
-    "code": 10,
-    "label": "g"
+    ascii: 103,
+    code: 10,
+    label: 'g',
   },
   {
-    "ascii": 104,
-    "code": 11,
-    "label": "h"
+    ascii: 104,
+    code: 11,
+    label: 'h',
   },
   {
-    "ascii": 105,
-    "code": 12,
-    "label": "i"
+    ascii: 105,
+    code: 12,
+    label: 'i',
   },
   {
-    "ascii": 106,
-    "code": 13,
-    "label": "j"
+    ascii: 106,
+    code: 13,
+    label: 'j',
   },
   {
-    "ascii": 107,
-    "code": 14,
-    "label": "k"
+    ascii: 107,
+    code: 14,
+    label: 'k',
   },
   {
-    "ascii": 108,
-    "code": 15,
-    "label": "l"
+    ascii: 108,
+    code: 15,
+    label: 'l',
   },
   {
-    "ascii": 109,
-    "code": 16,
-    "label": "m"
+    ascii: 109,
+    code: 16,
+    label: 'm',
   },
   {
-    "ascii": 110,
-    "code": 17,
-    "label": "n"
+    ascii: 110,
+    code: 17,
+    label: 'n',
   },
   {
-    "ascii": 111,
-    "code": 18,
-    "label": "o"
+    ascii: 111,
+    code: 18,
+    label: 'o',
   },
   {
-    "ascii": 112,
-    "code": 19,
-    "label": "p"
+    ascii: 112,
+    code: 19,
+    label: 'p',
   },
   {
-    "ascii": 113,
-    "code": 20,
-    "label": "q"
+    ascii: 113,
+    code: 20,
+    label: 'q',
   },
   {
-    "ascii": 114,
-    "code": 21,
-    "label": "r"
+    ascii: 114,
+    code: 21,
+    label: 'r',
   },
   {
-    "ascii": 115,
-    "code": 22,
-    "label": "s"
+    ascii: 115,
+    code: 22,
+    label: 's',
   },
   {
-    "ascii": 116,
-    "code": 23,
-    "label": "t"
+    ascii: 116,
+    code: 23,
+    label: 't',
   },
   {
-    "ascii": 117,
-    "code": 24,
-    "label": "u"
+    ascii: 117,
+    code: 24,
+    label: 'u',
   },
   {
-    "ascii": 118,
-    "code": 25,
-    "label": "v"
+    ascii: 118,
+    code: 25,
+    label: 'v',
   },
   {
-    "ascii": 119,
-    "code": 26,
-    "label": "w"
+    ascii: 119,
+    code: 26,
+    label: 'w',
   },
   {
-    "ascii": 120,
-    "code": 27,
-    "label": "x"
+    ascii: 120,
+    code: 27,
+    label: 'x',
   },
   {
-    "ascii": 121,
-    "code": 29,
-    "label": "y"
+    ascii: 121,
+    code: 29,
+    label: 'y',
   },
   {
-    "ascii": 122,
-    "code": 28,
-    "label": "z"
+    ascii: 122,
+    code: 28,
+    label: 'z',
   },
   {
-    "ascii": 123,
-    "code": 52,
-    "label": "ä"
+    ascii: 123,
+    code: 52,
+    label: 'ä',
   },
   {
-    "ascii": 124,
-    "code": 36,
-    "label": "7"
+    ascii: 124,
+    code: 36,
+    label: '7',
   },
   {
-    "ascii": 125,
-    "code": 50,
-    "label": "$"
+    ascii: 125,
+    code: 50,
+    label: '$',
   },
   {
-    "ascii": 126,
-    "code": 46,
-    "label": "^ (dead)"
+    ascii: 126,
+    code: 46,
+    label: '^ (dead)',
   },
   {
-    "ascii": 127,
-    "code": 76,
-    "label": "del"
-  }
+    ascii: 127,
+    code: 76,
+    label: 'del',
+  },
 ];
-    

--- a/src/services/labellang/AsciiLabelGerman_osx.ts
+++ b/src/services/labellang/AsciiLabelGerman_osx.ts
@@ -1,645 +1,644 @@
 import { AsciiLabel } from './AsciiLabel';
-        
+
 export const AsciiLabelGerman_osx: AsciiLabel[] = [
   {
-    "ascii": 0,
-    "code": 0,
-    "label": ""
+    ascii: 0,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 1,
-    "code": 0,
-    "label": ""
+    ascii: 1,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 2,
-    "code": 0,
-    "label": ""
+    ascii: 2,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 3,
-    "code": 0,
-    "label": ""
+    ascii: 3,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 4,
-    "code": 0,
-    "label": ""
+    ascii: 4,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 5,
-    "code": 0,
-    "label": ""
+    ascii: 5,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 6,
-    "code": 0,
-    "label": ""
+    ascii: 6,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 7,
-    "code": 0,
-    "label": ""
+    ascii: 7,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 8,
-    "code": 42,
-    "label": "back space"
+    ascii: 8,
+    code: 42,
+    label: 'back space',
   },
   {
-    "ascii": 9,
-    "code": 43,
-    "label": "tab"
+    ascii: 9,
+    code: 43,
+    label: 'tab',
   },
   {
-    "ascii": 10,
-    "code": 40,
-    "label": "enter"
+    ascii: 10,
+    code: 40,
+    label: 'enter',
   },
   {
-    "ascii": 11,
-    "code": 0,
-    "label": ""
+    ascii: 11,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 12,
-    "code": 0,
-    "label": ""
+    ascii: 12,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 13,
-    "code": 0,
-    "label": ""
+    ascii: 13,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 14,
-    "code": 0,
-    "label": ""
+    ascii: 14,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 15,
-    "code": 0,
-    "label": ""
+    ascii: 15,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 16,
-    "code": 0,
-    "label": ""
+    ascii: 16,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 17,
-    "code": 0,
-    "label": ""
+    ascii: 17,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 18,
-    "code": 0,
-    "label": ""
+    ascii: 18,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 19,
-    "code": 0,
-    "label": ""
+    ascii: 19,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 20,
-    "code": 0,
-    "label": ""
+    ascii: 20,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 21,
-    "code": 0,
-    "label": ""
+    ascii: 21,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 22,
-    "code": 0,
-    "label": ""
+    ascii: 22,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 23,
-    "code": 0,
-    "label": ""
+    ascii: 23,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 24,
-    "code": 0,
-    "label": ""
+    ascii: 24,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 25,
-    "code": 0,
-    "label": ""
+    ascii: 25,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 26,
-    "code": 0,
-    "label": ""
+    ascii: 26,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 27,
-    "code": 41,
-    "label": "esc"
+    ascii: 27,
+    code: 41,
+    label: 'esc',
   },
   {
-    "ascii": 28,
-    "code": 0,
-    "label": ""
+    ascii: 28,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 29,
-    "code": 0,
-    "label": ""
+    ascii: 29,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 30,
-    "code": 0,
-    "label": ""
+    ascii: 30,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 31,
-    "code": 0,
-    "label": ""
+    ascii: 31,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 32,
-    "code": 44,
-    "label": "space"
+    ascii: 32,
+    code: 44,
+    label: 'space',
   },
   {
-    "ascii": 33,
-    "code": 542,
-    "label": "!"
+    ascii: 33,
+    code: 542,
+    label: '!',
   },
   {
-    "ascii": 34,
-    "code": 543,
-    "label": "\""
+    ascii: 34,
+    code: 543,
+    label: '"',
   },
   {
-    "ascii": 35,
-    "code": 50,
-    "label": "#"
+    ascii: 35,
+    code: 50,
+    label: '#',
   },
   {
-    "ascii": 36,
-    "code": 545,
-    "label": "$"
+    ascii: 36,
+    code: 545,
+    label: '$',
   },
   {
-    "ascii": 37,
-    "code": 546,
-    "label": "%"
+    ascii: 37,
+    code: 546,
+    label: '%',
   },
   {
-    "ascii": 38,
-    "code": 547,
-    "label": "&"
+    ascii: 38,
+    code: 547,
+    label: '&',
   },
   {
-    "ascii": 39,
-    "code": 562,
-    "label": "'"
+    ascii: 39,
+    code: 562,
+    label: "'",
   },
   {
-    "ascii": 40,
-    "code": 549,
-    "label": "("
+    ascii: 40,
+    code: 549,
+    label: '(',
   },
   {
-    "ascii": 41,
-    "code": 550,
-    "label": ")"
+    ascii: 41,
+    code: 550,
+    label: ')',
   },
   {
-    "ascii": 42,
-    "code": 560,
-    "label": "*"
+    ascii: 42,
+    code: 560,
+    label: '*',
   },
   {
-    "ascii": 43,
-    "code": 48,
-    "label": "+"
+    ascii: 43,
+    code: 48,
+    label: '+',
   },
   {
-    "ascii": 44,
-    "code": 54,
-    "label": ","
+    ascii: 44,
+    code: 54,
+    label: ',',
   },
   {
-    "ascii": 45,
-    "code": 56,
-    "label": "-"
+    ascii: 45,
+    code: 56,
+    label: '-',
   },
   {
-    "ascii": 46,
-    "code": 55,
-    "label": "."
+    ascii: 46,
+    code: 55,
+    label: '.',
   },
   {
-    "ascii": 47,
-    "code": 548,
-    "label": "/"
+    ascii: 47,
+    code: 548,
+    label: '/',
   },
   {
-    "ascii": 48,
-    "code": 39,
-    "label": "0"
+    ascii: 48,
+    code: 39,
+    label: '0',
   },
   {
-    "ascii": 49,
-    "code": 30,
-    "label": "1"
+    ascii: 49,
+    code: 30,
+    label: '1',
   },
   {
-    "ascii": 50,
-    "code": 31,
-    "label": "2"
+    ascii: 50,
+    code: 31,
+    label: '2',
   },
   {
-    "ascii": 51,
-    "code": 32,
-    "label": "3"
+    ascii: 51,
+    code: 32,
+    label: '3',
   },
   {
-    "ascii": 52,
-    "code": 33,
-    "label": "4"
+    ascii: 52,
+    code: 33,
+    label: '4',
   },
   {
-    "ascii": 53,
-    "code": 34,
-    "label": "5"
+    ascii: 53,
+    code: 34,
+    label: '5',
   },
   {
-    "ascii": 54,
-    "code": 35,
-    "label": "6"
+    ascii: 54,
+    code: 35,
+    label: '6',
   },
   {
-    "ascii": 55,
-    "code": 36,
-    "label": "7"
+    ascii: 55,
+    code: 36,
+    label: '7',
   },
   {
-    "ascii": 56,
-    "code": 37,
-    "label": "8"
+    ascii: 56,
+    code: 37,
+    label: '8',
   },
   {
-    "ascii": 57,
-    "code": 38,
-    "label": "9"
+    ascii: 57,
+    code: 38,
+    label: '9',
   },
   {
-    "ascii": 58,
-    "code": 567,
-    "label": ":"
+    ascii: 58,
+    code: 567,
+    label: ':',
   },
   {
-    "ascii": 59,
-    "code": 566,
-    "label": ";"
+    ascii: 59,
+    code: 566,
+    label: ';',
   },
   {
-    "ascii": 60,
-    "code": 100,
-    "label": "<"
+    ascii: 60,
+    code: 100,
+    label: '<',
   },
   {
-    "ascii": 61,
-    "code": 551,
-    "label": "="
+    ascii: 61,
+    code: 551,
+    label: '=',
   },
   {
-    "ascii": 62,
-    "code": 612,
-    "label": ">"
+    ascii: 62,
+    code: 612,
+    label: '>',
   },
   {
-    "ascii": 63,
-    "code": 557,
-    "label": "?"
+    ascii: 63,
+    code: 557,
+    label: '?',
   },
   {
-    "ascii": 64,
-    "code": 15,
-    "label": "l"
+    ascii: 64,
+    code: 15,
+    label: 'l',
   },
   {
-    "ascii": 65,
-    "code": 516,
-    "label": "A"
+    ascii: 65,
+    code: 516,
+    label: 'A',
   },
   {
-    "ascii": 66,
-    "code": 517,
-    "label": "B"
+    ascii: 66,
+    code: 517,
+    label: 'B',
   },
   {
-    "ascii": 67,
-    "code": 518,
-    "label": "C"
+    ascii: 67,
+    code: 518,
+    label: 'C',
   },
   {
-    "ascii": 68,
-    "code": 519,
-    "label": "D"
+    ascii: 68,
+    code: 519,
+    label: 'D',
   },
   {
-    "ascii": 69,
-    "code": 520,
-    "label": "E"
+    ascii: 69,
+    code: 520,
+    label: 'E',
   },
   {
-    "ascii": 70,
-    "code": 521,
-    "label": "F"
+    ascii: 70,
+    code: 521,
+    label: 'F',
   },
   {
-    "ascii": 71,
-    "code": 522,
-    "label": "G"
+    ascii: 71,
+    code: 522,
+    label: 'G',
   },
   {
-    "ascii": 72,
-    "code": 523,
-    "label": "H"
+    ascii: 72,
+    code: 523,
+    label: 'H',
   },
   {
-    "ascii": 73,
-    "code": 524,
-    "label": "I"
+    ascii: 73,
+    code: 524,
+    label: 'I',
   },
   {
-    "ascii": 74,
-    "code": 525,
-    "label": "J"
+    ascii: 74,
+    code: 525,
+    label: 'J',
   },
   {
-    "ascii": 75,
-    "code": 526,
-    "label": "K"
+    ascii: 75,
+    code: 526,
+    label: 'K',
   },
   {
-    "ascii": 76,
-    "code": 527,
-    "label": "L"
+    ascii: 76,
+    code: 527,
+    label: 'L',
   },
   {
-    "ascii": 77,
-    "code": 528,
-    "label": "M"
+    ascii: 77,
+    code: 528,
+    label: 'M',
   },
   {
-    "ascii": 78,
-    "code": 529,
-    "label": "N"
+    ascii: 78,
+    code: 529,
+    label: 'N',
   },
   {
-    "ascii": 79,
-    "code": 530,
-    "label": "O"
+    ascii: 79,
+    code: 530,
+    label: 'O',
   },
   {
-    "ascii": 80,
-    "code": 531,
-    "label": "P"
+    ascii: 80,
+    code: 531,
+    label: 'P',
   },
   {
-    "ascii": 81,
-    "code": 532,
-    "label": "Q"
+    ascii: 81,
+    code: 532,
+    label: 'Q',
   },
   {
-    "ascii": 82,
-    "code": 533,
-    "label": "R"
+    ascii: 82,
+    code: 533,
+    label: 'R',
   },
   {
-    "ascii": 83,
-    "code": 534,
-    "label": "S"
+    ascii: 83,
+    code: 534,
+    label: 'S',
   },
   {
-    "ascii": 84,
-    "code": 535,
-    "label": "T"
+    ascii: 84,
+    code: 535,
+    label: 'T',
   },
   {
-    "ascii": 85,
-    "code": 536,
-    "label": "U"
+    ascii: 85,
+    code: 536,
+    label: 'U',
   },
   {
-    "ascii": 86,
-    "code": 537,
-    "label": "V"
+    ascii: 86,
+    code: 537,
+    label: 'V',
   },
   {
-    "ascii": 87,
-    "code": 538,
-    "label": "W"
+    ascii: 87,
+    code: 538,
+    label: 'W',
   },
   {
-    "ascii": 88,
-    "code": 539,
-    "label": "X"
+    ascii: 88,
+    code: 539,
+    label: 'X',
   },
   {
-    "ascii": 89,
-    "code": 541,
-    "label": "Y"
+    ascii: 89,
+    code: 541,
+    label: 'Y',
   },
   {
-    "ascii": 90,
-    "code": 540,
-    "label": "Z"
+    ascii: 90,
+    code: 540,
+    label: 'Z',
   },
   {
-    "ascii": 91,
-    "code": 34,
-    "label": "5"
+    ascii: 91,
+    code: 34,
+    label: '5',
   },
   {
-    "ascii": 92,
-    "code": 548,
-    "label": "/"
+    ascii: 92,
+    code: 548,
+    label: '/',
   },
   {
-    "ascii": 93,
-    "code": 35,
-    "label": "6"
+    ascii: 93,
+    code: 35,
+    label: '6',
   },
   {
-    "ascii": 94,
-    "code": 53,
-    "label": "^ (dead)"
+    ascii: 94,
+    code: 53,
+    label: '^ (dead)',
   },
   {
-    "ascii": 95,
-    "code": 568,
-    "label": "_"
+    ascii: 95,
+    code: 568,
+    label: '_',
   },
   {
-    "ascii": 96,
-    "code": 558,
-    "label": "` (dead)"
+    ascii: 96,
+    code: 558,
+    label: '` (dead)',
   },
   {
-    "ascii": 97,
-    "code": 4,
-    "label": "a"
+    ascii: 97,
+    code: 4,
+    label: 'a',
   },
   {
-    "ascii": 98,
-    "code": 5,
-    "label": "b"
+    ascii: 98,
+    code: 5,
+    label: 'b',
   },
   {
-    "ascii": 99,
-    "code": 6,
-    "label": "c"
+    ascii: 99,
+    code: 6,
+    label: 'c',
   },
   {
-    "ascii": 100,
-    "code": 7,
-    "label": "d"
+    ascii: 100,
+    code: 7,
+    label: 'd',
   },
   {
-    "ascii": 101,
-    "code": 8,
-    "label": "e"
+    ascii: 101,
+    code: 8,
+    label: 'e',
   },
   {
-    "ascii": 102,
-    "code": 9,
-    "label": "f"
+    ascii: 102,
+    code: 9,
+    label: 'f',
   },
   {
-    "ascii": 103,
-    "code": 10,
-    "label": "g"
+    ascii: 103,
+    code: 10,
+    label: 'g',
   },
   {
-    "ascii": 104,
-    "code": 11,
-    "label": "h"
+    ascii: 104,
+    code: 11,
+    label: 'h',
   },
   {
-    "ascii": 105,
-    "code": 12,
-    "label": "i"
+    ascii: 105,
+    code: 12,
+    label: 'i',
   },
   {
-    "ascii": 106,
-    "code": 13,
-    "label": "j"
+    ascii: 106,
+    code: 13,
+    label: 'j',
   },
   {
-    "ascii": 107,
-    "code": 14,
-    "label": "k"
+    ascii: 107,
+    code: 14,
+    label: 'k',
   },
   {
-    "ascii": 108,
-    "code": 15,
-    "label": "l"
+    ascii: 108,
+    code: 15,
+    label: 'l',
   },
   {
-    "ascii": 109,
-    "code": 16,
-    "label": "m"
+    ascii: 109,
+    code: 16,
+    label: 'm',
   },
   {
-    "ascii": 110,
-    "code": 17,
-    "label": "n"
+    ascii: 110,
+    code: 17,
+    label: 'n',
   },
   {
-    "ascii": 111,
-    "code": 18,
-    "label": "o"
+    ascii: 111,
+    code: 18,
+    label: 'o',
   },
   {
-    "ascii": 112,
-    "code": 19,
-    "label": "p"
+    ascii: 112,
+    code: 19,
+    label: 'p',
   },
   {
-    "ascii": 113,
-    "code": 20,
-    "label": "q"
+    ascii: 113,
+    code: 20,
+    label: 'q',
   },
   {
-    "ascii": 114,
-    "code": 21,
-    "label": "r"
+    ascii: 114,
+    code: 21,
+    label: 'r',
   },
   {
-    "ascii": 115,
-    "code": 22,
-    "label": "s"
+    ascii: 115,
+    code: 22,
+    label: 's',
   },
   {
-    "ascii": 116,
-    "code": 23,
-    "label": "t"
+    ascii: 116,
+    code: 23,
+    label: 't',
   },
   {
-    "ascii": 117,
-    "code": 24,
-    "label": "u"
+    ascii: 117,
+    code: 24,
+    label: 'u',
   },
   {
-    "ascii": 118,
-    "code": 25,
-    "label": "v"
+    ascii: 118,
+    code: 25,
+    label: 'v',
   },
   {
-    "ascii": 119,
-    "code": 26,
-    "label": "w"
+    ascii: 119,
+    code: 26,
+    label: 'w',
   },
   {
-    "ascii": 120,
-    "code": 27,
-    "label": "x"
+    ascii: 120,
+    code: 27,
+    label: 'x',
   },
   {
-    "ascii": 121,
-    "code": 29,
-    "label": "y"
+    ascii: 121,
+    code: 29,
+    label: 'y',
   },
   {
-    "ascii": 122,
-    "code": 28,
-    "label": "z"
+    ascii: 122,
+    code: 28,
+    label: 'z',
   },
   {
-    "ascii": 123,
-    "code": 37,
-    "label": "8"
+    ascii: 123,
+    code: 37,
+    label: '8',
   },
   {
-    "ascii": 124,
-    "code": 36,
-    "label": "7"
+    ascii: 124,
+    code: 36,
+    label: '7',
   },
   {
-    "ascii": 125,
-    "code": 38,
-    "label": "9"
+    ascii: 125,
+    code: 38,
+    label: '9',
   },
   {
-    "ascii": 126,
-    "code": 17,
-    "label": "n"
+    ascii: 126,
+    code: 17,
+    label: 'n',
   },
   {
-    "ascii": 127,
-    "code": 76,
-    "label": "del"
-  }
+    ascii: 127,
+    code: 76,
+    label: 'del',
+  },
 ];
-    

--- a/src/services/labellang/AsciiLabelHungarian.ts
+++ b/src/services/labellang/AsciiLabelHungarian.ts
@@ -1,645 +1,644 @@
 import { AsciiLabel } from './AsciiLabel';
-        
+
 export const AsciiLabelHungarian: AsciiLabel[] = [
   {
-    "ascii": 0,
-    "code": 0,
-    "label": ""
+    ascii: 0,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 1,
-    "code": 0,
-    "label": ""
+    ascii: 1,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 2,
-    "code": 0,
-    "label": ""
+    ascii: 2,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 3,
-    "code": 0,
-    "label": ""
+    ascii: 3,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 4,
-    "code": 0,
-    "label": ""
+    ascii: 4,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 5,
-    "code": 0,
-    "label": ""
+    ascii: 5,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 6,
-    "code": 0,
-    "label": ""
+    ascii: 6,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 7,
-    "code": 0,
-    "label": ""
+    ascii: 7,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 8,
-    "code": 42,
-    "label": "back space"
+    ascii: 8,
+    code: 42,
+    label: 'back space',
   },
   {
-    "ascii": 9,
-    "code": 43,
-    "label": "tab"
+    ascii: 9,
+    code: 43,
+    label: 'tab',
   },
   {
-    "ascii": 10,
-    "code": 40,
-    "label": "enter"
+    ascii: 10,
+    code: 40,
+    label: 'enter',
   },
   {
-    "ascii": 11,
-    "code": 0,
-    "label": ""
+    ascii: 11,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 12,
-    "code": 0,
-    "label": ""
+    ascii: 12,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 13,
-    "code": 0,
-    "label": ""
+    ascii: 13,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 14,
-    "code": 0,
-    "label": ""
+    ascii: 14,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 15,
-    "code": 0,
-    "label": ""
+    ascii: 15,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 16,
-    "code": 0,
-    "label": ""
+    ascii: 16,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 17,
-    "code": 0,
-    "label": ""
+    ascii: 17,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 18,
-    "code": 0,
-    "label": ""
+    ascii: 18,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 19,
-    "code": 0,
-    "label": ""
+    ascii: 19,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 20,
-    "code": 0,
-    "label": ""
+    ascii: 20,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 21,
-    "code": 0,
-    "label": ""
+    ascii: 21,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 22,
-    "code": 0,
-    "label": ""
+    ascii: 22,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 23,
-    "code": 0,
-    "label": ""
+    ascii: 23,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 24,
-    "code": 0,
-    "label": ""
+    ascii: 24,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 25,
-    "code": 0,
-    "label": ""
+    ascii: 25,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 26,
-    "code": 0,
-    "label": ""
+    ascii: 26,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 27,
-    "code": 41,
-    "label": "esc"
+    ascii: 27,
+    code: 41,
+    label: 'esc',
   },
   {
-    "ascii": 28,
-    "code": 0,
-    "label": ""
+    ascii: 28,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 29,
-    "code": 0,
-    "label": ""
+    ascii: 29,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 30,
-    "code": 0,
-    "label": ""
+    ascii: 30,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 31,
-    "code": 0,
-    "label": ""
+    ascii: 31,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 32,
-    "code": 44,
-    "label": "space"
+    ascii: 32,
+    code: 44,
+    label: 'space',
   },
   {
-    "ascii": 33,
-    "code": 545,
-    "label": "!"
+    ascii: 33,
+    code: 545,
+    label: '!',
   },
   {
-    "ascii": 34,
-    "code": 543,
-    "label": "\""
+    ascii: 34,
+    code: 543,
+    label: '"',
   },
   {
-    "ascii": 35,
-    "code": 27,
-    "label": "x"
+    ascii: 35,
+    code: 27,
+    label: 'x',
   },
   {
-    "ascii": 36,
-    "code": 51,
-    "label": "É"
+    ascii: 36,
+    code: 51,
+    label: 'É',
   },
   {
-    "ascii": 37,
-    "code": 546,
-    "label": "%"
+    ascii: 37,
+    code: 546,
+    label: '%',
   },
   {
-    "ascii": 38,
-    "code": 6,
-    "label": "c"
+    ascii: 38,
+    code: 6,
+    label: 'c',
   },
   {
-    "ascii": 39,
-    "code": 542,
-    "label": "'"
+    ascii: 39,
+    code: 542,
+    label: "'",
   },
   {
-    "ascii": 40,
-    "code": 549,
-    "label": "("
+    ascii: 40,
+    code: 549,
+    label: '(',
   },
   {
-    "ascii": 41,
-    "code": 550,
-    "label": ")"
+    ascii: 41,
+    code: 550,
+    label: ')',
   },
   {
-    "ascii": 42,
-    "code": 56,
-    "label": "-"
+    ascii: 42,
+    code: 56,
+    label: '-',
   },
   {
-    "ascii": 43,
-    "code": 544,
-    "label": "+"
+    ascii: 43,
+    code: 544,
+    label: '+',
   },
   {
-    "ascii": 44,
-    "code": 54,
-    "label": ","
+    ascii: 44,
+    code: 54,
+    label: ',',
   },
   {
-    "ascii": 45,
-    "code": 56,
-    "label": "-"
+    ascii: 45,
+    code: 56,
+    label: '-',
   },
   {
-    "ascii": 46,
-    "code": 55,
-    "label": "."
+    ascii: 46,
+    code: 55,
+    label: '.',
   },
   {
-    "ascii": 47,
-    "code": 547,
-    "label": "/"
+    ascii: 47,
+    code: 547,
+    label: '/',
   },
   {
-    "ascii": 48,
-    "code": 53,
-    "label": "0"
+    ascii: 48,
+    code: 53,
+    label: '0',
   },
   {
-    "ascii": 49,
-    "code": 30,
-    "label": "1"
+    ascii: 49,
+    code: 30,
+    label: '1',
   },
   {
-    "ascii": 50,
-    "code": 31,
-    "label": "2"
+    ascii: 50,
+    code: 31,
+    label: '2',
   },
   {
-    "ascii": 51,
-    "code": 32,
-    "label": "3"
+    ascii: 51,
+    code: 32,
+    label: '3',
   },
   {
-    "ascii": 52,
-    "code": 33,
-    "label": "4"
+    ascii: 52,
+    code: 33,
+    label: '4',
   },
   {
-    "ascii": 53,
-    "code": 34,
-    "label": "5"
+    ascii: 53,
+    code: 34,
+    label: '5',
   },
   {
-    "ascii": 54,
-    "code": 35,
-    "label": "6"
+    ascii: 54,
+    code: 35,
+    label: '6',
   },
   {
-    "ascii": 55,
-    "code": 36,
-    "label": "7"
+    ascii: 55,
+    code: 36,
+    label: '7',
   },
   {
-    "ascii": 56,
-    "code": 37,
-    "label": "8"
+    ascii: 56,
+    code: 37,
+    label: '8',
   },
   {
-    "ascii": 57,
-    "code": 38,
-    "label": "9"
+    ascii: 57,
+    code: 38,
+    label: '9',
   },
   {
-    "ascii": 58,
-    "code": 567,
-    "label": ":"
+    ascii: 58,
+    code: 567,
+    label: ':',
   },
   {
-    "ascii": 59,
-    "code": 54,
-    "label": ","
+    ascii: 59,
+    code: 54,
+    label: ',',
   },
   {
-    "ascii": 60,
-    "code": 16,
-    "label": "m"
+    ascii: 60,
+    code: 16,
+    label: 'm',
   },
   {
-    "ascii": 61,
-    "code": 548,
-    "label": "="
+    ascii: 61,
+    code: 548,
+    label: '=',
   },
   {
-    "ascii": 62,
-    "code": 55,
-    "label": "."
+    ascii: 62,
+    code: 55,
+    label: '.',
   },
   {
-    "ascii": 63,
-    "code": 566,
-    "label": "?"
+    ascii: 63,
+    code: 566,
+    label: '?',
   },
   {
-    "ascii": 64,
-    "code": 25,
-    "label": "v"
+    ascii: 64,
+    code: 25,
+    label: 'v',
   },
   {
-    "ascii": 65,
-    "code": 516,
-    "label": "A"
+    ascii: 65,
+    code: 516,
+    label: 'A',
   },
   {
-    "ascii": 66,
-    "code": 517,
-    "label": "B"
+    ascii: 66,
+    code: 517,
+    label: 'B',
   },
   {
-    "ascii": 67,
-    "code": 518,
-    "label": "C"
+    ascii: 67,
+    code: 518,
+    label: 'C',
   },
   {
-    "ascii": 68,
-    "code": 519,
-    "label": "D"
+    ascii: 68,
+    code: 519,
+    label: 'D',
   },
   {
-    "ascii": 69,
-    "code": 520,
-    "label": "E"
+    ascii: 69,
+    code: 520,
+    label: 'E',
   },
   {
-    "ascii": 70,
-    "code": 521,
-    "label": "F"
+    ascii: 70,
+    code: 521,
+    label: 'F',
   },
   {
-    "ascii": 71,
-    "code": 522,
-    "label": "G"
+    ascii: 71,
+    code: 522,
+    label: 'G',
   },
   {
-    "ascii": 72,
-    "code": 523,
-    "label": "H"
+    ascii: 72,
+    code: 523,
+    label: 'H',
   },
   {
-    "ascii": 73,
-    "code": 524,
-    "label": "I"
+    ascii: 73,
+    code: 524,
+    label: 'I',
   },
   {
-    "ascii": 74,
-    "code": 525,
-    "label": "J"
+    ascii: 74,
+    code: 525,
+    label: 'J',
   },
   {
-    "ascii": 75,
-    "code": 526,
-    "label": "K"
+    ascii: 75,
+    code: 526,
+    label: 'K',
   },
   {
-    "ascii": 76,
-    "code": 527,
-    "label": "L"
+    ascii: 76,
+    code: 527,
+    label: 'L',
   },
   {
-    "ascii": 77,
-    "code": 528,
-    "label": "M"
+    ascii: 77,
+    code: 528,
+    label: 'M',
   },
   {
-    "ascii": 78,
-    "code": 529,
-    "label": "N"
+    ascii: 78,
+    code: 529,
+    label: 'N',
   },
   {
-    "ascii": 79,
-    "code": 530,
-    "label": "O"
+    ascii: 79,
+    code: 530,
+    label: 'O',
   },
   {
-    "ascii": 80,
-    "code": 531,
-    "label": "P"
+    ascii: 80,
+    code: 531,
+    label: 'P',
   },
   {
-    "ascii": 81,
-    "code": 532,
-    "label": "Q"
+    ascii: 81,
+    code: 532,
+    label: 'Q',
   },
   {
-    "ascii": 82,
-    "code": 533,
-    "label": "R"
+    ascii: 82,
+    code: 533,
+    label: 'R',
   },
   {
-    "ascii": 83,
-    "code": 534,
-    "label": "S"
+    ascii: 83,
+    code: 534,
+    label: 'S',
   },
   {
-    "ascii": 84,
-    "code": 535,
-    "label": "T"
+    ascii: 84,
+    code: 535,
+    label: 'T',
   },
   {
-    "ascii": 85,
-    "code": 536,
-    "label": "U"
+    ascii: 85,
+    code: 536,
+    label: 'U',
   },
   {
-    "ascii": 86,
-    "code": 537,
-    "label": "V"
+    ascii: 86,
+    code: 537,
+    label: 'V',
   },
   {
-    "ascii": 87,
-    "code": 538,
-    "label": "W"
+    ascii: 87,
+    code: 538,
+    label: 'W',
   },
   {
-    "ascii": 88,
-    "code": 539,
-    "label": "X"
+    ascii: 88,
+    code: 539,
+    label: 'X',
   },
   {
-    "ascii": 89,
-    "code": 541,
-    "label": "Y"
+    ascii: 89,
+    code: 541,
+    label: 'Y',
   },
   {
-    "ascii": 90,
-    "code": 540,
-    "label": "Z"
+    ascii: 90,
+    code: 540,
+    label: 'Z',
   },
   {
-    "ascii": 91,
-    "code": 9,
-    "label": "f"
+    ascii: 91,
+    code: 9,
+    label: 'f',
   },
   {
-    "ascii": 92,
-    "code": 20,
-    "label": "q"
+    ascii: 92,
+    code: 20,
+    label: 'q',
   },
   {
-    "ascii": 93,
-    "code": 10,
-    "label": "g"
+    ascii: 93,
+    code: 10,
+    label: 'g',
   },
   {
-    "ascii": 94,
-    "code": 32,
-    "label": "3"
+    ascii: 94,
+    code: 32,
+    label: '3',
   },
   {
-    "ascii": 95,
-    "code": 568,
-    "label": "_"
+    ascii: 95,
+    code: 568,
+    label: '_',
   },
   {
-    "ascii": 96,
-    "code": 36,
-    "label": "7"
+    ascii: 96,
+    code: 36,
+    label: '7',
   },
   {
-    "ascii": 97,
-    "code": 4,
-    "label": "a"
+    ascii: 97,
+    code: 4,
+    label: 'a',
   },
   {
-    "ascii": 98,
-    "code": 5,
-    "label": "b"
+    ascii: 98,
+    code: 5,
+    label: 'b',
   },
   {
-    "ascii": 99,
-    "code": 6,
-    "label": "c"
+    ascii: 99,
+    code: 6,
+    label: 'c',
   },
   {
-    "ascii": 100,
-    "code": 7,
-    "label": "d"
+    ascii: 100,
+    code: 7,
+    label: 'd',
   },
   {
-    "ascii": 101,
-    "code": 8,
-    "label": "e"
+    ascii: 101,
+    code: 8,
+    label: 'e',
   },
   {
-    "ascii": 102,
-    "code": 9,
-    "label": "f"
+    ascii: 102,
+    code: 9,
+    label: 'f',
   },
   {
-    "ascii": 103,
-    "code": 10,
-    "label": "g"
+    ascii: 103,
+    code: 10,
+    label: 'g',
   },
   {
-    "ascii": 104,
-    "code": 11,
-    "label": "h"
+    ascii: 104,
+    code: 11,
+    label: 'h',
   },
   {
-    "ascii": 105,
-    "code": 12,
-    "label": "i"
+    ascii: 105,
+    code: 12,
+    label: 'i',
   },
   {
-    "ascii": 106,
-    "code": 13,
-    "label": "j"
+    ascii: 106,
+    code: 13,
+    label: 'j',
   },
   {
-    "ascii": 107,
-    "code": 14,
-    "label": "k"
+    ascii: 107,
+    code: 14,
+    label: 'k',
   },
   {
-    "ascii": 108,
-    "code": 15,
-    "label": "l"
+    ascii: 108,
+    code: 15,
+    label: 'l',
   },
   {
-    "ascii": 109,
-    "code": 16,
-    "label": "m"
+    ascii: 109,
+    code: 16,
+    label: 'm',
   },
   {
-    "ascii": 110,
-    "code": 17,
-    "label": "n"
+    ascii: 110,
+    code: 17,
+    label: 'n',
   },
   {
-    "ascii": 111,
-    "code": 18,
-    "label": "o"
+    ascii: 111,
+    code: 18,
+    label: 'o',
   },
   {
-    "ascii": 112,
-    "code": 19,
-    "label": "p"
+    ascii: 112,
+    code: 19,
+    label: 'p',
   },
   {
-    "ascii": 113,
-    "code": 20,
-    "label": "q"
+    ascii: 113,
+    code: 20,
+    label: 'q',
   },
   {
-    "ascii": 114,
-    "code": 21,
-    "label": "r"
+    ascii: 114,
+    code: 21,
+    label: 'r',
   },
   {
-    "ascii": 115,
-    "code": 22,
-    "label": "s"
+    ascii: 115,
+    code: 22,
+    label: 's',
   },
   {
-    "ascii": 116,
-    "code": 23,
-    "label": "t"
+    ascii: 116,
+    code: 23,
+    label: 't',
   },
   {
-    "ascii": 117,
-    "code": 24,
-    "label": "u"
+    ascii: 117,
+    code: 24,
+    label: 'u',
   },
   {
-    "ascii": 118,
-    "code": 25,
-    "label": "v"
+    ascii: 118,
+    code: 25,
+    label: 'v',
   },
   {
-    "ascii": 119,
-    "code": 26,
-    "label": "w"
+    ascii: 119,
+    code: 26,
+    label: 'w',
   },
   {
-    "ascii": 120,
-    "code": 27,
-    "label": "x"
+    ascii: 120,
+    code: 27,
+    label: 'x',
   },
   {
-    "ascii": 121,
-    "code": 29,
-    "label": "y"
+    ascii: 121,
+    code: 29,
+    label: 'y',
   },
   {
-    "ascii": 122,
-    "code": 28,
-    "label": "z"
+    ascii: 122,
+    code: 28,
+    label: 'z',
   },
   {
-    "ascii": 123,
-    "code": 5,
-    "label": "b"
+    ascii: 123,
+    code: 5,
+    label: 'b',
   },
   {
-    "ascii": 124,
-    "code": 26,
-    "label": "w"
+    ascii: 124,
+    code: 26,
+    label: 'w',
   },
   {
-    "ascii": 125,
-    "code": 17,
-    "label": "n"
+    ascii: 125,
+    code: 17,
+    label: 'n',
   },
   {
-    "ascii": 126,
-    "code": 30,
-    "label": "1"
+    ascii: 126,
+    code: 30,
+    label: '1',
   },
   {
-    "ascii": 127,
-    "code": 76,
-    "label": "del"
-  }
+    ascii: 127,
+    code: 76,
+    label: 'del',
+  },
 ];
-    

--- a/src/services/labellang/AsciiLabelIcelandic.ts
+++ b/src/services/labellang/AsciiLabelIcelandic.ts
@@ -1,645 +1,644 @@
 import { AsciiLabel } from './AsciiLabel';
-        
+
 export const AsciiLabelIcelandic: AsciiLabel[] = [
   {
-    "ascii": 0,
-    "code": 0,
-    "label": ""
+    ascii: 0,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 1,
-    "code": 0,
-    "label": ""
+    ascii: 1,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 2,
-    "code": 0,
-    "label": ""
+    ascii: 2,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 3,
-    "code": 0,
-    "label": ""
+    ascii: 3,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 4,
-    "code": 0,
-    "label": ""
+    ascii: 4,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 5,
-    "code": 0,
-    "label": ""
+    ascii: 5,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 6,
-    "code": 0,
-    "label": ""
+    ascii: 6,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 7,
-    "code": 0,
-    "label": ""
+    ascii: 7,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 8,
-    "code": 42,
-    "label": "back space"
+    ascii: 8,
+    code: 42,
+    label: 'back space',
   },
   {
-    "ascii": 9,
-    "code": 43,
-    "label": "tab"
+    ascii: 9,
+    code: 43,
+    label: 'tab',
   },
   {
-    "ascii": 10,
-    "code": 40,
-    "label": "enter"
+    ascii: 10,
+    code: 40,
+    label: 'enter',
   },
   {
-    "ascii": 11,
-    "code": 0,
-    "label": ""
+    ascii: 11,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 12,
-    "code": 0,
-    "label": ""
+    ascii: 12,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 13,
-    "code": 0,
-    "label": ""
+    ascii: 13,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 14,
-    "code": 0,
-    "label": ""
+    ascii: 14,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 15,
-    "code": 0,
-    "label": ""
+    ascii: 15,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 16,
-    "code": 0,
-    "label": ""
+    ascii: 16,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 17,
-    "code": 0,
-    "label": ""
+    ascii: 17,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 18,
-    "code": 0,
-    "label": ""
+    ascii: 18,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 19,
-    "code": 0,
-    "label": ""
+    ascii: 19,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 20,
-    "code": 0,
-    "label": ""
+    ascii: 20,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 21,
-    "code": 0,
-    "label": ""
+    ascii: 21,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 22,
-    "code": 0,
-    "label": ""
+    ascii: 22,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 23,
-    "code": 0,
-    "label": ""
+    ascii: 23,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 24,
-    "code": 0,
-    "label": ""
+    ascii: 24,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 25,
-    "code": 0,
-    "label": ""
+    ascii: 25,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 26,
-    "code": 0,
-    "label": ""
+    ascii: 26,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 27,
-    "code": 41,
-    "label": "esc"
+    ascii: 27,
+    code: 41,
+    label: 'esc',
   },
   {
-    "ascii": 28,
-    "code": 0,
-    "label": ""
+    ascii: 28,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 29,
-    "code": 0,
-    "label": ""
+    ascii: 29,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 30,
-    "code": 0,
-    "label": ""
+    ascii: 30,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 31,
-    "code": 0,
-    "label": ""
+    ascii: 31,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 32,
-    "code": 44,
-    "label": "space"
+    ascii: 32,
+    code: 44,
+    label: 'space',
   },
   {
-    "ascii": 33,
-    "code": 542,
-    "label": "!"
+    ascii: 33,
+    code: 542,
+    label: '!',
   },
   {
-    "ascii": 34,
-    "code": 543,
-    "label": "\""
+    ascii: 34,
+    code: 543,
+    label: '"',
   },
   {
-    "ascii": 35,
-    "code": 544,
-    "label": "#"
+    ascii: 35,
+    code: 544,
+    label: '#',
   },
   {
-    "ascii": 36,
-    "code": 545,
-    "label": "$"
+    ascii: 36,
+    code: 545,
+    label: '$',
   },
   {
-    "ascii": 37,
-    "code": 546,
-    "label": "%"
+    ascii: 37,
+    code: 546,
+    label: '%',
   },
   {
-    "ascii": 38,
-    "code": 547,
-    "label": "&"
+    ascii: 38,
+    code: 547,
+    label: '&',
   },
   {
-    "ascii": 39,
-    "code": 48,
-    "label": "'"
+    ascii: 39,
+    code: 48,
+    label: "'",
   },
   {
-    "ascii": 40,
-    "code": 549,
-    "label": "("
+    ascii: 40,
+    code: 549,
+    label: '(',
   },
   {
-    "ascii": 41,
-    "code": 550,
-    "label": ")"
+    ascii: 41,
+    code: 550,
+    label: ')',
   },
   {
-    "ascii": 42,
-    "code": 562,
-    "label": "*"
+    ascii: 42,
+    code: 562,
+    label: '*',
   },
   {
-    "ascii": 43,
-    "code": 50,
-    "label": "+"
+    ascii: 43,
+    code: 50,
+    label: '+',
   },
   {
-    "ascii": 44,
-    "code": 54,
-    "label": ","
+    ascii: 44,
+    code: 54,
+    label: ',',
   },
   {
-    "ascii": 45,
-    "code": 46,
-    "label": "-"
+    ascii: 45,
+    code: 46,
+    label: '-',
   },
   {
-    "ascii": 46,
-    "code": 55,
-    "label": "."
+    ascii: 46,
+    code: 55,
+    label: '.',
   },
   {
-    "ascii": 47,
-    "code": 548,
-    "label": "/"
+    ascii: 47,
+    code: 548,
+    label: '/',
   },
   {
-    "ascii": 48,
-    "code": 39,
-    "label": "0"
+    ascii: 48,
+    code: 39,
+    label: '0',
   },
   {
-    "ascii": 49,
-    "code": 30,
-    "label": "1"
+    ascii: 49,
+    code: 30,
+    label: '1',
   },
   {
-    "ascii": 50,
-    "code": 31,
-    "label": "2"
+    ascii: 50,
+    code: 31,
+    label: '2',
   },
   {
-    "ascii": 51,
-    "code": 32,
-    "label": "3"
+    ascii: 51,
+    code: 32,
+    label: '3',
   },
   {
-    "ascii": 52,
-    "code": 33,
-    "label": "4"
+    ascii: 52,
+    code: 33,
+    label: '4',
   },
   {
-    "ascii": 53,
-    "code": 34,
-    "label": "5"
+    ascii: 53,
+    code: 34,
+    label: '5',
   },
   {
-    "ascii": 54,
-    "code": 35,
-    "label": "6"
+    ascii: 54,
+    code: 35,
+    label: '6',
   },
   {
-    "ascii": 55,
-    "code": 36,
-    "label": "7"
+    ascii: 55,
+    code: 36,
+    label: '7',
   },
   {
-    "ascii": 56,
-    "code": 37,
-    "label": "8"
+    ascii: 56,
+    code: 37,
+    label: '8',
   },
   {
-    "ascii": 57,
-    "code": 38,
-    "label": "9"
+    ascii: 57,
+    code: 38,
+    label: '9',
   },
   {
-    "ascii": 58,
-    "code": 567,
-    "label": ":"
+    ascii: 58,
+    code: 567,
+    label: ':',
   },
   {
-    "ascii": 59,
-    "code": 566,
-    "label": ";"
+    ascii: 59,
+    code: 566,
+    label: ';',
   },
   {
-    "ascii": 60,
-    "code": 100,
-    "label": "<"
+    ascii: 60,
+    code: 100,
+    label: '<',
   },
   {
-    "ascii": 61,
-    "code": 551,
-    "label": "="
+    ascii: 61,
+    code: 551,
+    label: '=',
   },
   {
-    "ascii": 62,
-    "code": 612,
-    "label": ">"
+    ascii: 62,
+    code: 612,
+    label: '>',
   },
   {
-    "ascii": 63,
-    "code": 560,
-    "label": "?"
+    ascii: 63,
+    code: 560,
+    label: '?',
   },
   {
-    "ascii": 64,
-    "code": 20,
-    "label": "q"
+    ascii: 64,
+    code: 20,
+    label: 'q',
   },
   {
-    "ascii": 65,
-    "code": 516,
-    "label": "A"
+    ascii: 65,
+    code: 516,
+    label: 'A',
   },
   {
-    "ascii": 66,
-    "code": 517,
-    "label": "B"
+    ascii: 66,
+    code: 517,
+    label: 'B',
   },
   {
-    "ascii": 67,
-    "code": 518,
-    "label": "C"
+    ascii: 67,
+    code: 518,
+    label: 'C',
   },
   {
-    "ascii": 68,
-    "code": 519,
-    "label": "D"
+    ascii: 68,
+    code: 519,
+    label: 'D',
   },
   {
-    "ascii": 69,
-    "code": 520,
-    "label": "E"
+    ascii: 69,
+    code: 520,
+    label: 'E',
   },
   {
-    "ascii": 70,
-    "code": 521,
-    "label": "F"
+    ascii: 70,
+    code: 521,
+    label: 'F',
   },
   {
-    "ascii": 71,
-    "code": 522,
-    "label": "G"
+    ascii: 71,
+    code: 522,
+    label: 'G',
   },
   {
-    "ascii": 72,
-    "code": 523,
-    "label": "H"
+    ascii: 72,
+    code: 523,
+    label: 'H',
   },
   {
-    "ascii": 73,
-    "code": 524,
-    "label": "I"
+    ascii: 73,
+    code: 524,
+    label: 'I',
   },
   {
-    "ascii": 74,
-    "code": 525,
-    "label": "J"
+    ascii: 74,
+    code: 525,
+    label: 'J',
   },
   {
-    "ascii": 75,
-    "code": 526,
-    "label": "K"
+    ascii: 75,
+    code: 526,
+    label: 'K',
   },
   {
-    "ascii": 76,
-    "code": 527,
-    "label": "L"
+    ascii: 76,
+    code: 527,
+    label: 'L',
   },
   {
-    "ascii": 77,
-    "code": 528,
-    "label": "M"
+    ascii: 77,
+    code: 528,
+    label: 'M',
   },
   {
-    "ascii": 78,
-    "code": 529,
-    "label": "N"
+    ascii: 78,
+    code: 529,
+    label: 'N',
   },
   {
-    "ascii": 79,
-    "code": 530,
-    "label": "O"
+    ascii: 79,
+    code: 530,
+    label: 'O',
   },
   {
-    "ascii": 80,
-    "code": 531,
-    "label": "P"
+    ascii: 80,
+    code: 531,
+    label: 'P',
   },
   {
-    "ascii": 81,
-    "code": 532,
-    "label": "Q"
+    ascii: 81,
+    code: 532,
+    label: 'Q',
   },
   {
-    "ascii": 82,
-    "code": 533,
-    "label": "R"
+    ascii: 82,
+    code: 533,
+    label: 'R',
   },
   {
-    "ascii": 83,
-    "code": 534,
-    "label": "S"
+    ascii: 83,
+    code: 534,
+    label: 'S',
   },
   {
-    "ascii": 84,
-    "code": 535,
-    "label": "T"
+    ascii: 84,
+    code: 535,
+    label: 'T',
   },
   {
-    "ascii": 85,
-    "code": 536,
-    "label": "U"
+    ascii: 85,
+    code: 536,
+    label: 'U',
   },
   {
-    "ascii": 86,
-    "code": 537,
-    "label": "V"
+    ascii: 86,
+    code: 537,
+    label: 'V',
   },
   {
-    "ascii": 87,
-    "code": 538,
-    "label": "W"
+    ascii: 87,
+    code: 538,
+    label: 'W',
   },
   {
-    "ascii": 88,
-    "code": 539,
-    "label": "X"
+    ascii: 88,
+    code: 539,
+    label: 'X',
   },
   {
-    "ascii": 89,
-    "code": 540,
-    "label": "Y"
+    ascii: 89,
+    code: 540,
+    label: 'Y',
   },
   {
-    "ascii": 90,
-    "code": 541,
-    "label": "Z"
+    ascii: 90,
+    code: 541,
+    label: 'Z',
   },
   {
-    "ascii": 91,
-    "code": 37,
-    "label": "8"
+    ascii: 91,
+    code: 37,
+    label: '8',
   },
   {
-    "ascii": 92,
-    "code": 45,
-    "label": "Ö"
+    ascii: 92,
+    code: 45,
+    label: 'Ö',
   },
   {
-    "ascii": 93,
-    "code": 38,
-    "label": "9"
+    ascii: 93,
+    code: 38,
+    label: '9',
   },
   {
-    "ascii": 94,
-    "code": 52,
-    "label": "´ (dead)"
+    ascii: 94,
+    code: 52,
+    label: '´ (dead)',
   },
   {
-    "ascii": 95,
-    "code": 558,
-    "label": "_"
+    ascii: 95,
+    code: 558,
+    label: '_',
   },
   {
-    "ascii": 96,
-    "code": 50,
-    "label": "+"
+    ascii: 96,
+    code: 50,
+    label: '+',
   },
   {
-    "ascii": 97,
-    "code": 4,
-    "label": "a"
+    ascii: 97,
+    code: 4,
+    label: 'a',
   },
   {
-    "ascii": 98,
-    "code": 5,
-    "label": "b"
+    ascii: 98,
+    code: 5,
+    label: 'b',
   },
   {
-    "ascii": 99,
-    "code": 6,
-    "label": "c"
+    ascii: 99,
+    code: 6,
+    label: 'c',
   },
   {
-    "ascii": 100,
-    "code": 7,
-    "label": "d"
+    ascii: 100,
+    code: 7,
+    label: 'd',
   },
   {
-    "ascii": 101,
-    "code": 8,
-    "label": "e"
+    ascii: 101,
+    code: 8,
+    label: 'e',
   },
   {
-    "ascii": 102,
-    "code": 9,
-    "label": "f"
+    ascii: 102,
+    code: 9,
+    label: 'f',
   },
   {
-    "ascii": 103,
-    "code": 10,
-    "label": "g"
+    ascii: 103,
+    code: 10,
+    label: 'g',
   },
   {
-    "ascii": 104,
-    "code": 11,
-    "label": "h"
+    ascii: 104,
+    code: 11,
+    label: 'h',
   },
   {
-    "ascii": 105,
-    "code": 12,
-    "label": "i"
+    ascii: 105,
+    code: 12,
+    label: 'i',
   },
   {
-    "ascii": 106,
-    "code": 13,
-    "label": "j"
+    ascii: 106,
+    code: 13,
+    label: 'j',
   },
   {
-    "ascii": 107,
-    "code": 14,
-    "label": "k"
+    ascii: 107,
+    code: 14,
+    label: 'k',
   },
   {
-    "ascii": 108,
-    "code": 15,
-    "label": "l"
+    ascii: 108,
+    code: 15,
+    label: 'l',
   },
   {
-    "ascii": 109,
-    "code": 16,
-    "label": "m"
+    ascii: 109,
+    code: 16,
+    label: 'm',
   },
   {
-    "ascii": 110,
-    "code": 17,
-    "label": "n"
+    ascii: 110,
+    code: 17,
+    label: 'n',
   },
   {
-    "ascii": 111,
-    "code": 18,
-    "label": "o"
+    ascii: 111,
+    code: 18,
+    label: 'o',
   },
   {
-    "ascii": 112,
-    "code": 19,
-    "label": "p"
+    ascii: 112,
+    code: 19,
+    label: 'p',
   },
   {
-    "ascii": 113,
-    "code": 20,
-    "label": "q"
+    ascii: 113,
+    code: 20,
+    label: 'q',
   },
   {
-    "ascii": 114,
-    "code": 21,
-    "label": "r"
+    ascii: 114,
+    code: 21,
+    label: 'r',
   },
   {
-    "ascii": 115,
-    "code": 22,
-    "label": "s"
+    ascii: 115,
+    code: 22,
+    label: 's',
   },
   {
-    "ascii": 116,
-    "code": 23,
-    "label": "t"
+    ascii: 116,
+    code: 23,
+    label: 't',
   },
   {
-    "ascii": 117,
-    "code": 24,
-    "label": "u"
+    ascii: 117,
+    code: 24,
+    label: 'u',
   },
   {
-    "ascii": 118,
-    "code": 25,
-    "label": "v"
+    ascii: 118,
+    code: 25,
+    label: 'v',
   },
   {
-    "ascii": 119,
-    "code": 26,
-    "label": "w"
+    ascii: 119,
+    code: 26,
+    label: 'w',
   },
   {
-    "ascii": 120,
-    "code": 27,
-    "label": "x"
+    ascii: 120,
+    code: 27,
+    label: 'x',
   },
   {
-    "ascii": 121,
-    "code": 28,
-    "label": "y"
+    ascii: 121,
+    code: 28,
+    label: 'y',
   },
   {
-    "ascii": 122,
-    "code": 29,
-    "label": "z"
+    ascii: 122,
+    code: 29,
+    label: 'z',
   },
   {
-    "ascii": 123,
-    "code": 36,
-    "label": "7"
+    ascii: 123,
+    code: 36,
+    label: '7',
   },
   {
-    "ascii": 124,
-    "code": 100,
-    "label": "<"
+    ascii: 124,
+    code: 100,
+    label: '<',
   },
   {
-    "ascii": 125,
-    "code": 39,
-    "label": "0"
+    ascii: 125,
+    code: 39,
+    label: '0',
   },
   {
-    "ascii": 126,
-    "code": 48,
-    "label": "'"
+    ascii: 126,
+    code: 48,
+    label: "'",
   },
   {
-    "ascii": 127,
-    "code": 76,
-    "label": "del"
-  }
+    ascii: 127,
+    code: 76,
+    label: 'del',
+  },
 ];
-    

--- a/src/services/labellang/AsciiLabelItalian.ts
+++ b/src/services/labellang/AsciiLabelItalian.ts
@@ -1,645 +1,644 @@
 import { AsciiLabel } from './AsciiLabel';
-        
+
 export const AsciiLabelItalian: AsciiLabel[] = [
   {
-    "ascii": 0,
-    "code": 0,
-    "label": ""
+    ascii: 0,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 1,
-    "code": 0,
-    "label": ""
+    ascii: 1,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 2,
-    "code": 0,
-    "label": ""
+    ascii: 2,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 3,
-    "code": 0,
-    "label": ""
+    ascii: 3,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 4,
-    "code": 0,
-    "label": ""
+    ascii: 4,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 5,
-    "code": 0,
-    "label": ""
+    ascii: 5,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 6,
-    "code": 0,
-    "label": ""
+    ascii: 6,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 7,
-    "code": 0,
-    "label": ""
+    ascii: 7,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 8,
-    "code": 42,
-    "label": "back space"
+    ascii: 8,
+    code: 42,
+    label: 'back space',
   },
   {
-    "ascii": 9,
-    "code": 43,
-    "label": "tab"
+    ascii: 9,
+    code: 43,
+    label: 'tab',
   },
   {
-    "ascii": 10,
-    "code": 40,
-    "label": "enter"
+    ascii: 10,
+    code: 40,
+    label: 'enter',
   },
   {
-    "ascii": 11,
-    "code": 0,
-    "label": ""
+    ascii: 11,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 12,
-    "code": 0,
-    "label": ""
+    ascii: 12,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 13,
-    "code": 0,
-    "label": ""
+    ascii: 13,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 14,
-    "code": 0,
-    "label": ""
+    ascii: 14,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 15,
-    "code": 0,
-    "label": ""
+    ascii: 15,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 16,
-    "code": 0,
-    "label": ""
+    ascii: 16,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 17,
-    "code": 0,
-    "label": ""
+    ascii: 17,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 18,
-    "code": 0,
-    "label": ""
+    ascii: 18,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 19,
-    "code": 0,
-    "label": ""
+    ascii: 19,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 20,
-    "code": 0,
-    "label": ""
+    ascii: 20,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 21,
-    "code": 0,
-    "label": ""
+    ascii: 21,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 22,
-    "code": 0,
-    "label": ""
+    ascii: 22,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 23,
-    "code": 0,
-    "label": ""
+    ascii: 23,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 24,
-    "code": 0,
-    "label": ""
+    ascii: 24,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 25,
-    "code": 0,
-    "label": ""
+    ascii: 25,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 26,
-    "code": 0,
-    "label": ""
+    ascii: 26,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 27,
-    "code": 41,
-    "label": "esc"
+    ascii: 27,
+    code: 41,
+    label: 'esc',
   },
   {
-    "ascii": 28,
-    "code": 0,
-    "label": ""
+    ascii: 28,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 29,
-    "code": 0,
-    "label": ""
+    ascii: 29,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 30,
-    "code": 0,
-    "label": ""
+    ascii: 30,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 31,
-    "code": 0,
-    "label": ""
+    ascii: 31,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 32,
-    "code": 44,
-    "label": "space"
+    ascii: 32,
+    code: 44,
+    label: 'space',
   },
   {
-    "ascii": 33,
-    "code": 542,
-    "label": "!"
+    ascii: 33,
+    code: 542,
+    label: '!',
   },
   {
-    "ascii": 34,
-    "code": 543,
-    "label": "\""
+    ascii: 34,
+    code: 543,
+    label: '"',
   },
   {
-    "ascii": 35,
-    "code": 52,
-    "label": "à"
+    ascii: 35,
+    code: 52,
+    label: 'à',
   },
   {
-    "ascii": 36,
-    "code": 545,
-    "label": "$"
+    ascii: 36,
+    code: 545,
+    label: '$',
   },
   {
-    "ascii": 37,
-    "code": 546,
-    "label": "%"
+    ascii: 37,
+    code: 546,
+    label: '%',
   },
   {
-    "ascii": 38,
-    "code": 547,
-    "label": "&"
+    ascii: 38,
+    code: 547,
+    label: '&',
   },
   {
-    "ascii": 39,
-    "code": 45,
-    "label": "'"
+    ascii: 39,
+    code: 45,
+    label: "'",
   },
   {
-    "ascii": 40,
-    "code": 549,
-    "label": "("
+    ascii: 40,
+    code: 549,
+    label: '(',
   },
   {
-    "ascii": 41,
-    "code": 550,
-    "label": ")"
+    ascii: 41,
+    code: 550,
+    label: ')',
   },
   {
-    "ascii": 42,
-    "code": 560,
-    "label": "*"
+    ascii: 42,
+    code: 560,
+    label: '*',
   },
   {
-    "ascii": 43,
-    "code": 48,
-    "label": "+"
+    ascii: 43,
+    code: 48,
+    label: '+',
   },
   {
-    "ascii": 44,
-    "code": 54,
-    "label": ","
+    ascii: 44,
+    code: 54,
+    label: ',',
   },
   {
-    "ascii": 45,
-    "code": 56,
-    "label": "-"
+    ascii: 45,
+    code: 56,
+    label: '-',
   },
   {
-    "ascii": 46,
-    "code": 55,
-    "label": "."
+    ascii: 46,
+    code: 55,
+    label: '.',
   },
   {
-    "ascii": 47,
-    "code": 548,
-    "label": "/"
+    ascii: 47,
+    code: 548,
+    label: '/',
   },
   {
-    "ascii": 48,
-    "code": 39,
-    "label": "0"
+    ascii: 48,
+    code: 39,
+    label: '0',
   },
   {
-    "ascii": 49,
-    "code": 30,
-    "label": "1"
+    ascii: 49,
+    code: 30,
+    label: '1',
   },
   {
-    "ascii": 50,
-    "code": 31,
-    "label": "2"
+    ascii: 50,
+    code: 31,
+    label: '2',
   },
   {
-    "ascii": 51,
-    "code": 32,
-    "label": "3"
+    ascii: 51,
+    code: 32,
+    label: '3',
   },
   {
-    "ascii": 52,
-    "code": 33,
-    "label": "4"
+    ascii: 52,
+    code: 33,
+    label: '4',
   },
   {
-    "ascii": 53,
-    "code": 34,
-    "label": "5"
+    ascii: 53,
+    code: 34,
+    label: '5',
   },
   {
-    "ascii": 54,
-    "code": 35,
-    "label": "6"
+    ascii: 54,
+    code: 35,
+    label: '6',
   },
   {
-    "ascii": 55,
-    "code": 36,
-    "label": "7"
+    ascii: 55,
+    code: 36,
+    label: '7',
   },
   {
-    "ascii": 56,
-    "code": 37,
-    "label": "8"
+    ascii: 56,
+    code: 37,
+    label: '8',
   },
   {
-    "ascii": 57,
-    "code": 38,
-    "label": "9"
+    ascii: 57,
+    code: 38,
+    label: '9',
   },
   {
-    "ascii": 58,
-    "code": 567,
-    "label": ":"
+    ascii: 58,
+    code: 567,
+    label: ':',
   },
   {
-    "ascii": 59,
-    "code": 566,
-    "label": ";"
+    ascii: 59,
+    code: 566,
+    label: ';',
   },
   {
-    "ascii": 60,
-    "code": 100,
-    "label": "<"
+    ascii: 60,
+    code: 100,
+    label: '<',
   },
   {
-    "ascii": 61,
-    "code": 551,
-    "label": "="
+    ascii: 61,
+    code: 551,
+    label: '=',
   },
   {
-    "ascii": 62,
-    "code": 612,
-    "label": ">"
+    ascii: 62,
+    code: 612,
+    label: '>',
   },
   {
-    "ascii": 63,
-    "code": 557,
-    "label": "?"
+    ascii: 63,
+    code: 557,
+    label: '?',
   },
   {
-    "ascii": 64,
-    "code": 51,
-    "label": "ò"
+    ascii: 64,
+    code: 51,
+    label: 'ò',
   },
   {
-    "ascii": 65,
-    "code": 516,
-    "label": "A"
+    ascii: 65,
+    code: 516,
+    label: 'A',
   },
   {
-    "ascii": 66,
-    "code": 517,
-    "label": "B"
+    ascii: 66,
+    code: 517,
+    label: 'B',
   },
   {
-    "ascii": 67,
-    "code": 518,
-    "label": "C"
+    ascii: 67,
+    code: 518,
+    label: 'C',
   },
   {
-    "ascii": 68,
-    "code": 519,
-    "label": "D"
+    ascii: 68,
+    code: 519,
+    label: 'D',
   },
   {
-    "ascii": 69,
-    "code": 520,
-    "label": "E"
+    ascii: 69,
+    code: 520,
+    label: 'E',
   },
   {
-    "ascii": 70,
-    "code": 521,
-    "label": "F"
+    ascii: 70,
+    code: 521,
+    label: 'F',
   },
   {
-    "ascii": 71,
-    "code": 522,
-    "label": "G"
+    ascii: 71,
+    code: 522,
+    label: 'G',
   },
   {
-    "ascii": 72,
-    "code": 523,
-    "label": "H"
+    ascii: 72,
+    code: 523,
+    label: 'H',
   },
   {
-    "ascii": 73,
-    "code": 524,
-    "label": "I"
+    ascii: 73,
+    code: 524,
+    label: 'I',
   },
   {
-    "ascii": 74,
-    "code": 525,
-    "label": "J"
+    ascii: 74,
+    code: 525,
+    label: 'J',
   },
   {
-    "ascii": 75,
-    "code": 526,
-    "label": "K"
+    ascii: 75,
+    code: 526,
+    label: 'K',
   },
   {
-    "ascii": 76,
-    "code": 527,
-    "label": "L"
+    ascii: 76,
+    code: 527,
+    label: 'L',
   },
   {
-    "ascii": 77,
-    "code": 528,
-    "label": "M"
+    ascii: 77,
+    code: 528,
+    label: 'M',
   },
   {
-    "ascii": 78,
-    "code": 529,
-    "label": "N"
+    ascii: 78,
+    code: 529,
+    label: 'N',
   },
   {
-    "ascii": 79,
-    "code": 530,
-    "label": "O"
+    ascii: 79,
+    code: 530,
+    label: 'O',
   },
   {
-    "ascii": 80,
-    "code": 531,
-    "label": "P"
+    ascii: 80,
+    code: 531,
+    label: 'P',
   },
   {
-    "ascii": 81,
-    "code": 532,
-    "label": "Q"
+    ascii: 81,
+    code: 532,
+    label: 'Q',
   },
   {
-    "ascii": 82,
-    "code": 533,
-    "label": "R"
+    ascii: 82,
+    code: 533,
+    label: 'R',
   },
   {
-    "ascii": 83,
-    "code": 534,
-    "label": "S"
+    ascii: 83,
+    code: 534,
+    label: 'S',
   },
   {
-    "ascii": 84,
-    "code": 535,
-    "label": "T"
+    ascii: 84,
+    code: 535,
+    label: 'T',
   },
   {
-    "ascii": 85,
-    "code": 536,
-    "label": "U"
+    ascii: 85,
+    code: 536,
+    label: 'U',
   },
   {
-    "ascii": 86,
-    "code": 537,
-    "label": "V"
+    ascii: 86,
+    code: 537,
+    label: 'V',
   },
   {
-    "ascii": 87,
-    "code": 538,
-    "label": "W"
+    ascii: 87,
+    code: 538,
+    label: 'W',
   },
   {
-    "ascii": 88,
-    "code": 539,
-    "label": "X"
+    ascii: 88,
+    code: 539,
+    label: 'X',
   },
   {
-    "ascii": 89,
-    "code": 540,
-    "label": "Y"
+    ascii: 89,
+    code: 540,
+    label: 'Y',
   },
   {
-    "ascii": 90,
-    "code": 541,
-    "label": "Z"
+    ascii: 90,
+    code: 541,
+    label: 'Z',
   },
   {
-    "ascii": 91,
-    "code": 47,
-    "label": "è"
+    ascii: 91,
+    code: 47,
+    label: 'è',
   },
   {
-    "ascii": 92,
-    "code": 53,
-    "label": "(backslash)"
+    ascii: 92,
+    code: 53,
+    label: '(backslash)',
   },
   {
-    "ascii": 93,
-    "code": 48,
-    "label": "+"
+    ascii: 93,
+    code: 48,
+    label: '+',
   },
   {
-    "ascii": 94,
-    "code": 558,
-    "label": "^"
+    ascii: 94,
+    code: 558,
+    label: '^',
   },
   {
-    "ascii": 95,
-    "code": 568,
-    "label": "_"
+    ascii: 95,
+    code: 568,
+    label: '_',
   },
   {
-    "ascii": 96,
-    "code": 0,
-    "label": ""
+    ascii: 96,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 97,
-    "code": 4,
-    "label": "a"
+    ascii: 97,
+    code: 4,
+    label: 'a',
   },
   {
-    "ascii": 98,
-    "code": 5,
-    "label": "b"
+    ascii: 98,
+    code: 5,
+    label: 'b',
   },
   {
-    "ascii": 99,
-    "code": 6,
-    "label": "c"
+    ascii: 99,
+    code: 6,
+    label: 'c',
   },
   {
-    "ascii": 100,
-    "code": 7,
-    "label": "d"
+    ascii: 100,
+    code: 7,
+    label: 'd',
   },
   {
-    "ascii": 101,
-    "code": 8,
-    "label": "e"
+    ascii: 101,
+    code: 8,
+    label: 'e',
   },
   {
-    "ascii": 102,
-    "code": 9,
-    "label": "f"
+    ascii: 102,
+    code: 9,
+    label: 'f',
   },
   {
-    "ascii": 103,
-    "code": 10,
-    "label": "g"
+    ascii: 103,
+    code: 10,
+    label: 'g',
   },
   {
-    "ascii": 104,
-    "code": 11,
-    "label": "h"
+    ascii: 104,
+    code: 11,
+    label: 'h',
   },
   {
-    "ascii": 105,
-    "code": 12,
-    "label": "i"
+    ascii: 105,
+    code: 12,
+    label: 'i',
   },
   {
-    "ascii": 106,
-    "code": 13,
-    "label": "j"
+    ascii: 106,
+    code: 13,
+    label: 'j',
   },
   {
-    "ascii": 107,
-    "code": 14,
-    "label": "k"
+    ascii: 107,
+    code: 14,
+    label: 'k',
   },
   {
-    "ascii": 108,
-    "code": 15,
-    "label": "l"
+    ascii: 108,
+    code: 15,
+    label: 'l',
   },
   {
-    "ascii": 109,
-    "code": 16,
-    "label": "m"
+    ascii: 109,
+    code: 16,
+    label: 'm',
   },
   {
-    "ascii": 110,
-    "code": 17,
-    "label": "n"
+    ascii: 110,
+    code: 17,
+    label: 'n',
   },
   {
-    "ascii": 111,
-    "code": 18,
-    "label": "o"
+    ascii: 111,
+    code: 18,
+    label: 'o',
   },
   {
-    "ascii": 112,
-    "code": 19,
-    "label": "p"
+    ascii: 112,
+    code: 19,
+    label: 'p',
   },
   {
-    "ascii": 113,
-    "code": 20,
-    "label": "q"
+    ascii: 113,
+    code: 20,
+    label: 'q',
   },
   {
-    "ascii": 114,
-    "code": 21,
-    "label": "r"
+    ascii: 114,
+    code: 21,
+    label: 'r',
   },
   {
-    "ascii": 115,
-    "code": 22,
-    "label": "s"
+    ascii: 115,
+    code: 22,
+    label: 's',
   },
   {
-    "ascii": 116,
-    "code": 23,
-    "label": "t"
+    ascii: 116,
+    code: 23,
+    label: 't',
   },
   {
-    "ascii": 117,
-    "code": 24,
-    "label": "u"
+    ascii: 117,
+    code: 24,
+    label: 'u',
   },
   {
-    "ascii": 118,
-    "code": 25,
-    "label": "v"
+    ascii: 118,
+    code: 25,
+    label: 'v',
   },
   {
-    "ascii": 119,
-    "code": 26,
-    "label": "w"
+    ascii: 119,
+    code: 26,
+    label: 'w',
   },
   {
-    "ascii": 120,
-    "code": 27,
-    "label": "x"
+    ascii: 120,
+    code: 27,
+    label: 'x',
   },
   {
-    "ascii": 121,
-    "code": 28,
-    "label": "y"
+    ascii: 121,
+    code: 28,
+    label: 'y',
   },
   {
-    "ascii": 122,
-    "code": 29,
-    "label": "z"
+    ascii: 122,
+    code: 29,
+    label: 'z',
   },
   {
-    "ascii": 123,
-    "code": 559,
-    "label": "é"
+    ascii: 123,
+    code: 559,
+    label: 'é',
   },
   {
-    "ascii": 124,
-    "code": 565,
-    "label": "|"
+    ascii: 124,
+    code: 565,
+    label: '|',
   },
   {
-    "ascii": 125,
-    "code": 560,
-    "label": "*"
+    ascii: 125,
+    code: 560,
+    label: '*',
   },
   {
-    "ascii": 126,
-    "code": 0,
-    "label": ""
+    ascii: 126,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 127,
-    "code": 76,
-    "label": "del"
-  }
+    ascii: 127,
+    code: 76,
+    label: 'del',
+  },
 ];
-    

--- a/src/services/labellang/AsciiLabelItalian_osx_ansi.ts
+++ b/src/services/labellang/AsciiLabelItalian_osx_ansi.ts
@@ -1,645 +1,644 @@
 import { AsciiLabel } from './AsciiLabel';
-        
+
 export const AsciiLabelItalian_osx_ansi: AsciiLabel[] = [
   {
-    "ascii": 0,
-    "code": 0,
-    "label": ""
+    ascii: 0,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 1,
-    "code": 0,
-    "label": ""
+    ascii: 1,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 2,
-    "code": 0,
-    "label": ""
+    ascii: 2,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 3,
-    "code": 0,
-    "label": ""
+    ascii: 3,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 4,
-    "code": 0,
-    "label": ""
+    ascii: 4,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 5,
-    "code": 0,
-    "label": ""
+    ascii: 5,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 6,
-    "code": 0,
-    "label": ""
+    ascii: 6,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 7,
-    "code": 0,
-    "label": ""
+    ascii: 7,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 8,
-    "code": 42,
-    "label": "back space"
+    ascii: 8,
+    code: 42,
+    label: 'back space',
   },
   {
-    "ascii": 9,
-    "code": 43,
-    "label": "tab"
+    ascii: 9,
+    code: 43,
+    label: 'tab',
   },
   {
-    "ascii": 10,
-    "code": 40,
-    "label": "enter"
+    ascii: 10,
+    code: 40,
+    label: 'enter',
   },
   {
-    "ascii": 11,
-    "code": 0,
-    "label": ""
+    ascii: 11,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 12,
-    "code": 0,
-    "label": ""
+    ascii: 12,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 13,
-    "code": 0,
-    "label": ""
+    ascii: 13,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 14,
-    "code": 0,
-    "label": ""
+    ascii: 14,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 15,
-    "code": 0,
-    "label": ""
+    ascii: 15,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 16,
-    "code": 0,
-    "label": ""
+    ascii: 16,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 17,
-    "code": 0,
-    "label": ""
+    ascii: 17,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 18,
-    "code": 0,
-    "label": ""
+    ascii: 18,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 19,
-    "code": 0,
-    "label": ""
+    ascii: 19,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 20,
-    "code": 0,
-    "label": ""
+    ascii: 20,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 21,
-    "code": 0,
-    "label": ""
+    ascii: 21,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 22,
-    "code": 0,
-    "label": ""
+    ascii: 22,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 23,
-    "code": 0,
-    "label": ""
+    ascii: 23,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 24,
-    "code": 0,
-    "label": ""
+    ascii: 24,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 25,
-    "code": 0,
-    "label": ""
+    ascii: 25,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 26,
-    "code": 0,
-    "label": ""
+    ascii: 26,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 27,
-    "code": 41,
-    "label": "esc"
+    ascii: 27,
+    code: 41,
+    label: 'esc',
   },
   {
-    "ascii": 28,
-    "code": 0,
-    "label": ""
+    ascii: 28,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 29,
-    "code": 0,
-    "label": ""
+    ascii: 29,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 30,
-    "code": 0,
-    "label": ""
+    ascii: 30,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 31,
-    "code": 0,
-    "label": ""
+    ascii: 31,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 32,
-    "code": 44,
-    "label": "space"
+    ascii: 32,
+    code: 44,
+    label: 'space',
   },
   {
-    "ascii": 33,
-    "code": 542,
-    "label": "!"
+    ascii: 33,
+    code: 542,
+    label: '!',
   },
   {
-    "ascii": 34,
-    "code": 543,
-    "label": "\""
+    ascii: 34,
+    code: 543,
+    label: '"',
   },
   {
-    "ascii": 35,
-    "code": 52,
-    "label": "à"
+    ascii: 35,
+    code: 52,
+    label: 'à',
   },
   {
-    "ascii": 36,
-    "code": 545,
-    "label": "$"
+    ascii: 36,
+    code: 545,
+    label: '$',
   },
   {
-    "ascii": 37,
-    "code": 546,
-    "label": "%"
+    ascii: 37,
+    code: 546,
+    label: '%',
   },
   {
-    "ascii": 38,
-    "code": 547,
-    "label": "&"
+    ascii: 38,
+    code: 547,
+    label: '&',
   },
   {
-    "ascii": 39,
-    "code": 45,
-    "label": "'"
+    ascii: 39,
+    code: 45,
+    label: "'",
   },
   {
-    "ascii": 40,
-    "code": 549,
-    "label": "("
+    ascii: 40,
+    code: 549,
+    label: '(',
   },
   {
-    "ascii": 41,
-    "code": 550,
-    "label": ")"
+    ascii: 41,
+    code: 550,
+    label: ')',
   },
   {
-    "ascii": 42,
-    "code": 560,
-    "label": "*"
+    ascii: 42,
+    code: 560,
+    label: '*',
   },
   {
-    "ascii": 43,
-    "code": 48,
-    "label": "+"
+    ascii: 43,
+    code: 48,
+    label: '+',
   },
   {
-    "ascii": 44,
-    "code": 54,
-    "label": ","
+    ascii: 44,
+    code: 54,
+    label: ',',
   },
   {
-    "ascii": 45,
-    "code": 56,
-    "label": "-"
+    ascii: 45,
+    code: 56,
+    label: '-',
   },
   {
-    "ascii": 46,
-    "code": 55,
-    "label": "."
+    ascii: 46,
+    code: 55,
+    label: '.',
   },
   {
-    "ascii": 47,
-    "code": 548,
-    "label": "/"
+    ascii: 47,
+    code: 548,
+    label: '/',
   },
   {
-    "ascii": 48,
-    "code": 39,
-    "label": "0"
+    ascii: 48,
+    code: 39,
+    label: '0',
   },
   {
-    "ascii": 49,
-    "code": 30,
-    "label": "1"
+    ascii: 49,
+    code: 30,
+    label: '1',
   },
   {
-    "ascii": 50,
-    "code": 31,
-    "label": "2"
+    ascii: 50,
+    code: 31,
+    label: '2',
   },
   {
-    "ascii": 51,
-    "code": 32,
-    "label": "3"
+    ascii: 51,
+    code: 32,
+    label: '3',
   },
   {
-    "ascii": 52,
-    "code": 33,
-    "label": "4"
+    ascii: 52,
+    code: 33,
+    label: '4',
   },
   {
-    "ascii": 53,
-    "code": 34,
-    "label": "5"
+    ascii: 53,
+    code: 34,
+    label: '5',
   },
   {
-    "ascii": 54,
-    "code": 35,
-    "label": "6"
+    ascii: 54,
+    code: 35,
+    label: '6',
   },
   {
-    "ascii": 55,
-    "code": 36,
-    "label": "7"
+    ascii: 55,
+    code: 36,
+    label: '7',
   },
   {
-    "ascii": 56,
-    "code": 37,
-    "label": "8"
+    ascii: 56,
+    code: 37,
+    label: '8',
   },
   {
-    "ascii": 57,
-    "code": 38,
-    "label": "9"
+    ascii: 57,
+    code: 38,
+    label: '9',
   },
   {
-    "ascii": 58,
-    "code": 567,
-    "label": ":"
+    ascii: 58,
+    code: 567,
+    label: ':',
   },
   {
-    "ascii": 59,
-    "code": 566,
-    "label": ";"
+    ascii: 59,
+    code: 566,
+    label: ';',
   },
   {
-    "ascii": 60,
-    "code": 53,
-    "label": "<"
+    ascii: 60,
+    code: 53,
+    label: '<',
   },
   {
-    "ascii": 61,
-    "code": 551,
-    "label": "="
+    ascii: 61,
+    code: 551,
+    label: '=',
   },
   {
-    "ascii": 62,
-    "code": 565,
-    "label": ">"
+    ascii: 62,
+    code: 565,
+    label: '>',
   },
   {
-    "ascii": 63,
-    "code": 557,
-    "label": "?"
+    ascii: 63,
+    code: 557,
+    label: '?',
   },
   {
-    "ascii": 64,
-    "code": 51,
-    "label": "ò"
+    ascii: 64,
+    code: 51,
+    label: 'ò',
   },
   {
-    "ascii": 65,
-    "code": 516,
-    "label": "A"
+    ascii: 65,
+    code: 516,
+    label: 'A',
   },
   {
-    "ascii": 66,
-    "code": 517,
-    "label": "B"
+    ascii: 66,
+    code: 517,
+    label: 'B',
   },
   {
-    "ascii": 67,
-    "code": 518,
-    "label": "C"
+    ascii: 67,
+    code: 518,
+    label: 'C',
   },
   {
-    "ascii": 68,
-    "code": 519,
-    "label": "D"
+    ascii: 68,
+    code: 519,
+    label: 'D',
   },
   {
-    "ascii": 69,
-    "code": 520,
-    "label": "E"
+    ascii: 69,
+    code: 520,
+    label: 'E',
   },
   {
-    "ascii": 70,
-    "code": 521,
-    "label": "F"
+    ascii: 70,
+    code: 521,
+    label: 'F',
   },
   {
-    "ascii": 71,
-    "code": 522,
-    "label": "G"
+    ascii: 71,
+    code: 522,
+    label: 'G',
   },
   {
-    "ascii": 72,
-    "code": 523,
-    "label": "H"
+    ascii: 72,
+    code: 523,
+    label: 'H',
   },
   {
-    "ascii": 73,
-    "code": 524,
-    "label": "I"
+    ascii: 73,
+    code: 524,
+    label: 'I',
   },
   {
-    "ascii": 74,
-    "code": 525,
-    "label": "J"
+    ascii: 74,
+    code: 525,
+    label: 'J',
   },
   {
-    "ascii": 75,
-    "code": 526,
-    "label": "K"
+    ascii: 75,
+    code: 526,
+    label: 'K',
   },
   {
-    "ascii": 76,
-    "code": 527,
-    "label": "L"
+    ascii: 76,
+    code: 527,
+    label: 'L',
   },
   {
-    "ascii": 77,
-    "code": 528,
-    "label": "M"
+    ascii: 77,
+    code: 528,
+    label: 'M',
   },
   {
-    "ascii": 78,
-    "code": 529,
-    "label": "N"
+    ascii: 78,
+    code: 529,
+    label: 'N',
   },
   {
-    "ascii": 79,
-    "code": 530,
-    "label": "O"
+    ascii: 79,
+    code: 530,
+    label: 'O',
   },
   {
-    "ascii": 80,
-    "code": 531,
-    "label": "P"
+    ascii: 80,
+    code: 531,
+    label: 'P',
   },
   {
-    "ascii": 81,
-    "code": 532,
-    "label": "Q"
+    ascii: 81,
+    code: 532,
+    label: 'Q',
   },
   {
-    "ascii": 82,
-    "code": 533,
-    "label": "R"
+    ascii: 82,
+    code: 533,
+    label: 'R',
   },
   {
-    "ascii": 83,
-    "code": 534,
-    "label": "S"
+    ascii: 83,
+    code: 534,
+    label: 'S',
   },
   {
-    "ascii": 84,
-    "code": 535,
-    "label": "T"
+    ascii: 84,
+    code: 535,
+    label: 'T',
   },
   {
-    "ascii": 85,
-    "code": 536,
-    "label": "U"
+    ascii: 85,
+    code: 536,
+    label: 'U',
   },
   {
-    "ascii": 86,
-    "code": 537,
-    "label": "V"
+    ascii: 86,
+    code: 537,
+    label: 'V',
   },
   {
-    "ascii": 87,
-    "code": 538,
-    "label": "W"
+    ascii: 87,
+    code: 538,
+    label: 'W',
   },
   {
-    "ascii": 88,
-    "code": 539,
-    "label": "X"
+    ascii: 88,
+    code: 539,
+    label: 'X',
   },
   {
-    "ascii": 89,
-    "code": 540,
-    "label": "Y"
+    ascii: 89,
+    code: 540,
+    label: 'Y',
   },
   {
-    "ascii": 90,
-    "code": 541,
-    "label": "Z"
+    ascii: 90,
+    code: 541,
+    label: 'Z',
   },
   {
-    "ascii": 91,
-    "code": 47,
-    "label": "è"
+    ascii: 91,
+    code: 47,
+    label: 'è',
   },
   {
-    "ascii": 92,
-    "code": 100,
-    "label": "(backslash, not physically present)"
+    ascii: 92,
+    code: 100,
+    label: '(backslash, not physically present)',
   },
   {
-    "ascii": 93,
-    "code": 48,
-    "label": "+"
+    ascii: 93,
+    code: 48,
+    label: '+',
   },
   {
-    "ascii": 94,
-    "code": 558,
-    "label": "^"
+    ascii: 94,
+    code: 558,
+    label: '^',
   },
   {
-    "ascii": 95,
-    "code": 568,
-    "label": "_"
+    ascii: 95,
+    code: 568,
+    label: '_',
   },
   {
-    "ascii": 96,
-    "code": 100,
-    "label": "(backslash, not physically present)"
+    ascii: 96,
+    code: 100,
+    label: '(backslash, not physically present)',
   },
   {
-    "ascii": 97,
-    "code": 4,
-    "label": "a"
+    ascii: 97,
+    code: 4,
+    label: 'a',
   },
   {
-    "ascii": 98,
-    "code": 5,
-    "label": "b"
+    ascii: 98,
+    code: 5,
+    label: 'b',
   },
   {
-    "ascii": 99,
-    "code": 6,
-    "label": "c"
+    ascii: 99,
+    code: 6,
+    label: 'c',
   },
   {
-    "ascii": 100,
-    "code": 7,
-    "label": "d"
+    ascii: 100,
+    code: 7,
+    label: 'd',
   },
   {
-    "ascii": 101,
-    "code": 8,
-    "label": "e"
+    ascii: 101,
+    code: 8,
+    label: 'e',
   },
   {
-    "ascii": 102,
-    "code": 9,
-    "label": "f"
+    ascii: 102,
+    code: 9,
+    label: 'f',
   },
   {
-    "ascii": 103,
-    "code": 10,
-    "label": "g"
+    ascii: 103,
+    code: 10,
+    label: 'g',
   },
   {
-    "ascii": 104,
-    "code": 11,
-    "label": "h"
+    ascii: 104,
+    code: 11,
+    label: 'h',
   },
   {
-    "ascii": 105,
-    "code": 12,
-    "label": "i"
+    ascii: 105,
+    code: 12,
+    label: 'i',
   },
   {
-    "ascii": 106,
-    "code": 13,
-    "label": "j"
+    ascii: 106,
+    code: 13,
+    label: 'j',
   },
   {
-    "ascii": 107,
-    "code": 14,
-    "label": "k"
+    ascii: 107,
+    code: 14,
+    label: 'k',
   },
   {
-    "ascii": 108,
-    "code": 15,
-    "label": "l"
+    ascii: 108,
+    code: 15,
+    label: 'l',
   },
   {
-    "ascii": 109,
-    "code": 16,
-    "label": "m"
+    ascii: 109,
+    code: 16,
+    label: 'm',
   },
   {
-    "ascii": 110,
-    "code": 17,
-    "label": "n"
+    ascii: 110,
+    code: 17,
+    label: 'n',
   },
   {
-    "ascii": 111,
-    "code": 18,
-    "label": "o"
+    ascii: 111,
+    code: 18,
+    label: 'o',
   },
   {
-    "ascii": 112,
-    "code": 19,
-    "label": "p"
+    ascii: 112,
+    code: 19,
+    label: 'p',
   },
   {
-    "ascii": 113,
-    "code": 20,
-    "label": "q"
+    ascii: 113,
+    code: 20,
+    label: 'q',
   },
   {
-    "ascii": 114,
-    "code": 21,
-    "label": "r"
+    ascii: 114,
+    code: 21,
+    label: 'r',
   },
   {
-    "ascii": 115,
-    "code": 22,
-    "label": "s"
+    ascii: 115,
+    code: 22,
+    label: 's',
   },
   {
-    "ascii": 116,
-    "code": 23,
-    "label": "t"
+    ascii: 116,
+    code: 23,
+    label: 't',
   },
   {
-    "ascii": 117,
-    "code": 24,
-    "label": "u"
+    ascii: 117,
+    code: 24,
+    label: 'u',
   },
   {
-    "ascii": 118,
-    "code": 25,
-    "label": "v"
+    ascii: 118,
+    code: 25,
+    label: 'v',
   },
   {
-    "ascii": 119,
-    "code": 26,
-    "label": "w"
+    ascii: 119,
+    code: 26,
+    label: 'w',
   },
   {
-    "ascii": 120,
-    "code": 27,
-    "label": "x"
+    ascii: 120,
+    code: 27,
+    label: 'x',
   },
   {
-    "ascii": 121,
-    "code": 28,
-    "label": "y"
+    ascii: 121,
+    code: 28,
+    label: 'y',
   },
   {
-    "ascii": 122,
-    "code": 29,
-    "label": "z"
+    ascii: 122,
+    code: 29,
+    label: 'z',
   },
   {
-    "ascii": 123,
-    "code": 559,
-    "label": "é"
+    ascii: 123,
+    code: 559,
+    label: 'é',
   },
   {
-    "ascii": 124,
-    "code": 612,
-    "label": "| (not physically present)"
+    ascii: 124,
+    code: 612,
+    label: '| (not physically present)',
   },
   {
-    "ascii": 125,
-    "code": 560,
-    "label": "*"
+    ascii: 125,
+    code: 560,
+    label: '*',
   },
   {
-    "ascii": 126,
-    "code": 34,
-    "label": "5"
+    ascii: 126,
+    code: 34,
+    label: '5',
   },
   {
-    "ascii": 127,
-    "code": 76,
-    "label": "del"
-  }
+    ascii: 127,
+    code: 76,
+    label: 'del',
+  },
 ];
-    

--- a/src/services/labellang/AsciiLabelItalian_osx_iso.ts
+++ b/src/services/labellang/AsciiLabelItalian_osx_iso.ts
@@ -1,645 +1,644 @@
 import { AsciiLabel } from './AsciiLabel';
-        
+
 export const AsciiLabelItalian_osx_iso: AsciiLabel[] = [
   {
-    "ascii": 0,
-    "code": 0,
-    "label": ""
+    ascii: 0,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 1,
-    "code": 0,
-    "label": ""
+    ascii: 1,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 2,
-    "code": 0,
-    "label": ""
+    ascii: 2,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 3,
-    "code": 0,
-    "label": ""
+    ascii: 3,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 4,
-    "code": 0,
-    "label": ""
+    ascii: 4,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 5,
-    "code": 0,
-    "label": ""
+    ascii: 5,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 6,
-    "code": 0,
-    "label": ""
+    ascii: 6,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 7,
-    "code": 0,
-    "label": ""
+    ascii: 7,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 8,
-    "code": 42,
-    "label": "back space"
+    ascii: 8,
+    code: 42,
+    label: 'back space',
   },
   {
-    "ascii": 9,
-    "code": 43,
-    "label": "tab"
+    ascii: 9,
+    code: 43,
+    label: 'tab',
   },
   {
-    "ascii": 10,
-    "code": 40,
-    "label": "enter"
+    ascii: 10,
+    code: 40,
+    label: 'enter',
   },
   {
-    "ascii": 11,
-    "code": 0,
-    "label": ""
+    ascii: 11,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 12,
-    "code": 0,
-    "label": ""
+    ascii: 12,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 13,
-    "code": 0,
-    "label": ""
+    ascii: 13,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 14,
-    "code": 0,
-    "label": ""
+    ascii: 14,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 15,
-    "code": 0,
-    "label": ""
+    ascii: 15,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 16,
-    "code": 0,
-    "label": ""
+    ascii: 16,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 17,
-    "code": 0,
-    "label": ""
+    ascii: 17,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 18,
-    "code": 0,
-    "label": ""
+    ascii: 18,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 19,
-    "code": 0,
-    "label": ""
+    ascii: 19,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 20,
-    "code": 0,
-    "label": ""
+    ascii: 20,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 21,
-    "code": 0,
-    "label": ""
+    ascii: 21,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 22,
-    "code": 0,
-    "label": ""
+    ascii: 22,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 23,
-    "code": 0,
-    "label": ""
+    ascii: 23,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 24,
-    "code": 0,
-    "label": ""
+    ascii: 24,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 25,
-    "code": 0,
-    "label": ""
+    ascii: 25,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 26,
-    "code": 0,
-    "label": ""
+    ascii: 26,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 27,
-    "code": 41,
-    "label": "esc"
+    ascii: 27,
+    code: 41,
+    label: 'esc',
   },
   {
-    "ascii": 28,
-    "code": 0,
-    "label": ""
+    ascii: 28,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 29,
-    "code": 0,
-    "label": ""
+    ascii: 29,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 30,
-    "code": 0,
-    "label": ""
+    ascii: 30,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 31,
-    "code": 0,
-    "label": ""
+    ascii: 31,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 32,
-    "code": 44,
-    "label": "space"
+    ascii: 32,
+    code: 44,
+    label: 'space',
   },
   {
-    "ascii": 33,
-    "code": 542,
-    "label": "!"
+    ascii: 33,
+    code: 542,
+    label: '!',
   },
   {
-    "ascii": 34,
-    "code": 543,
-    "label": "\""
+    ascii: 34,
+    code: 543,
+    label: '"',
   },
   {
-    "ascii": 35,
-    "code": 52,
-    "label": "à"
+    ascii: 35,
+    code: 52,
+    label: 'à',
   },
   {
-    "ascii": 36,
-    "code": 545,
-    "label": "$"
+    ascii: 36,
+    code: 545,
+    label: '$',
   },
   {
-    "ascii": 37,
-    "code": 546,
-    "label": "%"
+    ascii: 37,
+    code: 546,
+    label: '%',
   },
   {
-    "ascii": 38,
-    "code": 547,
-    "label": "&"
+    ascii: 38,
+    code: 547,
+    label: '&',
   },
   {
-    "ascii": 39,
-    "code": 45,
-    "label": "'"
+    ascii: 39,
+    code: 45,
+    label: "'",
   },
   {
-    "ascii": 40,
-    "code": 549,
-    "label": "("
+    ascii: 40,
+    code: 549,
+    label: '(',
   },
   {
-    "ascii": 41,
-    "code": 550,
-    "label": ")"
+    ascii: 41,
+    code: 550,
+    label: ')',
   },
   {
-    "ascii": 42,
-    "code": 560,
-    "label": "*"
+    ascii: 42,
+    code: 560,
+    label: '*',
   },
   {
-    "ascii": 43,
-    "code": 48,
-    "label": "+"
+    ascii: 43,
+    code: 48,
+    label: '+',
   },
   {
-    "ascii": 44,
-    "code": 54,
-    "label": ","
+    ascii: 44,
+    code: 54,
+    label: ',',
   },
   {
-    "ascii": 45,
-    "code": 56,
-    "label": "-"
+    ascii: 45,
+    code: 56,
+    label: '-',
   },
   {
-    "ascii": 46,
-    "code": 55,
-    "label": "."
+    ascii: 46,
+    code: 55,
+    label: '.',
   },
   {
-    "ascii": 47,
-    "code": 548,
-    "label": "/"
+    ascii: 47,
+    code: 548,
+    label: '/',
   },
   {
-    "ascii": 48,
-    "code": 39,
-    "label": "0"
+    ascii: 48,
+    code: 39,
+    label: '0',
   },
   {
-    "ascii": 49,
-    "code": 30,
-    "label": "1"
+    ascii: 49,
+    code: 30,
+    label: '1',
   },
   {
-    "ascii": 50,
-    "code": 31,
-    "label": "2"
+    ascii: 50,
+    code: 31,
+    label: '2',
   },
   {
-    "ascii": 51,
-    "code": 32,
-    "label": "3"
+    ascii: 51,
+    code: 32,
+    label: '3',
   },
   {
-    "ascii": 52,
-    "code": 33,
-    "label": "4"
+    ascii: 52,
+    code: 33,
+    label: '4',
   },
   {
-    "ascii": 53,
-    "code": 34,
-    "label": "5"
+    ascii: 53,
+    code: 34,
+    label: '5',
   },
   {
-    "ascii": 54,
-    "code": 35,
-    "label": "6"
+    ascii: 54,
+    code: 35,
+    label: '6',
   },
   {
-    "ascii": 55,
-    "code": 36,
-    "label": "7"
+    ascii: 55,
+    code: 36,
+    label: '7',
   },
   {
-    "ascii": 56,
-    "code": 37,
-    "label": "8"
+    ascii: 56,
+    code: 37,
+    label: '8',
   },
   {
-    "ascii": 57,
-    "code": 38,
-    "label": "9"
+    ascii: 57,
+    code: 38,
+    label: '9',
   },
   {
-    "ascii": 58,
-    "code": 567,
-    "label": ":"
+    ascii: 58,
+    code: 567,
+    label: ':',
   },
   {
-    "ascii": 59,
-    "code": 566,
-    "label": ";"
+    ascii: 59,
+    code: 566,
+    label: ';',
   },
   {
-    "ascii": 60,
-    "code": 100,
-    "label": "<"
+    ascii: 60,
+    code: 100,
+    label: '<',
   },
   {
-    "ascii": 61,
-    "code": 551,
-    "label": "="
+    ascii: 61,
+    code: 551,
+    label: '=',
   },
   {
-    "ascii": 62,
-    "code": 612,
-    "label": ">"
+    ascii: 62,
+    code: 612,
+    label: '>',
   },
   {
-    "ascii": 63,
-    "code": 557,
-    "label": "?"
+    ascii: 63,
+    code: 557,
+    label: '?',
   },
   {
-    "ascii": 64,
-    "code": 51,
-    "label": "ò"
+    ascii: 64,
+    code: 51,
+    label: 'ò',
   },
   {
-    "ascii": 65,
-    "code": 516,
-    "label": "A"
+    ascii: 65,
+    code: 516,
+    label: 'A',
   },
   {
-    "ascii": 66,
-    "code": 517,
-    "label": "B"
+    ascii: 66,
+    code: 517,
+    label: 'B',
   },
   {
-    "ascii": 67,
-    "code": 518,
-    "label": "C"
+    ascii: 67,
+    code: 518,
+    label: 'C',
   },
   {
-    "ascii": 68,
-    "code": 519,
-    "label": "D"
+    ascii: 68,
+    code: 519,
+    label: 'D',
   },
   {
-    "ascii": 69,
-    "code": 520,
-    "label": "E"
+    ascii: 69,
+    code: 520,
+    label: 'E',
   },
   {
-    "ascii": 70,
-    "code": 521,
-    "label": "F"
+    ascii: 70,
+    code: 521,
+    label: 'F',
   },
   {
-    "ascii": 71,
-    "code": 522,
-    "label": "G"
+    ascii: 71,
+    code: 522,
+    label: 'G',
   },
   {
-    "ascii": 72,
-    "code": 523,
-    "label": "H"
+    ascii: 72,
+    code: 523,
+    label: 'H',
   },
   {
-    "ascii": 73,
-    "code": 524,
-    "label": "I"
+    ascii: 73,
+    code: 524,
+    label: 'I',
   },
   {
-    "ascii": 74,
-    "code": 525,
-    "label": "J"
+    ascii: 74,
+    code: 525,
+    label: 'J',
   },
   {
-    "ascii": 75,
-    "code": 526,
-    "label": "K"
+    ascii: 75,
+    code: 526,
+    label: 'K',
   },
   {
-    "ascii": 76,
-    "code": 527,
-    "label": "L"
+    ascii: 76,
+    code: 527,
+    label: 'L',
   },
   {
-    "ascii": 77,
-    "code": 528,
-    "label": "M"
+    ascii: 77,
+    code: 528,
+    label: 'M',
   },
   {
-    "ascii": 78,
-    "code": 529,
-    "label": "N"
+    ascii: 78,
+    code: 529,
+    label: 'N',
   },
   {
-    "ascii": 79,
-    "code": 530,
-    "label": "O"
+    ascii: 79,
+    code: 530,
+    label: 'O',
   },
   {
-    "ascii": 80,
-    "code": 531,
-    "label": "P"
+    ascii: 80,
+    code: 531,
+    label: 'P',
   },
   {
-    "ascii": 81,
-    "code": 532,
-    "label": "Q"
+    ascii: 81,
+    code: 532,
+    label: 'Q',
   },
   {
-    "ascii": 82,
-    "code": 533,
-    "label": "R"
+    ascii: 82,
+    code: 533,
+    label: 'R',
   },
   {
-    "ascii": 83,
-    "code": 534,
-    "label": "S"
+    ascii: 83,
+    code: 534,
+    label: 'S',
   },
   {
-    "ascii": 84,
-    "code": 535,
-    "label": "T"
+    ascii: 84,
+    code: 535,
+    label: 'T',
   },
   {
-    "ascii": 85,
-    "code": 536,
-    "label": "U"
+    ascii: 85,
+    code: 536,
+    label: 'U',
   },
   {
-    "ascii": 86,
-    "code": 537,
-    "label": "V"
+    ascii: 86,
+    code: 537,
+    label: 'V',
   },
   {
-    "ascii": 87,
-    "code": 538,
-    "label": "W"
+    ascii: 87,
+    code: 538,
+    label: 'W',
   },
   {
-    "ascii": 88,
-    "code": 539,
-    "label": "X"
+    ascii: 88,
+    code: 539,
+    label: 'X',
   },
   {
-    "ascii": 89,
-    "code": 540,
-    "label": "Y"
+    ascii: 89,
+    code: 540,
+    label: 'Y',
   },
   {
-    "ascii": 90,
-    "code": 541,
-    "label": "Z"
+    ascii: 90,
+    code: 541,
+    label: 'Z',
   },
   {
-    "ascii": 91,
-    "code": 47,
-    "label": "è"
+    ascii: 91,
+    code: 47,
+    label: 'è',
   },
   {
-    "ascii": 92,
-    "code": 53,
-    "label": "(backslash)"
+    ascii: 92,
+    code: 53,
+    label: '(backslash)',
   },
   {
-    "ascii": 93,
-    "code": 48,
-    "label": "+"
+    ascii: 93,
+    code: 48,
+    label: '+',
   },
   {
-    "ascii": 94,
-    "code": 558,
-    "label": "^"
+    ascii: 94,
+    code: 558,
+    label: '^',
   },
   {
-    "ascii": 95,
-    "code": 568,
-    "label": "_"
+    ascii: 95,
+    code: 568,
+    label: '_',
   },
   {
-    "ascii": 96,
-    "code": 53,
-    "label": "(backslash)"
+    ascii: 96,
+    code: 53,
+    label: '(backslash)',
   },
   {
-    "ascii": 97,
-    "code": 4,
-    "label": "a"
+    ascii: 97,
+    code: 4,
+    label: 'a',
   },
   {
-    "ascii": 98,
-    "code": 5,
-    "label": "b"
+    ascii: 98,
+    code: 5,
+    label: 'b',
   },
   {
-    "ascii": 99,
-    "code": 6,
-    "label": "c"
+    ascii: 99,
+    code: 6,
+    label: 'c',
   },
   {
-    "ascii": 100,
-    "code": 7,
-    "label": "d"
+    ascii: 100,
+    code: 7,
+    label: 'd',
   },
   {
-    "ascii": 101,
-    "code": 8,
-    "label": "e"
+    ascii: 101,
+    code: 8,
+    label: 'e',
   },
   {
-    "ascii": 102,
-    "code": 9,
-    "label": "f"
+    ascii: 102,
+    code: 9,
+    label: 'f',
   },
   {
-    "ascii": 103,
-    "code": 10,
-    "label": "g"
+    ascii: 103,
+    code: 10,
+    label: 'g',
   },
   {
-    "ascii": 104,
-    "code": 11,
-    "label": "h"
+    ascii: 104,
+    code: 11,
+    label: 'h',
   },
   {
-    "ascii": 105,
-    "code": 12,
-    "label": "i"
+    ascii: 105,
+    code: 12,
+    label: 'i',
   },
   {
-    "ascii": 106,
-    "code": 13,
-    "label": "j"
+    ascii: 106,
+    code: 13,
+    label: 'j',
   },
   {
-    "ascii": 107,
-    "code": 14,
-    "label": "k"
+    ascii: 107,
+    code: 14,
+    label: 'k',
   },
   {
-    "ascii": 108,
-    "code": 15,
-    "label": "l"
+    ascii: 108,
+    code: 15,
+    label: 'l',
   },
   {
-    "ascii": 109,
-    "code": 16,
-    "label": "m"
+    ascii: 109,
+    code: 16,
+    label: 'm',
   },
   {
-    "ascii": 110,
-    "code": 17,
-    "label": "n"
+    ascii: 110,
+    code: 17,
+    label: 'n',
   },
   {
-    "ascii": 111,
-    "code": 18,
-    "label": "o"
+    ascii: 111,
+    code: 18,
+    label: 'o',
   },
   {
-    "ascii": 112,
-    "code": 19,
-    "label": "p"
+    ascii: 112,
+    code: 19,
+    label: 'p',
   },
   {
-    "ascii": 113,
-    "code": 20,
-    "label": "q"
+    ascii: 113,
+    code: 20,
+    label: 'q',
   },
   {
-    "ascii": 114,
-    "code": 21,
-    "label": "r"
+    ascii: 114,
+    code: 21,
+    label: 'r',
   },
   {
-    "ascii": 115,
-    "code": 22,
-    "label": "s"
+    ascii: 115,
+    code: 22,
+    label: 's',
   },
   {
-    "ascii": 116,
-    "code": 23,
-    "label": "t"
+    ascii: 116,
+    code: 23,
+    label: 't',
   },
   {
-    "ascii": 117,
-    "code": 24,
-    "label": "u"
+    ascii: 117,
+    code: 24,
+    label: 'u',
   },
   {
-    "ascii": 118,
-    "code": 25,
-    "label": "v"
+    ascii: 118,
+    code: 25,
+    label: 'v',
   },
   {
-    "ascii": 119,
-    "code": 26,
-    "label": "w"
+    ascii: 119,
+    code: 26,
+    label: 'w',
   },
   {
-    "ascii": 120,
-    "code": 27,
-    "label": "x"
+    ascii: 120,
+    code: 27,
+    label: 'x',
   },
   {
-    "ascii": 121,
-    "code": 28,
-    "label": "y"
+    ascii: 121,
+    code: 28,
+    label: 'y',
   },
   {
-    "ascii": 122,
-    "code": 29,
-    "label": "z"
+    ascii: 122,
+    code: 29,
+    label: 'z',
   },
   {
-    "ascii": 123,
-    "code": 559,
-    "label": "é"
+    ascii: 123,
+    code: 559,
+    label: 'é',
   },
   {
-    "ascii": 124,
-    "code": 565,
-    "label": "|"
+    ascii: 124,
+    code: 565,
+    label: '|',
   },
   {
-    "ascii": 125,
-    "code": 560,
-    "label": "*"
+    ascii: 125,
+    code: 560,
+    label: '*',
   },
   {
-    "ascii": 126,
-    "code": 34,
-    "label": "5"
+    ascii: 126,
+    code: 34,
+    label: '5',
   },
   {
-    "ascii": 127,
-    "code": 76,
-    "label": "del"
-  }
+    ascii: 127,
+    code: 76,
+    label: 'del',
+  },
 ];
-    

--- a/src/services/labellang/AsciiLabelJp.ts
+++ b/src/services/labellang/AsciiLabelJp.ts
@@ -1,645 +1,644 @@
 import { AsciiLabel } from './AsciiLabel';
-        
+
 export const AsciiLabelJp: AsciiLabel[] = [
   {
-    "ascii": 0,
-    "code": 0,
-    "label": ""
+    ascii: 0,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 1,
-    "code": 0,
-    "label": ""
+    ascii: 1,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 2,
-    "code": 0,
-    "label": ""
+    ascii: 2,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 3,
-    "code": 0,
-    "label": ""
+    ascii: 3,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 4,
-    "code": 0,
-    "label": ""
+    ascii: 4,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 5,
-    "code": 0,
-    "label": ""
+    ascii: 5,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 6,
-    "code": 0,
-    "label": ""
+    ascii: 6,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 7,
-    "code": 0,
-    "label": ""
+    ascii: 7,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 8,
-    "code": 42,
-    "label": "back space"
+    ascii: 8,
+    code: 42,
+    label: 'back space',
   },
   {
-    "ascii": 9,
-    "code": 43,
-    "label": "tab"
+    ascii: 9,
+    code: 43,
+    label: 'tab',
   },
   {
-    "ascii": 10,
-    "code": 40,
-    "label": "enter"
+    ascii: 10,
+    code: 40,
+    label: 'enter',
   },
   {
-    "ascii": 11,
-    "code": 0,
-    "label": ""
+    ascii: 11,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 12,
-    "code": 0,
-    "label": ""
+    ascii: 12,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 13,
-    "code": 0,
-    "label": ""
+    ascii: 13,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 14,
-    "code": 0,
-    "label": ""
+    ascii: 14,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 15,
-    "code": 0,
-    "label": ""
+    ascii: 15,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 16,
-    "code": 0,
-    "label": ""
+    ascii: 16,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 17,
-    "code": 0,
-    "label": ""
+    ascii: 17,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 18,
-    "code": 0,
-    "label": ""
+    ascii: 18,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 19,
-    "code": 0,
-    "label": ""
+    ascii: 19,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 20,
-    "code": 0,
-    "label": ""
+    ascii: 20,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 21,
-    "code": 0,
-    "label": ""
+    ascii: 21,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 22,
-    "code": 0,
-    "label": ""
+    ascii: 22,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 23,
-    "code": 0,
-    "label": ""
+    ascii: 23,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 24,
-    "code": 0,
-    "label": ""
+    ascii: 24,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 25,
-    "code": 0,
-    "label": ""
+    ascii: 25,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 26,
-    "code": 0,
-    "label": ""
+    ascii: 26,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 27,
-    "code": 41,
-    "label": "esc"
+    ascii: 27,
+    code: 41,
+    label: 'esc',
   },
   {
-    "ascii": 28,
-    "code": 0,
-    "label": ""
+    ascii: 28,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 29,
-    "code": 0,
-    "label": ""
+    ascii: 29,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 30,
-    "code": 0,
-    "label": ""
+    ascii: 30,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 31,
-    "code": 0,
-    "label": ""
+    ascii: 31,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 32,
-    "code": 44,
-    "label": "space"
+    ascii: 32,
+    code: 44,
+    label: 'space',
   },
   {
-    "ascii": 33,
-    "code": 542,
-    "label": "!"
+    ascii: 33,
+    code: 542,
+    label: '!',
   },
   {
-    "ascii": 34,
-    "code": 543,
-    "label": "\""
+    ascii: 34,
+    code: 543,
+    label: '"',
   },
   {
-    "ascii": 35,
-    "code": 544,
-    "label": "#"
+    ascii: 35,
+    code: 544,
+    label: '#',
   },
   {
-    "ascii": 36,
-    "code": 545,
-    "label": "$"
+    ascii: 36,
+    code: 545,
+    label: '$',
   },
   {
-    "ascii": 37,
-    "code": 546,
-    "label": "%"
+    ascii: 37,
+    code: 546,
+    label: '%',
   },
   {
-    "ascii": 38,
-    "code": 547,
-    "label": "&"
+    ascii: 38,
+    code: 547,
+    label: '&',
   },
   {
-    "ascii": 39,
-    "code": 548,
-    "label": "'"
+    ascii: 39,
+    code: 548,
+    label: "'",
   },
   {
-    "ascii": 40,
-    "code": 549,
-    "label": "("
+    ascii: 40,
+    code: 549,
+    label: '(',
   },
   {
-    "ascii": 41,
-    "code": 550,
-    "label": ")"
+    ascii: 41,
+    code: 550,
+    label: ')',
   },
   {
-    "ascii": 42,
-    "code": 564,
-    "label": "*"
+    ascii: 42,
+    code: 564,
+    label: '*',
   },
   {
-    "ascii": 43,
-    "code": 563,
-    "label": "+"
+    ascii: 43,
+    code: 563,
+    label: '+',
   },
   {
-    "ascii": 44,
-    "code": 54,
-    "label": ","
+    ascii: 44,
+    code: 54,
+    label: ',',
   },
   {
-    "ascii": 45,
-    "code": 45,
-    "label": "-"
+    ascii: 45,
+    code: 45,
+    label: '-',
   },
   {
-    "ascii": 46,
-    "code": 55,
-    "label": "."
+    ascii: 46,
+    code: 55,
+    label: '.',
   },
   {
-    "ascii": 47,
-    "code": 56,
-    "label": "/"
+    ascii: 47,
+    code: 56,
+    label: '/',
   },
   {
-    "ascii": 48,
-    "code": 39,
-    "label": "0"
+    ascii: 48,
+    code: 39,
+    label: '0',
   },
   {
-    "ascii": 49,
-    "code": 30,
-    "label": "1"
+    ascii: 49,
+    code: 30,
+    label: '1',
   },
   {
-    "ascii": 50,
-    "code": 31,
-    "label": "2"
+    ascii: 50,
+    code: 31,
+    label: '2',
   },
   {
-    "ascii": 51,
-    "code": 32,
-    "label": "3"
+    ascii: 51,
+    code: 32,
+    label: '3',
   },
   {
-    "ascii": 52,
-    "code": 33,
-    "label": "4"
+    ascii: 52,
+    code: 33,
+    label: '4',
   },
   {
-    "ascii": 53,
-    "code": 34,
-    "label": "5"
+    ascii: 53,
+    code: 34,
+    label: '5',
   },
   {
-    "ascii": 54,
-    "code": 35,
-    "label": "6"
+    ascii: 54,
+    code: 35,
+    label: '6',
   },
   {
-    "ascii": 55,
-    "code": 36,
-    "label": "7"
+    ascii: 55,
+    code: 36,
+    label: '7',
   },
   {
-    "ascii": 56,
-    "code": 37,
-    "label": "8"
+    ascii: 56,
+    code: 37,
+    label: '8',
   },
   {
-    "ascii": 57,
-    "code": 38,
-    "label": "9"
+    ascii: 57,
+    code: 38,
+    label: '9',
   },
   {
-    "ascii": 58,
-    "code": 52,
-    "label": ":"
+    ascii: 58,
+    code: 52,
+    label: ':',
   },
   {
-    "ascii": 59,
-    "code": 51,
-    "label": ";"
+    ascii: 59,
+    code: 51,
+    label: ';',
   },
   {
-    "ascii": 60,
-    "code": 566,
-    "label": "<"
+    ascii: 60,
+    code: 566,
+    label: '<',
   },
   {
-    "ascii": 61,
-    "code": 557,
-    "label": "="
+    ascii: 61,
+    code: 557,
+    label: '=',
   },
   {
-    "ascii": 62,
-    "code": 567,
-    "label": ">"
+    ascii: 62,
+    code: 567,
+    label: '>',
   },
   {
-    "ascii": 63,
-    "code": 568,
-    "label": "?"
+    ascii: 63,
+    code: 568,
+    label: '?',
   },
   {
-    "ascii": 64,
-    "code": 47,
-    "label": "@"
+    ascii: 64,
+    code: 47,
+    label: '@',
   },
   {
-    "ascii": 65,
-    "code": 516,
-    "label": "A"
+    ascii: 65,
+    code: 516,
+    label: 'A',
   },
   {
-    "ascii": 66,
-    "code": 517,
-    "label": "B"
+    ascii: 66,
+    code: 517,
+    label: 'B',
   },
   {
-    "ascii": 67,
-    "code": 518,
-    "label": "C"
+    ascii: 67,
+    code: 518,
+    label: 'C',
   },
   {
-    "ascii": 68,
-    "code": 519,
-    "label": "D"
+    ascii: 68,
+    code: 519,
+    label: 'D',
   },
   {
-    "ascii": 69,
-    "code": 520,
-    "label": "E"
+    ascii: 69,
+    code: 520,
+    label: 'E',
   },
   {
-    "ascii": 70,
-    "code": 521,
-    "label": "F"
+    ascii: 70,
+    code: 521,
+    label: 'F',
   },
   {
-    "ascii": 71,
-    "code": 522,
-    "label": "G"
+    ascii: 71,
+    code: 522,
+    label: 'G',
   },
   {
-    "ascii": 72,
-    "code": 523,
-    "label": "H"
+    ascii: 72,
+    code: 523,
+    label: 'H',
   },
   {
-    "ascii": 73,
-    "code": 524,
-    "label": "I"
+    ascii: 73,
+    code: 524,
+    label: 'I',
   },
   {
-    "ascii": 74,
-    "code": 525,
-    "label": "J"
+    ascii: 74,
+    code: 525,
+    label: 'J',
   },
   {
-    "ascii": 75,
-    "code": 526,
-    "label": "K"
+    ascii: 75,
+    code: 526,
+    label: 'K',
   },
   {
-    "ascii": 76,
-    "code": 527,
-    "label": "L"
+    ascii: 76,
+    code: 527,
+    label: 'L',
   },
   {
-    "ascii": 77,
-    "code": 528,
-    "label": "M"
+    ascii: 77,
+    code: 528,
+    label: 'M',
   },
   {
-    "ascii": 78,
-    "code": 529,
-    "label": "N"
+    ascii: 78,
+    code: 529,
+    label: 'N',
   },
   {
-    "ascii": 79,
-    "code": 530,
-    "label": "O"
+    ascii: 79,
+    code: 530,
+    label: 'O',
   },
   {
-    "ascii": 80,
-    "code": 531,
-    "label": "P"
+    ascii: 80,
+    code: 531,
+    label: 'P',
   },
   {
-    "ascii": 81,
-    "code": 532,
-    "label": "Q"
+    ascii: 81,
+    code: 532,
+    label: 'Q',
   },
   {
-    "ascii": 82,
-    "code": 533,
-    "label": "R"
+    ascii: 82,
+    code: 533,
+    label: 'R',
   },
   {
-    "ascii": 83,
-    "code": 534,
-    "label": "S"
+    ascii: 83,
+    code: 534,
+    label: 'S',
   },
   {
-    "ascii": 84,
-    "code": 535,
-    "label": "T"
+    ascii: 84,
+    code: 535,
+    label: 'T',
   },
   {
-    "ascii": 85,
-    "code": 536,
-    "label": "U"
+    ascii: 85,
+    code: 536,
+    label: 'U',
   },
   {
-    "ascii": 86,
-    "code": 537,
-    "label": "V"
+    ascii: 86,
+    code: 537,
+    label: 'V',
   },
   {
-    "ascii": 87,
-    "code": 538,
-    "label": "W"
+    ascii: 87,
+    code: 538,
+    label: 'W',
   },
   {
-    "ascii": 88,
-    "code": 539,
-    "label": "X"
+    ascii: 88,
+    code: 539,
+    label: 'X',
   },
   {
-    "ascii": 89,
-    "code": 540,
-    "label": "Y"
+    ascii: 89,
+    code: 540,
+    label: 'Y',
   },
   {
-    "ascii": 90,
-    "code": 541,
-    "label": "Z"
+    ascii: 90,
+    code: 541,
+    label: 'Z',
   },
   {
-    "ascii": 91,
-    "code": 48,
-    "label": "["
+    ascii: 91,
+    code: 48,
+    label: '[',
   },
   {
-    "ascii": 92,
-    "code": 135,
-    "label": "(backslash)"
+    ascii: 92,
+    code: 135,
+    label: '(backslash)',
   },
   {
-    "ascii": 93,
-    "code": 50,
-    "label": "]"
+    ascii: 93,
+    code: 50,
+    label: ']',
   },
   {
-    "ascii": 94,
-    "code": 46,
-    "label": "^"
+    ascii: 94,
+    code: 46,
+    label: '^',
   },
   {
-    "ascii": 95,
-    "code": 647,
-    "label": "_"
+    ascii: 95,
+    code: 647,
+    label: '_',
   },
   {
-    "ascii": 96,
-    "code": 559,
-    "label": "`"
+    ascii: 96,
+    code: 559,
+    label: '`',
   },
   {
-    "ascii": 97,
-    "code": 4,
-    "label": "a"
+    ascii: 97,
+    code: 4,
+    label: 'a',
   },
   {
-    "ascii": 98,
-    "code": 5,
-    "label": "b"
+    ascii: 98,
+    code: 5,
+    label: 'b',
   },
   {
-    "ascii": 99,
-    "code": 6,
-    "label": "c"
+    ascii: 99,
+    code: 6,
+    label: 'c',
   },
   {
-    "ascii": 100,
-    "code": 7,
-    "label": "d"
+    ascii: 100,
+    code: 7,
+    label: 'd',
   },
   {
-    "ascii": 101,
-    "code": 8,
-    "label": "e"
+    ascii: 101,
+    code: 8,
+    label: 'e',
   },
   {
-    "ascii": 102,
-    "code": 9,
-    "label": "f"
+    ascii: 102,
+    code: 9,
+    label: 'f',
   },
   {
-    "ascii": 103,
-    "code": 10,
-    "label": "g"
+    ascii: 103,
+    code: 10,
+    label: 'g',
   },
   {
-    "ascii": 104,
-    "code": 11,
-    "label": "h"
+    ascii: 104,
+    code: 11,
+    label: 'h',
   },
   {
-    "ascii": 105,
-    "code": 12,
-    "label": "i"
+    ascii: 105,
+    code: 12,
+    label: 'i',
   },
   {
-    "ascii": 106,
-    "code": 13,
-    "label": "j"
+    ascii: 106,
+    code: 13,
+    label: 'j',
   },
   {
-    "ascii": 107,
-    "code": 14,
-    "label": "k"
+    ascii: 107,
+    code: 14,
+    label: 'k',
   },
   {
-    "ascii": 108,
-    "code": 15,
-    "label": "l"
+    ascii: 108,
+    code: 15,
+    label: 'l',
   },
   {
-    "ascii": 109,
-    "code": 16,
-    "label": "m"
+    ascii: 109,
+    code: 16,
+    label: 'm',
   },
   {
-    "ascii": 110,
-    "code": 17,
-    "label": "n"
+    ascii: 110,
+    code: 17,
+    label: 'n',
   },
   {
-    "ascii": 111,
-    "code": 18,
-    "label": "o"
+    ascii: 111,
+    code: 18,
+    label: 'o',
   },
   {
-    "ascii": 112,
-    "code": 19,
-    "label": "p"
+    ascii: 112,
+    code: 19,
+    label: 'p',
   },
   {
-    "ascii": 113,
-    "code": 20,
-    "label": "q"
+    ascii: 113,
+    code: 20,
+    label: 'q',
   },
   {
-    "ascii": 114,
-    "code": 21,
-    "label": "r"
+    ascii: 114,
+    code: 21,
+    label: 'r',
   },
   {
-    "ascii": 115,
-    "code": 22,
-    "label": "s"
+    ascii: 115,
+    code: 22,
+    label: 's',
   },
   {
-    "ascii": 116,
-    "code": 23,
-    "label": "t"
+    ascii: 116,
+    code: 23,
+    label: 't',
   },
   {
-    "ascii": 117,
-    "code": 24,
-    "label": "u"
+    ascii: 117,
+    code: 24,
+    label: 'u',
   },
   {
-    "ascii": 118,
-    "code": 25,
-    "label": "v"
+    ascii: 118,
+    code: 25,
+    label: 'v',
   },
   {
-    "ascii": 119,
-    "code": 26,
-    "label": "w"
+    ascii: 119,
+    code: 26,
+    label: 'w',
   },
   {
-    "ascii": 120,
-    "code": 27,
-    "label": "x"
+    ascii: 120,
+    code: 27,
+    label: 'x',
   },
   {
-    "ascii": 121,
-    "code": 28,
-    "label": "y"
+    ascii: 121,
+    code: 28,
+    label: 'y',
   },
   {
-    "ascii": 122,
-    "code": 29,
-    "label": "z"
+    ascii: 122,
+    code: 29,
+    label: 'z',
   },
   {
-    "ascii": 123,
-    "code": 560,
-    "label": "{"
+    ascii: 123,
+    code: 560,
+    label: '{',
   },
   {
-    "ascii": 124,
-    "code": 649,
-    "label": "|"
+    ascii: 124,
+    code: 649,
+    label: '|',
   },
   {
-    "ascii": 125,
-    "code": 562,
-    "label": "}"
+    ascii: 125,
+    code: 562,
+    label: '}',
   },
   {
-    "ascii": 126,
-    "code": 558,
-    "label": "~"
+    ascii: 126,
+    code: 558,
+    label: '~',
   },
   {
-    "ascii": 127,
-    "code": 76,
-    "label": "del"
-  }
+    ascii: 127,
+    code: 76,
+    label: 'del',
+  },
 ];
-    

--- a/src/services/labellang/AsciiLabelLatvian.ts
+++ b/src/services/labellang/AsciiLabelLatvian.ts
@@ -1,645 +1,644 @@
 import { AsciiLabel } from './AsciiLabel';
-        
+
 export const AsciiLabelLatvian: AsciiLabel[] = [
   {
-    "ascii": 0,
-    "code": 0,
-    "label": ""
+    ascii: 0,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 1,
-    "code": 0,
-    "label": ""
+    ascii: 1,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 2,
-    "code": 0,
-    "label": ""
+    ascii: 2,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 3,
-    "code": 0,
-    "label": ""
+    ascii: 3,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 4,
-    "code": 0,
-    "label": ""
+    ascii: 4,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 5,
-    "code": 0,
-    "label": ""
+    ascii: 5,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 6,
-    "code": 0,
-    "label": ""
+    ascii: 6,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 7,
-    "code": 0,
-    "label": ""
+    ascii: 7,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 8,
-    "code": 42,
-    "label": "back space"
+    ascii: 8,
+    code: 42,
+    label: 'back space',
   },
   {
-    "ascii": 9,
-    "code": 43,
-    "label": "tab"
+    ascii: 9,
+    code: 43,
+    label: 'tab',
   },
   {
-    "ascii": 10,
-    "code": 40,
-    "label": "enter"
+    ascii: 10,
+    code: 40,
+    label: 'enter',
   },
   {
-    "ascii": 11,
-    "code": 0,
-    "label": ""
+    ascii: 11,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 12,
-    "code": 0,
-    "label": ""
+    ascii: 12,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 13,
-    "code": 0,
-    "label": ""
+    ascii: 13,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 14,
-    "code": 0,
-    "label": ""
+    ascii: 14,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 15,
-    "code": 0,
-    "label": ""
+    ascii: 15,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 16,
-    "code": 0,
-    "label": ""
+    ascii: 16,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 17,
-    "code": 0,
-    "label": ""
+    ascii: 17,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 18,
-    "code": 0,
-    "label": ""
+    ascii: 18,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 19,
-    "code": 0,
-    "label": ""
+    ascii: 19,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 20,
-    "code": 0,
-    "label": ""
+    ascii: 20,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 21,
-    "code": 0,
-    "label": ""
+    ascii: 21,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 22,
-    "code": 0,
-    "label": ""
+    ascii: 22,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 23,
-    "code": 0,
-    "label": ""
+    ascii: 23,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 24,
-    "code": 0,
-    "label": ""
+    ascii: 24,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 25,
-    "code": 0,
-    "label": ""
+    ascii: 25,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 26,
-    "code": 0,
-    "label": ""
+    ascii: 26,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 27,
-    "code": 41,
-    "label": "esc"
+    ascii: 27,
+    code: 41,
+    label: 'esc',
   },
   {
-    "ascii": 28,
-    "code": 0,
-    "label": ""
+    ascii: 28,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 29,
-    "code": 0,
-    "label": ""
+    ascii: 29,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 30,
-    "code": 0,
-    "label": ""
+    ascii: 30,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 31,
-    "code": 0,
-    "label": ""
+    ascii: 31,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 32,
-    "code": 44,
-    "label": "space"
+    ascii: 32,
+    code: 44,
+    label: 'space',
   },
   {
-    "ascii": 33,
-    "code": 30,
-    "label": "1"
+    ascii: 33,
+    code: 30,
+    label: '1',
   },
   {
-    "ascii": 34,
-    "code": 52,
-    "label": "' (dead)"
+    ascii: 34,
+    code: 52,
+    label: "' (dead)",
   },
   {
-    "ascii": 35,
-    "code": 32,
-    "label": "3"
+    ascii: 35,
+    code: 32,
+    label: '3',
   },
   {
-    "ascii": 36,
-    "code": 33,
-    "label": "4"
+    ascii: 36,
+    code: 33,
+    label: '4',
   },
   {
-    "ascii": 37,
-    "code": 34,
-    "label": "5"
+    ascii: 37,
+    code: 34,
+    label: '5',
   },
   {
-    "ascii": 38,
-    "code": 36,
-    "label": "7"
+    ascii: 38,
+    code: 36,
+    label: '7',
   },
   {
-    "ascii": 39,
-    "code": 52,
-    "label": "' (dead)"
+    ascii: 39,
+    code: 52,
+    label: "' (dead)",
   },
   {
-    "ascii": 40,
-    "code": 38,
-    "label": "9"
+    ascii: 40,
+    code: 38,
+    label: '9',
   },
   {
-    "ascii": 41,
-    "code": 39,
-    "label": "0"
+    ascii: 41,
+    code: 39,
+    label: '0',
   },
   {
-    "ascii": 42,
-    "code": 37,
-    "label": "8"
+    ascii: 42,
+    code: 37,
+    label: '8',
   },
   {
-    "ascii": 43,
-    "code": 46,
-    "label": "="
+    ascii: 43,
+    code: 46,
+    label: '=',
   },
   {
-    "ascii": 44,
-    "code": 54,
-    "label": ","
+    ascii: 44,
+    code: 54,
+    label: ',',
   },
   {
-    "ascii": 45,
-    "code": 45,
-    "label": "-"
+    ascii: 45,
+    code: 45,
+    label: '-',
   },
   {
-    "ascii": 46,
-    "code": 55,
-    "label": "."
+    ascii: 46,
+    code: 55,
+    label: '.',
   },
   {
-    "ascii": 47,
-    "code": 56,
-    "label": "/"
+    ascii: 47,
+    code: 56,
+    label: '/',
   },
   {
-    "ascii": 48,
-    "code": 39,
-    "label": "0"
+    ascii: 48,
+    code: 39,
+    label: '0',
   },
   {
-    "ascii": 49,
-    "code": 30,
-    "label": "1"
+    ascii: 49,
+    code: 30,
+    label: '1',
   },
   {
-    "ascii": 50,
-    "code": 31,
-    "label": "2"
+    ascii: 50,
+    code: 31,
+    label: '2',
   },
   {
-    "ascii": 51,
-    "code": 32,
-    "label": "3"
+    ascii: 51,
+    code: 32,
+    label: '3',
   },
   {
-    "ascii": 52,
-    "code": 33,
-    "label": "4"
+    ascii: 52,
+    code: 33,
+    label: '4',
   },
   {
-    "ascii": 53,
-    "code": 34,
-    "label": "5"
+    ascii: 53,
+    code: 34,
+    label: '5',
   },
   {
-    "ascii": 54,
-    "code": 35,
-    "label": "6"
+    ascii: 54,
+    code: 35,
+    label: '6',
   },
   {
-    "ascii": 55,
-    "code": 36,
-    "label": "7"
+    ascii: 55,
+    code: 36,
+    label: '7',
   },
   {
-    "ascii": 56,
-    "code": 37,
-    "label": "8"
+    ascii: 56,
+    code: 37,
+    label: '8',
   },
   {
-    "ascii": 57,
-    "code": 38,
-    "label": "9"
+    ascii: 57,
+    code: 38,
+    label: '9',
   },
   {
-    "ascii": 58,
-    "code": 51,
-    "label": ";"
+    ascii: 58,
+    code: 51,
+    label: ';',
   },
   {
-    "ascii": 59,
-    "code": 51,
-    "label": ";"
+    ascii: 59,
+    code: 51,
+    label: ';',
   },
   {
-    "ascii": 60,
-    "code": 54,
-    "label": ","
+    ascii: 60,
+    code: 54,
+    label: ',',
   },
   {
-    "ascii": 61,
-    "code": 46,
-    "label": "="
+    ascii: 61,
+    code: 46,
+    label: '=',
   },
   {
-    "ascii": 62,
-    "code": 55,
-    "label": "."
+    ascii: 62,
+    code: 55,
+    label: '.',
   },
   {
-    "ascii": 63,
-    "code": 56,
-    "label": "/"
+    ascii: 63,
+    code: 56,
+    label: '/',
   },
   {
-    "ascii": 64,
-    "code": 31,
-    "label": "2"
+    ascii: 64,
+    code: 31,
+    label: '2',
   },
   {
-    "ascii": 65,
-    "code": 4,
-    "label": "a"
+    ascii: 65,
+    code: 4,
+    label: 'a',
   },
   {
-    "ascii": 66,
-    "code": 5,
-    "label": "b"
+    ascii: 66,
+    code: 5,
+    label: 'b',
   },
   {
-    "ascii": 67,
-    "code": 6,
-    "label": "c"
+    ascii: 67,
+    code: 6,
+    label: 'c',
   },
   {
-    "ascii": 68,
-    "code": 7,
-    "label": "d"
+    ascii: 68,
+    code: 7,
+    label: 'd',
   },
   {
-    "ascii": 69,
-    "code": 8,
-    "label": "e"
+    ascii: 69,
+    code: 8,
+    label: 'e',
   },
   {
-    "ascii": 70,
-    "code": 9,
-    "label": "f"
+    ascii: 70,
+    code: 9,
+    label: 'f',
   },
   {
-    "ascii": 71,
-    "code": 10,
-    "label": "g"
+    ascii: 71,
+    code: 10,
+    label: 'g',
   },
   {
-    "ascii": 72,
-    "code": 11,
-    "label": "h"
+    ascii: 72,
+    code: 11,
+    label: 'h',
   },
   {
-    "ascii": 73,
-    "code": 12,
-    "label": "i"
+    ascii: 73,
+    code: 12,
+    label: 'i',
   },
   {
-    "ascii": 74,
-    "code": 13,
-    "label": "j"
+    ascii: 74,
+    code: 13,
+    label: 'j',
   },
   {
-    "ascii": 75,
-    "code": 14,
-    "label": "k"
+    ascii: 75,
+    code: 14,
+    label: 'k',
   },
   {
-    "ascii": 76,
-    "code": 15,
-    "label": "l"
+    ascii: 76,
+    code: 15,
+    label: 'l',
   },
   {
-    "ascii": 77,
-    "code": 16,
-    "label": "m"
+    ascii: 77,
+    code: 16,
+    label: 'm',
   },
   {
-    "ascii": 78,
-    "code": 17,
-    "label": "n"
+    ascii: 78,
+    code: 17,
+    label: 'n',
   },
   {
-    "ascii": 79,
-    "code": 18,
-    "label": "o"
+    ascii: 79,
+    code: 18,
+    label: 'o',
   },
   {
-    "ascii": 80,
-    "code": 19,
-    "label": "p"
+    ascii: 80,
+    code: 19,
+    label: 'p',
   },
   {
-    "ascii": 81,
-    "code": 20,
-    "label": "q"
+    ascii: 81,
+    code: 20,
+    label: 'q',
   },
   {
-    "ascii": 82,
-    "code": 21,
-    "label": "r"
+    ascii: 82,
+    code: 21,
+    label: 'r',
   },
   {
-    "ascii": 83,
-    "code": 22,
-    "label": "s"
+    ascii: 83,
+    code: 22,
+    label: 's',
   },
   {
-    "ascii": 84,
-    "code": 23,
-    "label": "t"
+    ascii: 84,
+    code: 23,
+    label: 't',
   },
   {
-    "ascii": 85,
-    "code": 24,
-    "label": "u"
+    ascii: 85,
+    code: 24,
+    label: 'u',
   },
   {
-    "ascii": 86,
-    "code": 25,
-    "label": "v"
+    ascii: 86,
+    code: 25,
+    label: 'v',
   },
   {
-    "ascii": 87,
-    "code": 26,
-    "label": "w"
+    ascii: 87,
+    code: 26,
+    label: 'w',
   },
   {
-    "ascii": 88,
-    "code": 27,
-    "label": "x"
+    ascii: 88,
+    code: 27,
+    label: 'x',
   },
   {
-    "ascii": 89,
-    "code": 28,
-    "label": "y"
+    ascii: 89,
+    code: 28,
+    label: 'y',
   },
   {
-    "ascii": 90,
-    "code": 29,
-    "label": "z"
+    ascii: 90,
+    code: 29,
+    label: 'z',
   },
   {
-    "ascii": 91,
-    "code": 47,
-    "label": "["
+    ascii: 91,
+    code: 47,
+    label: '[',
   },
   {
-    "ascii": 92,
-    "code": 50,
-    "label": "(backslash)"
+    ascii: 92,
+    code: 50,
+    label: '(backslash)',
   },
   {
-    "ascii": 93,
-    "code": 48,
-    "label": "]"
+    ascii: 93,
+    code: 48,
+    label: ']',
   },
   {
-    "ascii": 94,
-    "code": 35,
-    "label": "6"
+    ascii: 94,
+    code: 35,
+    label: '6',
   },
   {
-    "ascii": 95,
-    "code": 45,
-    "label": "-"
+    ascii: 95,
+    code: 45,
+    label: '-',
   },
   {
-    "ascii": 96,
-    "code": 53,
-    "label": "`"
+    ascii: 96,
+    code: 53,
+    label: '`',
   },
   {
-    "ascii": 97,
-    "code": 4,
-    "label": "a"
+    ascii: 97,
+    code: 4,
+    label: 'a',
   },
   {
-    "ascii": 98,
-    "code": 5,
-    "label": "b"
+    ascii: 98,
+    code: 5,
+    label: 'b',
   },
   {
-    "ascii": 99,
-    "code": 6,
-    "label": "c"
+    ascii: 99,
+    code: 6,
+    label: 'c',
   },
   {
-    "ascii": 100,
-    "code": 7,
-    "label": "d"
+    ascii: 100,
+    code: 7,
+    label: 'd',
   },
   {
-    "ascii": 101,
-    "code": 8,
-    "label": "e"
+    ascii: 101,
+    code: 8,
+    label: 'e',
   },
   {
-    "ascii": 102,
-    "code": 9,
-    "label": "f"
+    ascii: 102,
+    code: 9,
+    label: 'f',
   },
   {
-    "ascii": 103,
-    "code": 10,
-    "label": "g"
+    ascii: 103,
+    code: 10,
+    label: 'g',
   },
   {
-    "ascii": 104,
-    "code": 11,
-    "label": "h"
+    ascii: 104,
+    code: 11,
+    label: 'h',
   },
   {
-    "ascii": 105,
-    "code": 12,
-    "label": "i"
+    ascii: 105,
+    code: 12,
+    label: 'i',
   },
   {
-    "ascii": 106,
-    "code": 13,
-    "label": "j"
+    ascii: 106,
+    code: 13,
+    label: 'j',
   },
   {
-    "ascii": 107,
-    "code": 14,
-    "label": "k"
+    ascii: 107,
+    code: 14,
+    label: 'k',
   },
   {
-    "ascii": 108,
-    "code": 15,
-    "label": "l"
+    ascii: 108,
+    code: 15,
+    label: 'l',
   },
   {
-    "ascii": 109,
-    "code": 16,
-    "label": "m"
+    ascii: 109,
+    code: 16,
+    label: 'm',
   },
   {
-    "ascii": 110,
-    "code": 17,
-    "label": "n"
+    ascii: 110,
+    code: 17,
+    label: 'n',
   },
   {
-    "ascii": 111,
-    "code": 18,
-    "label": "o"
+    ascii: 111,
+    code: 18,
+    label: 'o',
   },
   {
-    "ascii": 112,
-    "code": 19,
-    "label": "p"
+    ascii: 112,
+    code: 19,
+    label: 'p',
   },
   {
-    "ascii": 113,
-    "code": 20,
-    "label": "q"
+    ascii: 113,
+    code: 20,
+    label: 'q',
   },
   {
-    "ascii": 114,
-    "code": 21,
-    "label": "r"
+    ascii: 114,
+    code: 21,
+    label: 'r',
   },
   {
-    "ascii": 115,
-    "code": 22,
-    "label": "s"
+    ascii: 115,
+    code: 22,
+    label: 's',
   },
   {
-    "ascii": 116,
-    "code": 23,
-    "label": "t"
+    ascii: 116,
+    code: 23,
+    label: 't',
   },
   {
-    "ascii": 117,
-    "code": 24,
-    "label": "u"
+    ascii: 117,
+    code: 24,
+    label: 'u',
   },
   {
-    "ascii": 118,
-    "code": 25,
-    "label": "v"
+    ascii: 118,
+    code: 25,
+    label: 'v',
   },
   {
-    "ascii": 119,
-    "code": 26,
-    "label": "w"
+    ascii: 119,
+    code: 26,
+    label: 'w',
   },
   {
-    "ascii": 120,
-    "code": 27,
-    "label": "x"
+    ascii: 120,
+    code: 27,
+    label: 'x',
   },
   {
-    "ascii": 121,
-    "code": 28,
-    "label": "y"
+    ascii: 121,
+    code: 28,
+    label: 'y',
   },
   {
-    "ascii": 122,
-    "code": 29,
-    "label": "z"
+    ascii: 122,
+    code: 29,
+    label: 'z',
   },
   {
-    "ascii": 123,
-    "code": 47,
-    "label": "["
+    ascii: 123,
+    code: 47,
+    label: '[',
   },
   {
-    "ascii": 124,
-    "code": 50,
-    "label": "(backslash)"
+    ascii: 124,
+    code: 50,
+    label: '(backslash)',
   },
   {
-    "ascii": 125,
-    "code": 48,
-    "label": "]"
+    ascii: 125,
+    code: 48,
+    label: ']',
   },
   {
-    "ascii": 126,
-    "code": 53,
-    "label": "`"
+    ascii: 126,
+    code: 53,
+    label: '`',
   },
   {
-    "ascii": 127,
-    "code": 76,
-    "label": "del"
-  }
+    ascii: 127,
+    code: 76,
+    label: 'del',
+  },
 ];
-    

--- a/src/services/labellang/AsciiLabelLithuanian_azerty.ts
+++ b/src/services/labellang/AsciiLabelLithuanian_azerty.ts
@@ -1,645 +1,644 @@
 import { AsciiLabel } from './AsciiLabel';
-        
+
 export const AsciiLabelLithuanian_azerty: AsciiLabel[] = [
   {
-    "ascii": 0,
-    "code": 0,
-    "label": ""
+    ascii: 0,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 1,
-    "code": 0,
-    "label": ""
+    ascii: 1,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 2,
-    "code": 0,
-    "label": ""
+    ascii: 2,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 3,
-    "code": 0,
-    "label": ""
+    ascii: 3,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 4,
-    "code": 0,
-    "label": ""
+    ascii: 4,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 5,
-    "code": 0,
-    "label": ""
+    ascii: 5,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 6,
-    "code": 0,
-    "label": ""
+    ascii: 6,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 7,
-    "code": 0,
-    "label": ""
+    ascii: 7,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 8,
-    "code": 42,
-    "label": "back space"
+    ascii: 8,
+    code: 42,
+    label: 'back space',
   },
   {
-    "ascii": 9,
-    "code": 43,
-    "label": "tab"
+    ascii: 9,
+    code: 43,
+    label: 'tab',
   },
   {
-    "ascii": 10,
-    "code": 40,
-    "label": "enter"
+    ascii: 10,
+    code: 40,
+    label: 'enter',
   },
   {
-    "ascii": 11,
-    "code": 0,
-    "label": ""
+    ascii: 11,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 12,
-    "code": 0,
-    "label": ""
+    ascii: 12,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 13,
-    "code": 0,
-    "label": ""
+    ascii: 13,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 14,
-    "code": 0,
-    "label": ""
+    ascii: 14,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 15,
-    "code": 0,
-    "label": ""
+    ascii: 15,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 16,
-    "code": 0,
-    "label": ""
+    ascii: 16,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 17,
-    "code": 0,
-    "label": ""
+    ascii: 17,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 18,
-    "code": 0,
-    "label": ""
+    ascii: 18,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 19,
-    "code": 0,
-    "label": ""
+    ascii: 19,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 20,
-    "code": 0,
-    "label": ""
+    ascii: 20,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 21,
-    "code": 0,
-    "label": ""
+    ascii: 21,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 22,
-    "code": 0,
-    "label": ""
+    ascii: 22,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 23,
-    "code": 0,
-    "label": ""
+    ascii: 23,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 24,
-    "code": 0,
-    "label": ""
+    ascii: 24,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 25,
-    "code": 0,
-    "label": ""
+    ascii: 25,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 26,
-    "code": 0,
-    "label": ""
+    ascii: 26,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 27,
-    "code": 41,
-    "label": "esc"
+    ascii: 27,
+    code: 41,
+    label: 'esc',
   },
   {
-    "ascii": 28,
-    "code": 0,
-    "label": ""
+    ascii: 28,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 29,
-    "code": 0,
-    "label": ""
+    ascii: 29,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 30,
-    "code": 0,
-    "label": ""
+    ascii: 30,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 31,
-    "code": 0,
-    "label": ""
+    ascii: 31,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 32,
-    "code": 44,
-    "label": "space"
+    ascii: 32,
+    code: 44,
+    label: 'space',
   },
   {
-    "ascii": 33,
-    "code": 30,
-    "label": "!"
+    ascii: 33,
+    code: 30,
+    label: '!',
   },
   {
-    "ascii": 34,
-    "code": 52,
-    "label": "Ė"
+    ascii: 34,
+    code: 52,
+    label: 'Ė',
   },
   {
-    "ascii": 35,
-    "code": 32,
-    "label": "/"
+    ascii: 35,
+    code: 32,
+    label: '/',
   },
   {
-    "ascii": 36,
-    "code": 33,
-    "label": ";"
+    ascii: 36,
+    code: 33,
+    label: ';',
   },
   {
-    "ascii": 37,
-    "code": 46,
-    "label": "x"
+    ascii: 37,
+    code: 46,
+    label: 'x',
   },
   {
-    "ascii": 38,
-    "code": 36,
-    "label": "."
+    ascii: 38,
+    code: 36,
+    label: '.',
   },
   {
-    "ascii": 39,
-    "code": 45,
-    "label": "?"
+    ascii: 39,
+    code: 45,
+    label: '?',
   },
   {
-    "ascii": 40,
-    "code": 38,
-    "label": "("
+    ascii: 40,
+    code: 38,
+    label: '(',
   },
   {
-    "ascii": 41,
-    "code": 39,
-    "label": ")"
+    ascii: 41,
+    code: 39,
+    label: ')',
   },
   {
-    "ascii": 42,
-    "code": 37,
-    "label": "="
+    ascii: 42,
+    code: 37,
+    label: '=',
   },
   {
-    "ascii": 43,
-    "code": 557,
-    "label": "+"
+    ascii: 43,
+    code: 557,
+    label: '+',
   },
   {
-    "ascii": 44,
-    "code": 35,
-    "label": ","
+    ascii: 44,
+    code: 35,
+    label: ',',
   },
   {
-    "ascii": 45,
-    "code": 31,
-    "label": "-"
+    ascii: 45,
+    code: 31,
+    label: '-',
   },
   {
-    "ascii": 46,
-    "code": 36,
-    "label": "."
+    ascii: 46,
+    code: 36,
+    label: '.',
   },
   {
-    "ascii": 47,
-    "code": 32,
-    "label": "/"
+    ascii: 47,
+    code: 32,
+    label: '/',
   },
   {
-    "ascii": 48,
-    "code": 551,
-    "label": "0"
+    ascii: 48,
+    code: 551,
+    label: '0',
   },
   {
-    "ascii": 49,
-    "code": 542,
-    "label": "1"
+    ascii: 49,
+    code: 542,
+    label: '1',
   },
   {
-    "ascii": 50,
-    "code": 543,
-    "label": "2"
+    ascii: 50,
+    code: 543,
+    label: '2',
   },
   {
-    "ascii": 51,
-    "code": 544,
-    "label": "3"
+    ascii: 51,
+    code: 544,
+    label: '3',
   },
   {
-    "ascii": 52,
-    "code": 545,
-    "label": "4"
+    ascii: 52,
+    code: 545,
+    label: '4',
   },
   {
-    "ascii": 53,
-    "code": 546,
-    "label": "5"
+    ascii: 53,
+    code: 546,
+    label: '5',
   },
   {
-    "ascii": 54,
-    "code": 547,
-    "label": "6"
+    ascii: 54,
+    code: 547,
+    label: '6',
   },
   {
-    "ascii": 55,
-    "code": 548,
-    "label": "7"
+    ascii: 55,
+    code: 548,
+    label: '7',
   },
   {
-    "ascii": 56,
-    "code": 549,
-    "label": "8"
+    ascii: 56,
+    code: 549,
+    label: '8',
   },
   {
-    "ascii": 57,
-    "code": 550,
-    "label": "9"
+    ascii: 57,
+    code: 550,
+    label: '9',
   },
   {
-    "ascii": 58,
-    "code": 34,
-    "label": ":"
+    ascii: 58,
+    code: 34,
+    label: ':',
   },
   {
-    "ascii": 59,
-    "code": 33,
-    "label": ";"
+    ascii: 59,
+    code: 33,
+    label: ';',
   },
   {
-    "ascii": 60,
-    "code": 100,
-    "label": "<"
+    ascii: 60,
+    code: 100,
+    label: '<',
   },
   {
-    "ascii": 61,
-    "code": 37,
-    "label": "="
+    ascii: 61,
+    code: 37,
+    label: '=',
   },
   {
-    "ascii": 62,
-    "code": 612,
-    "label": ">"
+    ascii: 62,
+    code: 612,
+    label: '>',
   },
   {
-    "ascii": 63,
-    "code": 45,
-    "label": "?"
+    ascii: 63,
+    code: 45,
+    label: '?',
   },
   {
-    "ascii": 64,
-    "code": 30,
-    "label": "!"
+    ascii: 64,
+    code: 30,
+    label: '!',
   },
   {
-    "ascii": 65,
-    "code": 516,
-    "label": "A"
+    ascii: 65,
+    code: 516,
+    label: 'A',
   },
   {
-    "ascii": 66,
-    "code": 517,
-    "label": "B"
+    ascii: 66,
+    code: 517,
+    label: 'B',
   },
   {
-    "ascii": 67,
-    "code": 518,
-    "label": "C"
+    ascii: 67,
+    code: 518,
+    label: 'C',
   },
   {
-    "ascii": 68,
-    "code": 519,
-    "label": "D"
+    ascii: 68,
+    code: 519,
+    label: 'D',
   },
   {
-    "ascii": 69,
-    "code": 520,
-    "label": "E"
+    ascii: 69,
+    code: 520,
+    label: 'E',
   },
   {
-    "ascii": 70,
-    "code": 567,
-    "label": "F"
+    ascii: 70,
+    code: 567,
+    label: 'F',
   },
   {
-    "ascii": 71,
-    "code": 522,
-    "label": "G"
+    ascii: 71,
+    code: 522,
+    label: 'G',
   },
   {
-    "ascii": 72,
-    "code": 523,
-    "label": "H"
+    ascii: 72,
+    code: 523,
+    label: 'H',
   },
   {
-    "ascii": 73,
-    "code": 524,
-    "label": "I"
+    ascii: 73,
+    code: 524,
+    label: 'I',
   },
   {
-    "ascii": 74,
-    "code": 525,
-    "label": "J"
+    ascii: 74,
+    code: 525,
+    label: 'J',
   },
   {
-    "ascii": 75,
-    "code": 526,
-    "label": "K"
+    ascii: 75,
+    code: 526,
+    label: 'K',
   },
   {
-    "ascii": 76,
-    "code": 527,
-    "label": "L"
+    ascii: 76,
+    code: 527,
+    label: 'L',
   },
   {
-    "ascii": 77,
-    "code": 528,
-    "label": "M"
+    ascii: 77,
+    code: 528,
+    label: 'M',
   },
   {
-    "ascii": 78,
-    "code": 529,
-    "label": "N"
+    ascii: 78,
+    code: 529,
+    label: 'N',
   },
   {
-    "ascii": 79,
-    "code": 530,
-    "label": "O"
+    ascii: 79,
+    code: 530,
+    label: 'O',
   },
   {
-    "ascii": 80,
-    "code": 531,
-    "label": "P"
+    ascii: 80,
+    code: 531,
+    label: 'P',
   },
   {
-    "ascii": 81,
-    "code": 562,
-    "label": "Q"
+    ascii: 81,
+    code: 562,
+    label: 'Q',
   },
   {
-    "ascii": 82,
-    "code": 533,
-    "label": "R"
+    ascii: 82,
+    code: 533,
+    label: 'R',
   },
   {
-    "ascii": 83,
-    "code": 534,
-    "label": "S"
+    ascii: 83,
+    code: 534,
+    label: 'S',
   },
   {
-    "ascii": 84,
-    "code": 535,
-    "label": "T"
+    ascii: 84,
+    code: 535,
+    label: 'T',
   },
   {
-    "ascii": 85,
-    "code": 536,
-    "label": "U"
+    ascii: 85,
+    code: 536,
+    label: 'U',
   },
   {
-    "ascii": 86,
-    "code": 537,
-    "label": "V"
+    ascii: 86,
+    code: 537,
+    label: 'V',
   },
   {
-    "ascii": 87,
-    "code": 560,
-    "label": "W"
+    ascii: 87,
+    code: 560,
+    label: 'W',
   },
   {
-    "ascii": 88,
-    "code": 558,
-    "label": "X"
+    ascii: 88,
+    code: 558,
+    label: 'X',
   },
   {
-    "ascii": 89,
-    "code": 540,
-    "label": "Y"
+    ascii: 89,
+    code: 540,
+    label: 'Y',
   },
   {
-    "ascii": 90,
-    "code": 541,
-    "label": "Z"
+    ascii: 90,
+    code: 541,
+    label: 'Z',
   },
   {
-    "ascii": 91,
-    "code": 38,
-    "label": "("
+    ascii: 91,
+    code: 38,
+    label: '(',
   },
   {
-    "ascii": 92,
-    "code": 56,
-    "label": "Ę"
+    ascii: 92,
+    code: 56,
+    label: 'Ę',
   },
   {
-    "ascii": 93,
-    "code": 39,
-    "label": ")"
+    ascii: 93,
+    code: 39,
+    label: ')',
   },
   {
-    "ascii": 94,
-    "code": 35,
-    "label": ","
+    ascii: 94,
+    code: 35,
+    label: ',',
   },
   {
-    "ascii": 95,
-    "code": 31,
-    "label": "-"
+    ascii: 95,
+    code: 31,
+    label: '-',
   },
   {
-    "ascii": 96,
-    "code": 53,
-    "label": "`"
+    ascii: 96,
+    code: 53,
+    label: '`',
   },
   {
-    "ascii": 97,
-    "code": 4,
-    "label": "a"
+    ascii: 97,
+    code: 4,
+    label: 'a',
   },
   {
-    "ascii": 98,
-    "code": 5,
-    "label": "b"
+    ascii: 98,
+    code: 5,
+    label: 'b',
   },
   {
-    "ascii": 99,
-    "code": 6,
-    "label": "c"
+    ascii: 99,
+    code: 6,
+    label: 'c',
   },
   {
-    "ascii": 100,
-    "code": 7,
-    "label": "d"
+    ascii: 100,
+    code: 7,
+    label: 'd',
   },
   {
-    "ascii": 101,
-    "code": 8,
-    "label": "e"
+    ascii: 101,
+    code: 8,
+    label: 'e',
   },
   {
-    "ascii": 102,
-    "code": 55,
-    "label": "f"
+    ascii: 102,
+    code: 55,
+    label: 'f',
   },
   {
-    "ascii": 103,
-    "code": 10,
-    "label": "g"
+    ascii: 103,
+    code: 10,
+    label: 'g',
   },
   {
-    "ascii": 104,
-    "code": 11,
-    "label": "h"
+    ascii: 104,
+    code: 11,
+    label: 'h',
   },
   {
-    "ascii": 105,
-    "code": 12,
-    "label": "i"
+    ascii: 105,
+    code: 12,
+    label: 'i',
   },
   {
-    "ascii": 106,
-    "code": 13,
-    "label": "j"
+    ascii: 106,
+    code: 13,
+    label: 'j',
   },
   {
-    "ascii": 107,
-    "code": 14,
-    "label": "k"
+    ascii: 107,
+    code: 14,
+    label: 'k',
   },
   {
-    "ascii": 108,
-    "code": 15,
-    "label": "l"
+    ascii: 108,
+    code: 15,
+    label: 'l',
   },
   {
-    "ascii": 109,
-    "code": 16,
-    "label": "m"
+    ascii: 109,
+    code: 16,
+    label: 'm',
   },
   {
-    "ascii": 110,
-    "code": 17,
-    "label": "n"
+    ascii: 110,
+    code: 17,
+    label: 'n',
   },
   {
-    "ascii": 111,
-    "code": 18,
-    "label": "o"
+    ascii: 111,
+    code: 18,
+    label: 'o',
   },
   {
-    "ascii": 112,
-    "code": 19,
-    "label": "p"
+    ascii: 112,
+    code: 19,
+    label: 'p',
   },
   {
-    "ascii": 113,
-    "code": 50,
-    "label": "q"
+    ascii: 113,
+    code: 50,
+    label: 'q',
   },
   {
-    "ascii": 114,
-    "code": 21,
-    "label": "r"
+    ascii: 114,
+    code: 21,
+    label: 'r',
   },
   {
-    "ascii": 115,
-    "code": 22,
-    "label": "s"
+    ascii: 115,
+    code: 22,
+    label: 's',
   },
   {
-    "ascii": 116,
-    "code": 23,
-    "label": "t"
+    ascii: 116,
+    code: 23,
+    label: 't',
   },
   {
-    "ascii": 117,
-    "code": 24,
-    "label": "u"
+    ascii: 117,
+    code: 24,
+    label: 'u',
   },
   {
-    "ascii": 118,
-    "code": 25,
-    "label": "v"
+    ascii: 118,
+    code: 25,
+    label: 'v',
   },
   {
-    "ascii": 119,
-    "code": 48,
-    "label": "w"
+    ascii: 119,
+    code: 48,
+    label: 'w',
   },
   {
-    "ascii": 120,
-    "code": 46,
-    "label": "x"
+    ascii: 120,
+    code: 46,
+    label: 'x',
   },
   {
-    "ascii": 121,
-    "code": 28,
-    "label": "y"
+    ascii: 121,
+    code: 28,
+    label: 'y',
   },
   {
-    "ascii": 122,
-    "code": 29,
-    "label": "z"
+    ascii: 122,
+    code: 29,
+    label: 'z',
   },
   {
-    "ascii": 123,
-    "code": 47,
-    "label": "Į"
+    ascii: 123,
+    code: 47,
+    label: 'Į',
   },
   {
-    "ascii": 124,
-    "code": 50,
-    "label": "q"
+    ascii: 124,
+    code: 50,
+    label: 'q',
   },
   {
-    "ascii": 125,
-    "code": 48,
-    "label": "w"
+    ascii: 125,
+    code: 48,
+    label: 'w',
   },
   {
-    "ascii": 126,
-    "code": 565,
-    "label": "~"
+    ascii: 126,
+    code: 565,
+    label: '~',
   },
   {
-    "ascii": 127,
-    "code": 76,
-    "label": "del"
-  }
+    ascii: 127,
+    code: 76,
+    label: 'del',
+  },
 ];
-    

--- a/src/services/labellang/AsciiLabelLithuanian_qwerty.ts
+++ b/src/services/labellang/AsciiLabelLithuanian_qwerty.ts
@@ -1,645 +1,644 @@
 import { AsciiLabel } from './AsciiLabel';
-        
+
 export const AsciiLabelLithuanian_qwerty: AsciiLabel[] = [
   {
-    "ascii": 0,
-    "code": 0,
-    "label": ""
+    ascii: 0,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 1,
-    "code": 0,
-    "label": ""
+    ascii: 1,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 2,
-    "code": 0,
-    "label": ""
+    ascii: 2,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 3,
-    "code": 0,
-    "label": ""
+    ascii: 3,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 4,
-    "code": 0,
-    "label": ""
+    ascii: 4,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 5,
-    "code": 0,
-    "label": ""
+    ascii: 5,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 6,
-    "code": 0,
-    "label": ""
+    ascii: 6,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 7,
-    "code": 0,
-    "label": ""
+    ascii: 7,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 8,
-    "code": 42,
-    "label": "back space"
+    ascii: 8,
+    code: 42,
+    label: 'back space',
   },
   {
-    "ascii": 9,
-    "code": 43,
-    "label": "tab"
+    ascii: 9,
+    code: 43,
+    label: 'tab',
   },
   {
-    "ascii": 10,
-    "code": 40,
-    "label": "enter"
+    ascii: 10,
+    code: 40,
+    label: 'enter',
   },
   {
-    "ascii": 11,
-    "code": 0,
-    "label": ""
+    ascii: 11,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 12,
-    "code": 0,
-    "label": ""
+    ascii: 12,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 13,
-    "code": 0,
-    "label": ""
+    ascii: 13,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 14,
-    "code": 0,
-    "label": ""
+    ascii: 14,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 15,
-    "code": 0,
-    "label": ""
+    ascii: 15,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 16,
-    "code": 0,
-    "label": ""
+    ascii: 16,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 17,
-    "code": 0,
-    "label": ""
+    ascii: 17,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 18,
-    "code": 0,
-    "label": ""
+    ascii: 18,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 19,
-    "code": 0,
-    "label": ""
+    ascii: 19,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 20,
-    "code": 0,
-    "label": ""
+    ascii: 20,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 21,
-    "code": 0,
-    "label": ""
+    ascii: 21,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 22,
-    "code": 0,
-    "label": ""
+    ascii: 22,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 23,
-    "code": 0,
-    "label": ""
+    ascii: 23,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 24,
-    "code": 0,
-    "label": ""
+    ascii: 24,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 25,
-    "code": 0,
-    "label": ""
+    ascii: 25,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 26,
-    "code": 0,
-    "label": ""
+    ascii: 26,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 27,
-    "code": 41,
-    "label": "esc"
+    ascii: 27,
+    code: 41,
+    label: 'esc',
   },
   {
-    "ascii": 28,
-    "code": 0,
-    "label": ""
+    ascii: 28,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 29,
-    "code": 0,
-    "label": ""
+    ascii: 29,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 30,
-    "code": 0,
-    "label": ""
+    ascii: 30,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 31,
-    "code": 0,
-    "label": ""
+    ascii: 31,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 32,
-    "code": 44,
-    "label": "space"
+    ascii: 32,
+    code: 44,
+    label: 'space',
   },
   {
-    "ascii": 33,
-    "code": 5150,
-    "label": "1"
+    ascii: 33,
+    code: 5150,
+    label: '1',
   },
   {
-    "ascii": 34,
-    "code": 52,
-    "label": "'"
+    ascii: 34,
+    code: 52,
+    label: "'",
   },
   {
-    "ascii": 35,
-    "code": 5152,
-    "label": "3"
+    ascii: 35,
+    code: 5152,
+    label: '3',
   },
   {
-    "ascii": 36,
-    "code": 5153,
-    "label": "4"
+    ascii: 36,
+    code: 5153,
+    label: '4',
   },
   {
-    "ascii": 37,
-    "code": 5154,
-    "label": "5"
+    ascii: 37,
+    code: 5154,
+    label: '5',
   },
   {
-    "ascii": 38,
-    "code": 5156,
-    "label": "7"
+    ascii: 38,
+    code: 5156,
+    label: '7',
   },
   {
-    "ascii": 39,
-    "code": 52,
-    "label": "'"
+    ascii: 39,
+    code: 52,
+    label: "'",
   },
   {
-    "ascii": 40,
-    "code": 38,
-    "label": "9"
+    ascii: 40,
+    code: 38,
+    label: '9',
   },
   {
-    "ascii": 41,
-    "code": 39,
-    "label": "0"
+    ascii: 41,
+    code: 39,
+    label: '0',
   },
   {
-    "ascii": 42,
-    "code": 5157,
-    "label": "8"
+    ascii: 42,
+    code: 5157,
+    label: '8',
   },
   {
-    "ascii": 43,
-    "code": 46,
-    "label": "Ž"
+    ascii: 43,
+    code: 46,
+    label: 'Ž',
   },
   {
-    "ascii": 44,
-    "code": 54,
-    "label": ","
+    ascii: 44,
+    code: 54,
+    label: ',',
   },
   {
-    "ascii": 45,
-    "code": 45,
-    "label": "-"
+    ascii: 45,
+    code: 45,
+    label: '-',
   },
   {
-    "ascii": 46,
-    "code": 55,
-    "label": "."
+    ascii: 46,
+    code: 55,
+    label: '.',
   },
   {
-    "ascii": 47,
-    "code": 56,
-    "label": "/"
+    ascii: 47,
+    code: 56,
+    label: '/',
   },
   {
-    "ascii": 48,
-    "code": 39,
-    "label": "0"
+    ascii: 48,
+    code: 39,
+    label: '0',
   },
   {
-    "ascii": 49,
-    "code": 30,
-    "label": "Ą"
+    ascii: 49,
+    code: 30,
+    label: 'Ą',
   },
   {
-    "ascii": 50,
-    "code": 31,
-    "label": "Č"
+    ascii: 50,
+    code: 31,
+    label: 'Č',
   },
   {
-    "ascii": 51,
-    "code": 32,
-    "label": "Ę"
+    ascii: 51,
+    code: 32,
+    label: 'Ę',
   },
   {
-    "ascii": 52,
-    "code": 33,
-    "label": "Ė"
+    ascii: 52,
+    code: 33,
+    label: 'Ė',
   },
   {
-    "ascii": 53,
-    "code": 34,
-    "label": "Į"
+    ascii: 53,
+    code: 34,
+    label: 'Į',
   },
   {
-    "ascii": 54,
-    "code": 35,
-    "label": "Š"
+    ascii: 54,
+    code: 35,
+    label: 'Š',
   },
   {
-    "ascii": 55,
-    "code": 36,
-    "label": "Ų"
+    ascii: 55,
+    code: 36,
+    label: 'Ų',
   },
   {
-    "ascii": 56,
-    "code": 37,
-    "label": "Ū"
+    ascii: 56,
+    code: 37,
+    label: 'Ū',
   },
   {
-    "ascii": 57,
-    "code": 38,
-    "label": "9"
+    ascii: 57,
+    code: 38,
+    label: '9',
   },
   {
-    "ascii": 58,
-    "code": 51,
-    "label": ";"
+    ascii: 58,
+    code: 51,
+    label: ';',
   },
   {
-    "ascii": 59,
-    "code": 51,
-    "label": ";"
+    ascii: 59,
+    code: 51,
+    label: ';',
   },
   {
-    "ascii": 60,
-    "code": 54,
-    "label": ","
+    ascii: 60,
+    code: 54,
+    label: ',',
   },
   {
-    "ascii": 61,
-    "code": 5632,
-    "label": "+"
+    ascii: 61,
+    code: 5632,
+    label: '+',
   },
   {
-    "ascii": 62,
-    "code": 55,
-    "label": "."
+    ascii: 62,
+    code: 55,
+    label: '.',
   },
   {
-    "ascii": 63,
-    "code": 56,
-    "label": "/"
+    ascii: 63,
+    code: 56,
+    label: '/',
   },
   {
-    "ascii": 64,
-    "code": 31,
-    "label": "Č"
+    ascii: 64,
+    code: 31,
+    label: 'Č',
   },
   {
-    "ascii": 65,
-    "code": 4,
-    "label": "a"
+    ascii: 65,
+    code: 4,
+    label: 'a',
   },
   {
-    "ascii": 66,
-    "code": 5,
-    "label": "b"
+    ascii: 66,
+    code: 5,
+    label: 'b',
   },
   {
-    "ascii": 67,
-    "code": 6,
-    "label": "c"
+    ascii: 67,
+    code: 6,
+    label: 'c',
   },
   {
-    "ascii": 68,
-    "code": 7,
-    "label": "d"
+    ascii: 68,
+    code: 7,
+    label: 'd',
   },
   {
-    "ascii": 69,
-    "code": 8,
-    "label": "e"
+    ascii: 69,
+    code: 8,
+    label: 'e',
   },
   {
-    "ascii": 70,
-    "code": 9,
-    "label": "f"
+    ascii: 70,
+    code: 9,
+    label: 'f',
   },
   {
-    "ascii": 71,
-    "code": 10,
-    "label": "g"
+    ascii: 71,
+    code: 10,
+    label: 'g',
   },
   {
-    "ascii": 72,
-    "code": 11,
-    "label": "h"
+    ascii: 72,
+    code: 11,
+    label: 'h',
   },
   {
-    "ascii": 73,
-    "code": 12,
-    "label": "i"
+    ascii: 73,
+    code: 12,
+    label: 'i',
   },
   {
-    "ascii": 74,
-    "code": 13,
-    "label": "j"
+    ascii: 74,
+    code: 13,
+    label: 'j',
   },
   {
-    "ascii": 75,
-    "code": 14,
-    "label": "k"
+    ascii: 75,
+    code: 14,
+    label: 'k',
   },
   {
-    "ascii": 76,
-    "code": 15,
-    "label": "l"
+    ascii: 76,
+    code: 15,
+    label: 'l',
   },
   {
-    "ascii": 77,
-    "code": 16,
-    "label": "m"
+    ascii: 77,
+    code: 16,
+    label: 'm',
   },
   {
-    "ascii": 78,
-    "code": 17,
-    "label": "n"
+    ascii: 78,
+    code: 17,
+    label: 'n',
   },
   {
-    "ascii": 79,
-    "code": 18,
-    "label": "o"
+    ascii: 79,
+    code: 18,
+    label: 'o',
   },
   {
-    "ascii": 80,
-    "code": 19,
-    "label": "p"
+    ascii: 80,
+    code: 19,
+    label: 'p',
   },
   {
-    "ascii": 81,
-    "code": 20,
-    "label": "q"
+    ascii: 81,
+    code: 20,
+    label: 'q',
   },
   {
-    "ascii": 82,
-    "code": 21,
-    "label": "r"
+    ascii: 82,
+    code: 21,
+    label: 'r',
   },
   {
-    "ascii": 83,
-    "code": 22,
-    "label": "s"
+    ascii: 83,
+    code: 22,
+    label: 's',
   },
   {
-    "ascii": 84,
-    "code": 23,
-    "label": "t"
+    ascii: 84,
+    code: 23,
+    label: 't',
   },
   {
-    "ascii": 85,
-    "code": 24,
-    "label": "u"
+    ascii: 85,
+    code: 24,
+    label: 'u',
   },
   {
-    "ascii": 86,
-    "code": 25,
-    "label": "v"
+    ascii: 86,
+    code: 25,
+    label: 'v',
   },
   {
-    "ascii": 87,
-    "code": 26,
-    "label": "w"
+    ascii: 87,
+    code: 26,
+    label: 'w',
   },
   {
-    "ascii": 88,
-    "code": 27,
-    "label": "x"
+    ascii: 88,
+    code: 27,
+    label: 'x',
   },
   {
-    "ascii": 89,
-    "code": 28,
-    "label": "y"
+    ascii: 89,
+    code: 28,
+    label: 'y',
   },
   {
-    "ascii": 90,
-    "code": 29,
-    "label": "z"
+    ascii: 90,
+    code: 29,
+    label: 'z',
   },
   {
-    "ascii": 91,
-    "code": 47,
-    "label": "["
+    ascii: 91,
+    code: 47,
+    label: '[',
   },
   {
-    "ascii": 92,
-    "code": 50,
-    "label": "(backslash)"
+    ascii: 92,
+    code: 50,
+    label: '(backslash)',
   },
   {
-    "ascii": 93,
-    "code": 48,
-    "label": "]"
+    ascii: 93,
+    code: 48,
+    label: ']',
   },
   {
-    "ascii": 94,
-    "code": 35,
-    "label": "Š"
+    ascii: 94,
+    code: 35,
+    label: 'Š',
   },
   {
-    "ascii": 95,
-    "code": 45,
-    "label": "-"
+    ascii: 95,
+    code: 45,
+    label: '-',
   },
   {
-    "ascii": 96,
-    "code": 53,
-    "label": "`"
+    ascii: 96,
+    code: 53,
+    label: '`',
   },
   {
-    "ascii": 97,
-    "code": 4,
-    "label": "a"
+    ascii: 97,
+    code: 4,
+    label: 'a',
   },
   {
-    "ascii": 98,
-    "code": 5,
-    "label": "b"
+    ascii: 98,
+    code: 5,
+    label: 'b',
   },
   {
-    "ascii": 99,
-    "code": 6,
-    "label": "c"
+    ascii: 99,
+    code: 6,
+    label: 'c',
   },
   {
-    "ascii": 100,
-    "code": 7,
-    "label": "d"
+    ascii: 100,
+    code: 7,
+    label: 'd',
   },
   {
-    "ascii": 101,
-    "code": 8,
-    "label": "e"
+    ascii: 101,
+    code: 8,
+    label: 'e',
   },
   {
-    "ascii": 102,
-    "code": 9,
-    "label": "f"
+    ascii: 102,
+    code: 9,
+    label: 'f',
   },
   {
-    "ascii": 103,
-    "code": 10,
-    "label": "g"
+    ascii: 103,
+    code: 10,
+    label: 'g',
   },
   {
-    "ascii": 104,
-    "code": 11,
-    "label": "h"
+    ascii: 104,
+    code: 11,
+    label: 'h',
   },
   {
-    "ascii": 105,
-    "code": 12,
-    "label": "i"
+    ascii: 105,
+    code: 12,
+    label: 'i',
   },
   {
-    "ascii": 106,
-    "code": 13,
-    "label": "j"
+    ascii: 106,
+    code: 13,
+    label: 'j',
   },
   {
-    "ascii": 107,
-    "code": 14,
-    "label": "k"
+    ascii: 107,
+    code: 14,
+    label: 'k',
   },
   {
-    "ascii": 108,
-    "code": 15,
-    "label": "l"
+    ascii: 108,
+    code: 15,
+    label: 'l',
   },
   {
-    "ascii": 109,
-    "code": 16,
-    "label": "m"
+    ascii: 109,
+    code: 16,
+    label: 'm',
   },
   {
-    "ascii": 110,
-    "code": 17,
-    "label": "n"
+    ascii: 110,
+    code: 17,
+    label: 'n',
   },
   {
-    "ascii": 111,
-    "code": 18,
-    "label": "o"
+    ascii: 111,
+    code: 18,
+    label: 'o',
   },
   {
-    "ascii": 112,
-    "code": 19,
-    "label": "p"
+    ascii: 112,
+    code: 19,
+    label: 'p',
   },
   {
-    "ascii": 113,
-    "code": 20,
-    "label": "q"
+    ascii: 113,
+    code: 20,
+    label: 'q',
   },
   {
-    "ascii": 114,
-    "code": 21,
-    "label": "r"
+    ascii: 114,
+    code: 21,
+    label: 'r',
   },
   {
-    "ascii": 115,
-    "code": 22,
-    "label": "s"
+    ascii: 115,
+    code: 22,
+    label: 's',
   },
   {
-    "ascii": 116,
-    "code": 23,
-    "label": "t"
+    ascii: 116,
+    code: 23,
+    label: 't',
   },
   {
-    "ascii": 117,
-    "code": 24,
-    "label": "u"
+    ascii: 117,
+    code: 24,
+    label: 'u',
   },
   {
-    "ascii": 118,
-    "code": 25,
-    "label": "v"
+    ascii: 118,
+    code: 25,
+    label: 'v',
   },
   {
-    "ascii": 119,
-    "code": 26,
-    "label": "w"
+    ascii: 119,
+    code: 26,
+    label: 'w',
   },
   {
-    "ascii": 120,
-    "code": 27,
-    "label": "x"
+    ascii: 120,
+    code: 27,
+    label: 'x',
   },
   {
-    "ascii": 121,
-    "code": 28,
-    "label": "y"
+    ascii: 121,
+    code: 28,
+    label: 'y',
   },
   {
-    "ascii": 122,
-    "code": 29,
-    "label": "z"
+    ascii: 122,
+    code: 29,
+    label: 'z',
   },
   {
-    "ascii": 123,
-    "code": 47,
-    "label": "["
+    ascii: 123,
+    code: 47,
+    label: '[',
   },
   {
-    "ascii": 124,
-    "code": 50,
-    "label": "(backslash)"
+    ascii: 124,
+    code: 50,
+    label: '(backslash)',
   },
   {
-    "ascii": 125,
-    "code": 48,
-    "label": "]"
+    ascii: 125,
+    code: 48,
+    label: ']',
   },
   {
-    "ascii": 126,
-    "code": 53,
-    "label": "`"
+    ascii: 126,
+    code: 53,
+    label: '`',
   },
   {
-    "ascii": 127,
-    "code": 76,
-    "label": "del"
-  }
+    ascii: 127,
+    code: 76,
+    label: 'del',
+  },
 ];
-    

--- a/src/services/labellang/AsciiLabelNorman.ts
+++ b/src/services/labellang/AsciiLabelNorman.ts
@@ -1,645 +1,644 @@
 import { AsciiLabel } from './AsciiLabel';
-        
+
 export const AsciiLabelNorman: AsciiLabel[] = [
   {
-    "ascii": 0,
-    "code": 0,
-    "label": ""
+    ascii: 0,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 1,
-    "code": 0,
-    "label": ""
+    ascii: 1,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 2,
-    "code": 0,
-    "label": ""
+    ascii: 2,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 3,
-    "code": 0,
-    "label": ""
+    ascii: 3,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 4,
-    "code": 0,
-    "label": ""
+    ascii: 4,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 5,
-    "code": 0,
-    "label": ""
+    ascii: 5,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 6,
-    "code": 0,
-    "label": ""
+    ascii: 6,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 7,
-    "code": 0,
-    "label": ""
+    ascii: 7,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 8,
-    "code": 42,
-    "label": "back space"
+    ascii: 8,
+    code: 42,
+    label: 'back space',
   },
   {
-    "ascii": 9,
-    "code": 43,
-    "label": "tab"
+    ascii: 9,
+    code: 43,
+    label: 'tab',
   },
   {
-    "ascii": 10,
-    "code": 40,
-    "label": "enter"
+    ascii: 10,
+    code: 40,
+    label: 'enter',
   },
   {
-    "ascii": 11,
-    "code": 0,
-    "label": ""
+    ascii: 11,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 12,
-    "code": 0,
-    "label": ""
+    ascii: 12,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 13,
-    "code": 0,
-    "label": ""
+    ascii: 13,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 14,
-    "code": 0,
-    "label": ""
+    ascii: 14,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 15,
-    "code": 0,
-    "label": ""
+    ascii: 15,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 16,
-    "code": 0,
-    "label": ""
+    ascii: 16,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 17,
-    "code": 0,
-    "label": ""
+    ascii: 17,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 18,
-    "code": 0,
-    "label": ""
+    ascii: 18,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 19,
-    "code": 0,
-    "label": ""
+    ascii: 19,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 20,
-    "code": 0,
-    "label": ""
+    ascii: 20,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 21,
-    "code": 0,
-    "label": ""
+    ascii: 21,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 22,
-    "code": 0,
-    "label": ""
+    ascii: 22,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 23,
-    "code": 0,
-    "label": ""
+    ascii: 23,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 24,
-    "code": 0,
-    "label": ""
+    ascii: 24,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 25,
-    "code": 0,
-    "label": ""
+    ascii: 25,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 26,
-    "code": 0,
-    "label": ""
+    ascii: 26,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 27,
-    "code": 41,
-    "label": "esc"
+    ascii: 27,
+    code: 41,
+    label: 'esc',
   },
   {
-    "ascii": 28,
-    "code": 0,
-    "label": ""
+    ascii: 28,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 29,
-    "code": 0,
-    "label": ""
+    ascii: 29,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 30,
-    "code": 0,
-    "label": ""
+    ascii: 30,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 31,
-    "code": 0,
-    "label": ""
+    ascii: 31,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 32,
-    "code": 44,
-    "label": "space"
+    ascii: 32,
+    code: 44,
+    label: 'space',
   },
   {
-    "ascii": 33,
-    "code": 30,
-    "label": "1"
+    ascii: 33,
+    code: 30,
+    label: '1',
   },
   {
-    "ascii": 34,
-    "code": 52,
-    "label": "'"
+    ascii: 34,
+    code: 52,
+    label: "'",
   },
   {
-    "ascii": 35,
-    "code": 32,
-    "label": "3"
+    ascii: 35,
+    code: 32,
+    label: '3',
   },
   {
-    "ascii": 36,
-    "code": 33,
-    "label": "4"
+    ascii: 36,
+    code: 33,
+    label: '4',
   },
   {
-    "ascii": 37,
-    "code": 34,
-    "label": "5"
+    ascii: 37,
+    code: 34,
+    label: '5',
   },
   {
-    "ascii": 38,
-    "code": 36,
-    "label": "7"
+    ascii: 38,
+    code: 36,
+    label: '7',
   },
   {
-    "ascii": 39,
-    "code": 52,
-    "label": "'"
+    ascii: 39,
+    code: 52,
+    label: "'",
   },
   {
-    "ascii": 40,
-    "code": 38,
-    "label": "9"
+    ascii: 40,
+    code: 38,
+    label: '9',
   },
   {
-    "ascii": 41,
-    "code": 39,
-    "label": "0"
+    ascii: 41,
+    code: 39,
+    label: '0',
   },
   {
-    "ascii": 42,
-    "code": 37,
-    "label": "8"
+    ascii: 42,
+    code: 37,
+    label: '8',
   },
   {
-    "ascii": 43,
-    "code": 46,
-    "label": "="
+    ascii: 43,
+    code: 46,
+    label: '=',
   },
   {
-    "ascii": 44,
-    "code": 54,
-    "label": ","
+    ascii: 44,
+    code: 54,
+    label: ',',
   },
   {
-    "ascii": 45,
-    "code": 45,
-    "label": "-"
+    ascii: 45,
+    code: 45,
+    label: '-',
   },
   {
-    "ascii": 46,
-    "code": 55,
-    "label": "."
+    ascii: 46,
+    code: 55,
+    label: '.',
   },
   {
-    "ascii": 47,
-    "code": 56,
-    "label": "/"
+    ascii: 47,
+    code: 56,
+    label: '/',
   },
   {
-    "ascii": 48,
-    "code": 39,
-    "label": "0"
+    ascii: 48,
+    code: 39,
+    label: '0',
   },
   {
-    "ascii": 49,
-    "code": 30,
-    "label": "1"
+    ascii: 49,
+    code: 30,
+    label: '1',
   },
   {
-    "ascii": 50,
-    "code": 31,
-    "label": "2"
+    ascii: 50,
+    code: 31,
+    label: '2',
   },
   {
-    "ascii": 51,
-    "code": 32,
-    "label": "3"
+    ascii: 51,
+    code: 32,
+    label: '3',
   },
   {
-    "ascii": 52,
-    "code": 33,
-    "label": "4"
+    ascii: 52,
+    code: 33,
+    label: '4',
   },
   {
-    "ascii": 53,
-    "code": 34,
-    "label": "5"
+    ascii: 53,
+    code: 34,
+    label: '5',
   },
   {
-    "ascii": 54,
-    "code": 35,
-    "label": "6"
+    ascii: 54,
+    code: 35,
+    label: '6',
   },
   {
-    "ascii": 55,
-    "code": 36,
-    "label": "7"
+    ascii: 55,
+    code: 36,
+    label: '7',
   },
   {
-    "ascii": 56,
-    "code": 37,
-    "label": "8"
+    ascii: 56,
+    code: 37,
+    label: '8',
   },
   {
-    "ascii": 57,
-    "code": 38,
-    "label": "9"
+    ascii: 57,
+    code: 38,
+    label: '9',
   },
   {
-    "ascii": 58,
-    "code": 19,
-    "label": ";"
+    ascii: 58,
+    code: 19,
+    label: ';',
   },
   {
-    "ascii": 59,
-    "code": 19,
-    "label": ";"
+    ascii: 59,
+    code: 19,
+    label: ';',
   },
   {
-    "ascii": 60,
-    "code": 54,
-    "label": ","
+    ascii: 60,
+    code: 54,
+    label: ',',
   },
   {
-    "ascii": 61,
-    "code": 46,
-    "label": "="
+    ascii: 61,
+    code: 46,
+    label: '=',
   },
   {
-    "ascii": 62,
-    "code": 55,
-    "label": "."
+    ascii: 62,
+    code: 55,
+    label: '.',
   },
   {
-    "ascii": 63,
-    "code": 56,
-    "label": "/"
+    ascii: 63,
+    code: 56,
+    label: '/',
   },
   {
-    "ascii": 64,
-    "code": 31,
-    "label": "2"
+    ascii: 64,
+    code: 31,
+    label: '2',
   },
   {
-    "ascii": 65,
-    "code": 4,
-    "label": "a"
+    ascii: 65,
+    code: 4,
+    label: 'a',
   },
   {
-    "ascii": 66,
-    "code": 5,
-    "label": "b"
+    ascii: 66,
+    code: 5,
+    label: 'b',
   },
   {
-    "ascii": 67,
-    "code": 6,
-    "label": "c"
+    ascii: 67,
+    code: 6,
+    label: 'c',
   },
   {
-    "ascii": 68,
-    "code": 8,
-    "label": "d"
+    ascii: 68,
+    code: 8,
+    label: 'd',
   },
   {
-    "ascii": 69,
-    "code": 7,
-    "label": "e"
+    ascii: 69,
+    code: 7,
+    label: 'e',
   },
   {
-    "ascii": 70,
-    "code": 21,
-    "label": "f"
+    ascii: 70,
+    code: 21,
+    label: 'f',
   },
   {
-    "ascii": 71,
-    "code": 10,
-    "label": "g"
+    ascii: 71,
+    code: 10,
+    label: 'g',
   },
   {
-    "ascii": 72,
-    "code": 51,
-    "label": "h"
+    ascii: 72,
+    code: 51,
+    label: 'h',
   },
   {
-    "ascii": 73,
-    "code": 14,
-    "label": "i"
+    ascii: 73,
+    code: 14,
+    label: 'i',
   },
   {
-    "ascii": 74,
-    "code": 28,
-    "label": "j"
+    ascii: 74,
+    code: 28,
+    label: 'j',
   },
   {
-    "ascii": 75,
-    "code": 23,
-    "label": "k"
+    ascii: 75,
+    code: 23,
+    label: 'k',
   },
   {
-    "ascii": 76,
-    "code": 18,
-    "label": "l"
+    ascii: 76,
+    code: 18,
+    label: 'l',
   },
   {
-    "ascii": 77,
-    "code": 16,
-    "label": "m"
+    ascii: 77,
+    code: 16,
+    label: 'm',
   },
   {
-    "ascii": 78,
-    "code": 13,
-    "label": "n"
+    ascii: 78,
+    code: 13,
+    label: 'n',
   },
   {
-    "ascii": 79,
-    "code": 15,
-    "label": "o"
+    ascii: 79,
+    code: 15,
+    label: 'o',
   },
   {
-    "ascii": 80,
-    "code": 17,
-    "label": "p"
+    ascii: 80,
+    code: 17,
+    label: 'p',
   },
   {
-    "ascii": 81,
-    "code": 20,
-    "label": "q"
+    ascii: 81,
+    code: 20,
+    label: 'q',
   },
   {
-    "ascii": 82,
-    "code": 12,
-    "label": "r"
+    ascii: 82,
+    code: 12,
+    label: 'r',
   },
   {
-    "ascii": 83,
-    "code": 22,
-    "label": "s"
+    ascii: 83,
+    code: 22,
+    label: 's',
   },
   {
-    "ascii": 84,
-    "code": 9,
-    "label": "t"
+    ascii: 84,
+    code: 9,
+    label: 't',
   },
   {
-    "ascii": 85,
-    "code": 24,
-    "label": "u"
+    ascii: 85,
+    code: 24,
+    label: 'u',
   },
   {
-    "ascii": 86,
-    "code": 25,
-    "label": "v"
+    ascii: 86,
+    code: 25,
+    label: 'v',
   },
   {
-    "ascii": 87,
-    "code": 26,
-    "label": "w"
+    ascii: 87,
+    code: 26,
+    label: 'w',
   },
   {
-    "ascii": 88,
-    "code": 27,
-    "label": "x"
+    ascii: 88,
+    code: 27,
+    label: 'x',
   },
   {
-    "ascii": 89,
-    "code": 11,
-    "label": "y"
+    ascii: 89,
+    code: 11,
+    label: 'y',
   },
   {
-    "ascii": 90,
-    "code": 29,
-    "label": "z"
+    ascii: 90,
+    code: 29,
+    label: 'z',
   },
   {
-    "ascii": 91,
-    "code": 47,
-    "label": "["
+    ascii: 91,
+    code: 47,
+    label: '[',
   },
   {
-    "ascii": 92,
-    "code": 49,
-    "label": "(backslash)"
+    ascii: 92,
+    code: 49,
+    label: '(backslash)',
   },
   {
-    "ascii": 93,
-    "code": 48,
-    "label": "]"
+    ascii: 93,
+    code: 48,
+    label: ']',
   },
   {
-    "ascii": 94,
-    "code": 35,
-    "label": "6"
+    ascii: 94,
+    code: 35,
+    label: '6',
   },
   {
-    "ascii": 95,
-    "code": 45,
-    "label": "-"
+    ascii: 95,
+    code: 45,
+    label: '-',
   },
   {
-    "ascii": 96,
-    "code": 53,
-    "label": "`"
+    ascii: 96,
+    code: 53,
+    label: '`',
   },
   {
-    "ascii": 97,
-    "code": 4,
-    "label": "a"
+    ascii: 97,
+    code: 4,
+    label: 'a',
   },
   {
-    "ascii": 98,
-    "code": 5,
-    "label": "b"
+    ascii: 98,
+    code: 5,
+    label: 'b',
   },
   {
-    "ascii": 99,
-    "code": 6,
-    "label": "c"
+    ascii: 99,
+    code: 6,
+    label: 'c',
   },
   {
-    "ascii": 100,
-    "code": 8,
-    "label": "d"
+    ascii: 100,
+    code: 8,
+    label: 'd',
   },
   {
-    "ascii": 101,
-    "code": 7,
-    "label": "e"
+    ascii: 101,
+    code: 7,
+    label: 'e',
   },
   {
-    "ascii": 102,
-    "code": 21,
-    "label": "f"
+    ascii: 102,
+    code: 21,
+    label: 'f',
   },
   {
-    "ascii": 103,
-    "code": 10,
-    "label": "g"
+    ascii: 103,
+    code: 10,
+    label: 'g',
   },
   {
-    "ascii": 104,
-    "code": 51,
-    "label": "h"
+    ascii: 104,
+    code: 51,
+    label: 'h',
   },
   {
-    "ascii": 105,
-    "code": 14,
-    "label": "i"
+    ascii: 105,
+    code: 14,
+    label: 'i',
   },
   {
-    "ascii": 106,
-    "code": 28,
-    "label": "j"
+    ascii: 106,
+    code: 28,
+    label: 'j',
   },
   {
-    "ascii": 107,
-    "code": 23,
-    "label": "k"
+    ascii: 107,
+    code: 23,
+    label: 'k',
   },
   {
-    "ascii": 108,
-    "code": 18,
-    "label": "l"
+    ascii: 108,
+    code: 18,
+    label: 'l',
   },
   {
-    "ascii": 109,
-    "code": 16,
-    "label": "m"
+    ascii: 109,
+    code: 16,
+    label: 'm',
   },
   {
-    "ascii": 110,
-    "code": 13,
-    "label": "n"
+    ascii: 110,
+    code: 13,
+    label: 'n',
   },
   {
-    "ascii": 111,
-    "code": 15,
-    "label": "o"
+    ascii: 111,
+    code: 15,
+    label: 'o',
   },
   {
-    "ascii": 112,
-    "code": 17,
-    "label": "p"
+    ascii: 112,
+    code: 17,
+    label: 'p',
   },
   {
-    "ascii": 113,
-    "code": 20,
-    "label": "q"
+    ascii: 113,
+    code: 20,
+    label: 'q',
   },
   {
-    "ascii": 114,
-    "code": 12,
-    "label": "r"
+    ascii: 114,
+    code: 12,
+    label: 'r',
   },
   {
-    "ascii": 115,
-    "code": 22,
-    "label": "s"
+    ascii: 115,
+    code: 22,
+    label: 's',
   },
   {
-    "ascii": 116,
-    "code": 9,
-    "label": "t"
+    ascii: 116,
+    code: 9,
+    label: 't',
   },
   {
-    "ascii": 117,
-    "code": 24,
-    "label": "u"
+    ascii: 117,
+    code: 24,
+    label: 'u',
   },
   {
-    "ascii": 118,
-    "code": 25,
-    "label": "v"
+    ascii: 118,
+    code: 25,
+    label: 'v',
   },
   {
-    "ascii": 119,
-    "code": 26,
-    "label": "w"
+    ascii: 119,
+    code: 26,
+    label: 'w',
   },
   {
-    "ascii": 120,
-    "code": 27,
-    "label": "x"
+    ascii: 120,
+    code: 27,
+    label: 'x',
   },
   {
-    "ascii": 121,
-    "code": 11,
-    "label": "y"
+    ascii: 121,
+    code: 11,
+    label: 'y',
   },
   {
-    "ascii": 122,
-    "code": 29,
-    "label": "z"
+    ascii: 122,
+    code: 29,
+    label: 'z',
   },
   {
-    "ascii": 123,
-    "code": 47,
-    "label": "["
+    ascii: 123,
+    code: 47,
+    label: '[',
   },
   {
-    "ascii": 124,
-    "code": 49,
-    "label": "(backslash)"
+    ascii: 124,
+    code: 49,
+    label: '(backslash)',
   },
   {
-    "ascii": 125,
-    "code": 48,
-    "label": "]"
+    ascii: 125,
+    code: 48,
+    label: ']',
   },
   {
-    "ascii": 126,
-    "code": 53,
-    "label": "`"
+    ascii: 126,
+    code: 53,
+    label: '`',
   },
   {
-    "ascii": 127,
-    "code": 76,
-    "label": "del"
-  }
+    ascii: 127,
+    code: 76,
+    label: 'del',
+  },
 ];
-    

--- a/src/services/labellang/AsciiLabelNorwegian.ts
+++ b/src/services/labellang/AsciiLabelNorwegian.ts
@@ -1,645 +1,644 @@
 import { AsciiLabel } from './AsciiLabel';
-        
+
 export const AsciiLabelNorwegian: AsciiLabel[] = [
   {
-    "ascii": 0,
-    "code": 0,
-    "label": ""
+    ascii: 0,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 1,
-    "code": 0,
-    "label": ""
+    ascii: 1,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 2,
-    "code": 0,
-    "label": ""
+    ascii: 2,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 3,
-    "code": 0,
-    "label": ""
+    ascii: 3,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 4,
-    "code": 0,
-    "label": ""
+    ascii: 4,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 5,
-    "code": 0,
-    "label": ""
+    ascii: 5,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 6,
-    "code": 0,
-    "label": ""
+    ascii: 6,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 7,
-    "code": 0,
-    "label": ""
+    ascii: 7,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 8,
-    "code": 42,
-    "label": "back space"
+    ascii: 8,
+    code: 42,
+    label: 'back space',
   },
   {
-    "ascii": 9,
-    "code": 43,
-    "label": "tab"
+    ascii: 9,
+    code: 43,
+    label: 'tab',
   },
   {
-    "ascii": 10,
-    "code": 40,
-    "label": "enter"
+    ascii: 10,
+    code: 40,
+    label: 'enter',
   },
   {
-    "ascii": 11,
-    "code": 0,
-    "label": ""
+    ascii: 11,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 12,
-    "code": 0,
-    "label": ""
+    ascii: 12,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 13,
-    "code": 0,
-    "label": ""
+    ascii: 13,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 14,
-    "code": 0,
-    "label": ""
+    ascii: 14,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 15,
-    "code": 0,
-    "label": ""
+    ascii: 15,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 16,
-    "code": 0,
-    "label": ""
+    ascii: 16,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 17,
-    "code": 0,
-    "label": ""
+    ascii: 17,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 18,
-    "code": 0,
-    "label": ""
+    ascii: 18,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 19,
-    "code": 0,
-    "label": ""
+    ascii: 19,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 20,
-    "code": 0,
-    "label": ""
+    ascii: 20,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 21,
-    "code": 0,
-    "label": ""
+    ascii: 21,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 22,
-    "code": 0,
-    "label": ""
+    ascii: 22,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 23,
-    "code": 0,
-    "label": ""
+    ascii: 23,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 24,
-    "code": 0,
-    "label": ""
+    ascii: 24,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 25,
-    "code": 0,
-    "label": ""
+    ascii: 25,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 26,
-    "code": 0,
-    "label": ""
+    ascii: 26,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 27,
-    "code": 41,
-    "label": "esc"
+    ascii: 27,
+    code: 41,
+    label: 'esc',
   },
   {
-    "ascii": 28,
-    "code": 0,
-    "label": ""
+    ascii: 28,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 29,
-    "code": 0,
-    "label": ""
+    ascii: 29,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 30,
-    "code": 0,
-    "label": ""
+    ascii: 30,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 31,
-    "code": 0,
-    "label": ""
+    ascii: 31,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 32,
-    "code": 44,
-    "label": "space"
+    ascii: 32,
+    code: 44,
+    label: 'space',
   },
   {
-    "ascii": 33,
-    "code": 542,
-    "label": "!"
+    ascii: 33,
+    code: 542,
+    label: '!',
   },
   {
-    "ascii": 34,
-    "code": 543,
-    "label": "\""
+    ascii: 34,
+    code: 543,
+    label: '"',
   },
   {
-    "ascii": 35,
-    "code": 544,
-    "label": "#"
+    ascii: 35,
+    code: 544,
+    label: '#',
   },
   {
-    "ascii": 36,
-    "code": 33,
-    "label": "4"
+    ascii: 36,
+    code: 33,
+    label: '4',
   },
   {
-    "ascii": 37,
-    "code": 546,
-    "label": "%"
+    ascii: 37,
+    code: 546,
+    label: '%',
   },
   {
-    "ascii": 38,
-    "code": 547,
-    "label": "&"
+    ascii: 38,
+    code: 547,
+    label: '&',
   },
   {
-    "ascii": 39,
-    "code": 50,
-    "label": "'"
+    ascii: 39,
+    code: 50,
+    label: "'",
   },
   {
-    "ascii": 40,
-    "code": 549,
-    "label": "("
+    ascii: 40,
+    code: 549,
+    label: '(',
   },
   {
-    "ascii": 41,
-    "code": 550,
-    "label": ")"
+    ascii: 41,
+    code: 550,
+    label: ')',
   },
   {
-    "ascii": 42,
-    "code": 562,
-    "label": "*"
+    ascii: 42,
+    code: 562,
+    label: '*',
   },
   {
-    "ascii": 43,
-    "code": 45,
-    "label": "+"
+    ascii: 43,
+    code: 45,
+    label: '+',
   },
   {
-    "ascii": 44,
-    "code": 54,
-    "label": ","
+    ascii: 44,
+    code: 54,
+    label: ',',
   },
   {
-    "ascii": 45,
-    "code": 56,
-    "label": "-"
+    ascii: 45,
+    code: 56,
+    label: '-',
   },
   {
-    "ascii": 46,
-    "code": 55,
-    "label": "."
+    ascii: 46,
+    code: 55,
+    label: '.',
   },
   {
-    "ascii": 47,
-    "code": 548,
-    "label": "/"
+    ascii: 47,
+    code: 548,
+    label: '/',
   },
   {
-    "ascii": 48,
-    "code": 39,
-    "label": "0"
+    ascii: 48,
+    code: 39,
+    label: '0',
   },
   {
-    "ascii": 49,
-    "code": 30,
-    "label": "1"
+    ascii: 49,
+    code: 30,
+    label: '1',
   },
   {
-    "ascii": 50,
-    "code": 31,
-    "label": "2"
+    ascii: 50,
+    code: 31,
+    label: '2',
   },
   {
-    "ascii": 51,
-    "code": 32,
-    "label": "3"
+    ascii: 51,
+    code: 32,
+    label: '3',
   },
   {
-    "ascii": 52,
-    "code": 33,
-    "label": "4"
+    ascii: 52,
+    code: 33,
+    label: '4',
   },
   {
-    "ascii": 53,
-    "code": 34,
-    "label": "5"
+    ascii: 53,
+    code: 34,
+    label: '5',
   },
   {
-    "ascii": 54,
-    "code": 35,
-    "label": "6"
+    ascii: 54,
+    code: 35,
+    label: '6',
   },
   {
-    "ascii": 55,
-    "code": 36,
-    "label": "7"
+    ascii: 55,
+    code: 36,
+    label: '7',
   },
   {
-    "ascii": 56,
-    "code": 37,
-    "label": "8"
+    ascii: 56,
+    code: 37,
+    label: '8',
   },
   {
-    "ascii": 57,
-    "code": 38,
-    "label": "9"
+    ascii: 57,
+    code: 38,
+    label: '9',
   },
   {
-    "ascii": 58,
-    "code": 567,
-    "label": ":"
+    ascii: 58,
+    code: 567,
+    label: ':',
   },
   {
-    "ascii": 59,
-    "code": 566,
-    "label": ";"
+    ascii: 59,
+    code: 566,
+    label: ';',
   },
   {
-    "ascii": 60,
-    "code": 100,
-    "label": "<"
+    ascii: 60,
+    code: 100,
+    label: '<',
   },
   {
-    "ascii": 61,
-    "code": 551,
-    "label": "="
+    ascii: 61,
+    code: 551,
+    label: '=',
   },
   {
-    "ascii": 62,
-    "code": 612,
-    "label": ">"
+    ascii: 62,
+    code: 612,
+    label: '>',
   },
   {
-    "ascii": 63,
-    "code": 557,
-    "label": "?"
+    ascii: 63,
+    code: 557,
+    label: '?',
   },
   {
-    "ascii": 64,
-    "code": 31,
-    "label": "2"
+    ascii: 64,
+    code: 31,
+    label: '2',
   },
   {
-    "ascii": 65,
-    "code": 516,
-    "label": "A"
+    ascii: 65,
+    code: 516,
+    label: 'A',
   },
   {
-    "ascii": 66,
-    "code": 517,
-    "label": "B"
+    ascii: 66,
+    code: 517,
+    label: 'B',
   },
   {
-    "ascii": 67,
-    "code": 518,
-    "label": "C"
+    ascii: 67,
+    code: 518,
+    label: 'C',
   },
   {
-    "ascii": 68,
-    "code": 519,
-    "label": "D"
+    ascii: 68,
+    code: 519,
+    label: 'D',
   },
   {
-    "ascii": 69,
-    "code": 520,
-    "label": "E"
+    ascii: 69,
+    code: 520,
+    label: 'E',
   },
   {
-    "ascii": 70,
-    "code": 521,
-    "label": "F"
+    ascii: 70,
+    code: 521,
+    label: 'F',
   },
   {
-    "ascii": 71,
-    "code": 522,
-    "label": "G"
+    ascii: 71,
+    code: 522,
+    label: 'G',
   },
   {
-    "ascii": 72,
-    "code": 523,
-    "label": "H"
+    ascii: 72,
+    code: 523,
+    label: 'H',
   },
   {
-    "ascii": 73,
-    "code": 524,
-    "label": "I"
+    ascii: 73,
+    code: 524,
+    label: 'I',
   },
   {
-    "ascii": 74,
-    "code": 525,
-    "label": "J"
+    ascii: 74,
+    code: 525,
+    label: 'J',
   },
   {
-    "ascii": 75,
-    "code": 526,
-    "label": "K"
+    ascii: 75,
+    code: 526,
+    label: 'K',
   },
   {
-    "ascii": 76,
-    "code": 527,
-    "label": "L"
+    ascii: 76,
+    code: 527,
+    label: 'L',
   },
   {
-    "ascii": 77,
-    "code": 528,
-    "label": "M"
+    ascii: 77,
+    code: 528,
+    label: 'M',
   },
   {
-    "ascii": 78,
-    "code": 529,
-    "label": "N"
+    ascii: 78,
+    code: 529,
+    label: 'N',
   },
   {
-    "ascii": 79,
-    "code": 530,
-    "label": "O"
+    ascii: 79,
+    code: 530,
+    label: 'O',
   },
   {
-    "ascii": 80,
-    "code": 531,
-    "label": "P"
+    ascii: 80,
+    code: 531,
+    label: 'P',
   },
   {
-    "ascii": 81,
-    "code": 532,
-    "label": "Q"
+    ascii: 81,
+    code: 532,
+    label: 'Q',
   },
   {
-    "ascii": 82,
-    "code": 533,
-    "label": "R"
+    ascii: 82,
+    code: 533,
+    label: 'R',
   },
   {
-    "ascii": 83,
-    "code": 534,
-    "label": "S"
+    ascii: 83,
+    code: 534,
+    label: 'S',
   },
   {
-    "ascii": 84,
-    "code": 535,
-    "label": "T"
+    ascii: 84,
+    code: 535,
+    label: 'T',
   },
   {
-    "ascii": 85,
-    "code": 536,
-    "label": "U"
+    ascii: 85,
+    code: 536,
+    label: 'U',
   },
   {
-    "ascii": 86,
-    "code": 537,
-    "label": "V"
+    ascii: 86,
+    code: 537,
+    label: 'V',
   },
   {
-    "ascii": 87,
-    "code": 538,
-    "label": "W"
+    ascii: 87,
+    code: 538,
+    label: 'W',
   },
   {
-    "ascii": 88,
-    "code": 539,
-    "label": "X"
+    ascii: 88,
+    code: 539,
+    label: 'X',
   },
   {
-    "ascii": 89,
-    "code": 540,
-    "label": "Y"
+    ascii: 89,
+    code: 540,
+    label: 'Y',
   },
   {
-    "ascii": 90,
-    "code": 541,
-    "label": "Z"
+    ascii: 90,
+    code: 541,
+    label: 'Z',
   },
   {
-    "ascii": 91,
-    "code": 37,
-    "label": "8"
+    ascii: 91,
+    code: 37,
+    label: '8',
   },
   {
-    "ascii": 92,
-    "code": 46,
-    "label": "(backslash)"
+    ascii: 92,
+    code: 46,
+    label: '(backslash)',
   },
   {
-    "ascii": 93,
-    "code": 38,
-    "label": "9"
+    ascii: 93,
+    code: 38,
+    label: '9',
   },
   {
-    "ascii": 94,
-    "code": 560,
-    "label": "^ (dead)"
+    ascii: 94,
+    code: 560,
+    label: '^ (dead)',
   },
   {
-    "ascii": 95,
-    "code": 568,
-    "label": "_"
+    ascii: 95,
+    code: 568,
+    label: '_',
   },
   {
-    "ascii": 96,
-    "code": 558,
-    "label": "` (dead)"
+    ascii: 96,
+    code: 558,
+    label: '` (dead)',
   },
   {
-    "ascii": 97,
-    "code": 4,
-    "label": "a"
+    ascii: 97,
+    code: 4,
+    label: 'a',
   },
   {
-    "ascii": 98,
-    "code": 5,
-    "label": "b"
+    ascii: 98,
+    code: 5,
+    label: 'b',
   },
   {
-    "ascii": 99,
-    "code": 6,
-    "label": "c"
+    ascii: 99,
+    code: 6,
+    label: 'c',
   },
   {
-    "ascii": 100,
-    "code": 7,
-    "label": "d"
+    ascii: 100,
+    code: 7,
+    label: 'd',
   },
   {
-    "ascii": 101,
-    "code": 8,
-    "label": "e"
+    ascii: 101,
+    code: 8,
+    label: 'e',
   },
   {
-    "ascii": 102,
-    "code": 9,
-    "label": "f"
+    ascii: 102,
+    code: 9,
+    label: 'f',
   },
   {
-    "ascii": 103,
-    "code": 10,
-    "label": "g"
+    ascii: 103,
+    code: 10,
+    label: 'g',
   },
   {
-    "ascii": 104,
-    "code": 11,
-    "label": "h"
+    ascii: 104,
+    code: 11,
+    label: 'h',
   },
   {
-    "ascii": 105,
-    "code": 12,
-    "label": "i"
+    ascii: 105,
+    code: 12,
+    label: 'i',
   },
   {
-    "ascii": 106,
-    "code": 13,
-    "label": "j"
+    ascii: 106,
+    code: 13,
+    label: 'j',
   },
   {
-    "ascii": 107,
-    "code": 14,
-    "label": "k"
+    ascii: 107,
+    code: 14,
+    label: 'k',
   },
   {
-    "ascii": 108,
-    "code": 15,
-    "label": "l"
+    ascii: 108,
+    code: 15,
+    label: 'l',
   },
   {
-    "ascii": 109,
-    "code": 16,
-    "label": "m"
+    ascii: 109,
+    code: 16,
+    label: 'm',
   },
   {
-    "ascii": 110,
-    "code": 17,
-    "label": "n"
+    ascii: 110,
+    code: 17,
+    label: 'n',
   },
   {
-    "ascii": 111,
-    "code": 18,
-    "label": "o"
+    ascii: 111,
+    code: 18,
+    label: 'o',
   },
   {
-    "ascii": 112,
-    "code": 19,
-    "label": "p"
+    ascii: 112,
+    code: 19,
+    label: 'p',
   },
   {
-    "ascii": 113,
-    "code": 20,
-    "label": "q"
+    ascii: 113,
+    code: 20,
+    label: 'q',
   },
   {
-    "ascii": 114,
-    "code": 21,
-    "label": "r"
+    ascii: 114,
+    code: 21,
+    label: 'r',
   },
   {
-    "ascii": 115,
-    "code": 22,
-    "label": "s"
+    ascii: 115,
+    code: 22,
+    label: 's',
   },
   {
-    "ascii": 116,
-    "code": 23,
-    "label": "t"
+    ascii: 116,
+    code: 23,
+    label: 't',
   },
   {
-    "ascii": 117,
-    "code": 24,
-    "label": "u"
+    ascii: 117,
+    code: 24,
+    label: 'u',
   },
   {
-    "ascii": 118,
-    "code": 25,
-    "label": "v"
+    ascii: 118,
+    code: 25,
+    label: 'v',
   },
   {
-    "ascii": 119,
-    "code": 26,
-    "label": "w"
+    ascii: 119,
+    code: 26,
+    label: 'w',
   },
   {
-    "ascii": 120,
-    "code": 27,
-    "label": "x"
+    ascii: 120,
+    code: 27,
+    label: 'x',
   },
   {
-    "ascii": 121,
-    "code": 28,
-    "label": "y"
+    ascii: 121,
+    code: 28,
+    label: 'y',
   },
   {
-    "ascii": 122,
-    "code": 29,
-    "label": "z"
+    ascii: 122,
+    code: 29,
+    label: 'z',
   },
   {
-    "ascii": 123,
-    "code": 36,
-    "label": "7"
+    ascii: 123,
+    code: 36,
+    label: '7',
   },
   {
-    "ascii": 124,
-    "code": 53,
-    "label": "|"
+    ascii: 124,
+    code: 53,
+    label: '|',
   },
   {
-    "ascii": 125,
-    "code": 39,
-    "label": "0"
+    ascii: 125,
+    code: 39,
+    label: '0',
   },
   {
-    "ascii": 126,
-    "code": 48,
-    "label": "¨ (dead)"
+    ascii: 126,
+    code: 48,
+    label: '¨ (dead)',
   },
   {
-    "ascii": 127,
-    "code": 76,
-    "label": "del"
-  }
+    ascii: 127,
+    code: 76,
+    label: 'del',
+  },
 ];
-    

--- a/src/services/labellang/AsciiLabelPortuguese.ts
+++ b/src/services/labellang/AsciiLabelPortuguese.ts
@@ -1,645 +1,644 @@
 import { AsciiLabel } from './AsciiLabel';
-        
+
 export const AsciiLabelPortuguese: AsciiLabel[] = [
   {
-    "ascii": 0,
-    "code": 0,
-    "label": ""
+    ascii: 0,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 1,
-    "code": 0,
-    "label": ""
+    ascii: 1,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 2,
-    "code": 0,
-    "label": ""
+    ascii: 2,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 3,
-    "code": 0,
-    "label": ""
+    ascii: 3,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 4,
-    "code": 0,
-    "label": ""
+    ascii: 4,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 5,
-    "code": 0,
-    "label": ""
+    ascii: 5,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 6,
-    "code": 0,
-    "label": ""
+    ascii: 6,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 7,
-    "code": 0,
-    "label": ""
+    ascii: 7,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 8,
-    "code": 42,
-    "label": "back space"
+    ascii: 8,
+    code: 42,
+    label: 'back space',
   },
   {
-    "ascii": 9,
-    "code": 43,
-    "label": "tab"
+    ascii: 9,
+    code: 43,
+    label: 'tab',
   },
   {
-    "ascii": 10,
-    "code": 40,
-    "label": "enter"
+    ascii: 10,
+    code: 40,
+    label: 'enter',
   },
   {
-    "ascii": 11,
-    "code": 0,
-    "label": ""
+    ascii: 11,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 12,
-    "code": 0,
-    "label": ""
+    ascii: 12,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 13,
-    "code": 0,
-    "label": ""
+    ascii: 13,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 14,
-    "code": 0,
-    "label": ""
+    ascii: 14,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 15,
-    "code": 0,
-    "label": ""
+    ascii: 15,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 16,
-    "code": 0,
-    "label": ""
+    ascii: 16,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 17,
-    "code": 0,
-    "label": ""
+    ascii: 17,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 18,
-    "code": 0,
-    "label": ""
+    ascii: 18,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 19,
-    "code": 0,
-    "label": ""
+    ascii: 19,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 20,
-    "code": 0,
-    "label": ""
+    ascii: 20,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 21,
-    "code": 0,
-    "label": ""
+    ascii: 21,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 22,
-    "code": 0,
-    "label": ""
+    ascii: 22,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 23,
-    "code": 0,
-    "label": ""
+    ascii: 23,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 24,
-    "code": 0,
-    "label": ""
+    ascii: 24,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 25,
-    "code": 0,
-    "label": ""
+    ascii: 25,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 26,
-    "code": 0,
-    "label": ""
+    ascii: 26,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 27,
-    "code": 41,
-    "label": "esc"
+    ascii: 27,
+    code: 41,
+    label: 'esc',
   },
   {
-    "ascii": 28,
-    "code": 0,
-    "label": ""
+    ascii: 28,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 29,
-    "code": 0,
-    "label": ""
+    ascii: 29,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 30,
-    "code": 0,
-    "label": ""
+    ascii: 30,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 31,
-    "code": 0,
-    "label": ""
+    ascii: 31,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 32,
-    "code": 44,
-    "label": "space"
+    ascii: 32,
+    code: 44,
+    label: 'space',
   },
   {
-    "ascii": 33,
-    "code": 542,
-    "label": "!"
+    ascii: 33,
+    code: 542,
+    label: '!',
   },
   {
-    "ascii": 34,
-    "code": 543,
-    "label": "\""
+    ascii: 34,
+    code: 543,
+    label: '"',
   },
   {
-    "ascii": 35,
-    "code": 544,
-    "label": "#"
+    ascii: 35,
+    code: 544,
+    label: '#',
   },
   {
-    "ascii": 36,
-    "code": 545,
-    "label": "$"
+    ascii: 36,
+    code: 545,
+    label: '$',
   },
   {
-    "ascii": 37,
-    "code": 546,
-    "label": "%"
+    ascii: 37,
+    code: 546,
+    label: '%',
   },
   {
-    "ascii": 38,
-    "code": 547,
-    "label": "&"
+    ascii: 38,
+    code: 547,
+    label: '&',
   },
   {
-    "ascii": 39,
-    "code": 45,
-    "label": "'"
+    ascii: 39,
+    code: 45,
+    label: "'",
   },
   {
-    "ascii": 40,
-    "code": 549,
-    "label": "("
+    ascii: 40,
+    code: 549,
+    label: '(',
   },
   {
-    "ascii": 41,
-    "code": 550,
-    "label": ")"
+    ascii: 41,
+    code: 550,
+    label: ')',
   },
   {
-    "ascii": 42,
-    "code": 559,
-    "label": "*"
+    ascii: 42,
+    code: 559,
+    label: '*',
   },
   {
-    "ascii": 43,
-    "code": 47,
-    "label": "+"
+    ascii: 43,
+    code: 47,
+    label: '+',
   },
   {
-    "ascii": 44,
-    "code": 54,
-    "label": ","
+    ascii: 44,
+    code: 54,
+    label: ',',
   },
   {
-    "ascii": 45,
-    "code": 56,
-    "label": "-"
+    ascii: 45,
+    code: 56,
+    label: '-',
   },
   {
-    "ascii": 46,
-    "code": 55,
-    "label": "."
+    ascii: 46,
+    code: 55,
+    label: '.',
   },
   {
-    "ascii": 47,
-    "code": 548,
-    "label": "/"
+    ascii: 47,
+    code: 548,
+    label: '/',
   },
   {
-    "ascii": 48,
-    "code": 39,
-    "label": "0"
+    ascii: 48,
+    code: 39,
+    label: '0',
   },
   {
-    "ascii": 49,
-    "code": 30,
-    "label": "1"
+    ascii: 49,
+    code: 30,
+    label: '1',
   },
   {
-    "ascii": 50,
-    "code": 31,
-    "label": "2"
+    ascii: 50,
+    code: 31,
+    label: '2',
   },
   {
-    "ascii": 51,
-    "code": 32,
-    "label": "3"
+    ascii: 51,
+    code: 32,
+    label: '3',
   },
   {
-    "ascii": 52,
-    "code": 33,
-    "label": "4"
+    ascii: 52,
+    code: 33,
+    label: '4',
   },
   {
-    "ascii": 53,
-    "code": 34,
-    "label": "5"
+    ascii: 53,
+    code: 34,
+    label: '5',
   },
   {
-    "ascii": 54,
-    "code": 35,
-    "label": "6"
+    ascii: 54,
+    code: 35,
+    label: '6',
   },
   {
-    "ascii": 55,
-    "code": 36,
-    "label": "7"
+    ascii: 55,
+    code: 36,
+    label: '7',
   },
   {
-    "ascii": 56,
-    "code": 37,
-    "label": "8"
+    ascii: 56,
+    code: 37,
+    label: '8',
   },
   {
-    "ascii": 57,
-    "code": 38,
-    "label": "9"
+    ascii: 57,
+    code: 38,
+    label: '9',
   },
   {
-    "ascii": 58,
-    "code": 567,
-    "label": ":"
+    ascii: 58,
+    code: 567,
+    label: ':',
   },
   {
-    "ascii": 59,
-    "code": 566,
-    "label": ";"
+    ascii: 59,
+    code: 566,
+    label: ';',
   },
   {
-    "ascii": 60,
-    "code": 100,
-    "label": "<"
+    ascii: 60,
+    code: 100,
+    label: '<',
   },
   {
-    "ascii": 61,
-    "code": 551,
-    "label": "="
+    ascii: 61,
+    code: 551,
+    label: '=',
   },
   {
-    "ascii": 62,
-    "code": 612,
-    "label": ">"
+    ascii: 62,
+    code: 612,
+    label: '>',
   },
   {
-    "ascii": 63,
-    "code": 557,
-    "label": "?"
+    ascii: 63,
+    code: 557,
+    label: '?',
   },
   {
-    "ascii": 64,
-    "code": 31,
-    "label": "2"
+    ascii: 64,
+    code: 31,
+    label: '2',
   },
   {
-    "ascii": 65,
-    "code": 516,
-    "label": "A"
+    ascii: 65,
+    code: 516,
+    label: 'A',
   },
   {
-    "ascii": 66,
-    "code": 517,
-    "label": "B"
+    ascii: 66,
+    code: 517,
+    label: 'B',
   },
   {
-    "ascii": 67,
-    "code": 518,
-    "label": "C"
+    ascii: 67,
+    code: 518,
+    label: 'C',
   },
   {
-    "ascii": 68,
-    "code": 519,
-    "label": "D"
+    ascii: 68,
+    code: 519,
+    label: 'D',
   },
   {
-    "ascii": 69,
-    "code": 520,
-    "label": "E"
+    ascii: 69,
+    code: 520,
+    label: 'E',
   },
   {
-    "ascii": 70,
-    "code": 521,
-    "label": "F"
+    ascii: 70,
+    code: 521,
+    label: 'F',
   },
   {
-    "ascii": 71,
-    "code": 522,
-    "label": "G"
+    ascii: 71,
+    code: 522,
+    label: 'G',
   },
   {
-    "ascii": 72,
-    "code": 523,
-    "label": "H"
+    ascii: 72,
+    code: 523,
+    label: 'H',
   },
   {
-    "ascii": 73,
-    "code": 524,
-    "label": "I"
+    ascii: 73,
+    code: 524,
+    label: 'I',
   },
   {
-    "ascii": 74,
-    "code": 525,
-    "label": "J"
+    ascii: 74,
+    code: 525,
+    label: 'J',
   },
   {
-    "ascii": 75,
-    "code": 526,
-    "label": "K"
+    ascii: 75,
+    code: 526,
+    label: 'K',
   },
   {
-    "ascii": 76,
-    "code": 527,
-    "label": "L"
+    ascii: 76,
+    code: 527,
+    label: 'L',
   },
   {
-    "ascii": 77,
-    "code": 528,
-    "label": "M"
+    ascii: 77,
+    code: 528,
+    label: 'M',
   },
   {
-    "ascii": 78,
-    "code": 529,
-    "label": "N"
+    ascii: 78,
+    code: 529,
+    label: 'N',
   },
   {
-    "ascii": 79,
-    "code": 530,
-    "label": "O"
+    ascii: 79,
+    code: 530,
+    label: 'O',
   },
   {
-    "ascii": 80,
-    "code": 531,
-    "label": "P"
+    ascii: 80,
+    code: 531,
+    label: 'P',
   },
   {
-    "ascii": 81,
-    "code": 532,
-    "label": "Q"
+    ascii: 81,
+    code: 532,
+    label: 'Q',
   },
   {
-    "ascii": 82,
-    "code": 533,
-    "label": "R"
+    ascii: 82,
+    code: 533,
+    label: 'R',
   },
   {
-    "ascii": 83,
-    "code": 534,
-    "label": "S"
+    ascii: 83,
+    code: 534,
+    label: 'S',
   },
   {
-    "ascii": 84,
-    "code": 535,
-    "label": "T"
+    ascii: 84,
+    code: 535,
+    label: 'T',
   },
   {
-    "ascii": 85,
-    "code": 536,
-    "label": "U"
+    ascii: 85,
+    code: 536,
+    label: 'U',
   },
   {
-    "ascii": 86,
-    "code": 537,
-    "label": "V"
+    ascii: 86,
+    code: 537,
+    label: 'V',
   },
   {
-    "ascii": 87,
-    "code": 538,
-    "label": "W"
+    ascii: 87,
+    code: 538,
+    label: 'W',
   },
   {
-    "ascii": 88,
-    "code": 539,
-    "label": "X"
+    ascii: 88,
+    code: 539,
+    label: 'X',
   },
   {
-    "ascii": 89,
-    "code": 540,
-    "label": "Y"
+    ascii: 89,
+    code: 540,
+    label: 'Y',
   },
   {
-    "ascii": 90,
-    "code": 541,
-    "label": "Z"
+    ascii: 90,
+    code: 541,
+    label: 'Z',
   },
   {
-    "ascii": 91,
-    "code": 37,
-    "label": "8"
+    ascii: 91,
+    code: 37,
+    label: '8',
   },
   {
-    "ascii": 92,
-    "code": 53,
-    "label": "(backslash)"
+    ascii: 92,
+    code: 53,
+    label: '(backslash)',
   },
   {
-    "ascii": 93,
-    "code": 38,
-    "label": "9"
+    ascii: 93,
+    code: 38,
+    label: '9',
   },
   {
-    "ascii": 94,
-    "code": 562,
-    "label": "^ (dead)"
+    ascii: 94,
+    code: 562,
+    label: '^ (dead)',
   },
   {
-    "ascii": 95,
-    "code": 568,
-    "label": "_"
+    ascii: 95,
+    code: 568,
+    label: '_',
   },
   {
-    "ascii": 96,
-    "code": 560,
-    "label": "` (dead)"
+    ascii: 96,
+    code: 560,
+    label: '` (dead)',
   },
   {
-    "ascii": 97,
-    "code": 4,
-    "label": "a"
+    ascii: 97,
+    code: 4,
+    label: 'a',
   },
   {
-    "ascii": 98,
-    "code": 5,
-    "label": "b"
+    ascii: 98,
+    code: 5,
+    label: 'b',
   },
   {
-    "ascii": 99,
-    "code": 6,
-    "label": "c"
+    ascii: 99,
+    code: 6,
+    label: 'c',
   },
   {
-    "ascii": 100,
-    "code": 7,
-    "label": "d"
+    ascii: 100,
+    code: 7,
+    label: 'd',
   },
   {
-    "ascii": 101,
-    "code": 8,
-    "label": "e"
+    ascii: 101,
+    code: 8,
+    label: 'e',
   },
   {
-    "ascii": 102,
-    "code": 9,
-    "label": "f"
+    ascii: 102,
+    code: 9,
+    label: 'f',
   },
   {
-    "ascii": 103,
-    "code": 10,
-    "label": "g"
+    ascii: 103,
+    code: 10,
+    label: 'g',
   },
   {
-    "ascii": 104,
-    "code": 11,
-    "label": "h"
+    ascii: 104,
+    code: 11,
+    label: 'h',
   },
   {
-    "ascii": 105,
-    "code": 12,
-    "label": "i"
+    ascii: 105,
+    code: 12,
+    label: 'i',
   },
   {
-    "ascii": 106,
-    "code": 13,
-    "label": "j"
+    ascii: 106,
+    code: 13,
+    label: 'j',
   },
   {
-    "ascii": 107,
-    "code": 14,
-    "label": "k"
+    ascii: 107,
+    code: 14,
+    label: 'k',
   },
   {
-    "ascii": 108,
-    "code": 15,
-    "label": "l"
+    ascii: 108,
+    code: 15,
+    label: 'l',
   },
   {
-    "ascii": 109,
-    "code": 16,
-    "label": "m"
+    ascii: 109,
+    code: 16,
+    label: 'm',
   },
   {
-    "ascii": 110,
-    "code": 17,
-    "label": "n"
+    ascii: 110,
+    code: 17,
+    label: 'n',
   },
   {
-    "ascii": 111,
-    "code": 18,
-    "label": "o"
+    ascii: 111,
+    code: 18,
+    label: 'o',
   },
   {
-    "ascii": 112,
-    "code": 19,
-    "label": "p"
+    ascii: 112,
+    code: 19,
+    label: 'p',
   },
   {
-    "ascii": 113,
-    "code": 20,
-    "label": "q"
+    ascii: 113,
+    code: 20,
+    label: 'q',
   },
   {
-    "ascii": 114,
-    "code": 21,
-    "label": "r"
+    ascii: 114,
+    code: 21,
+    label: 'r',
   },
   {
-    "ascii": 115,
-    "code": 22,
-    "label": "s"
+    ascii: 115,
+    code: 22,
+    label: 's',
   },
   {
-    "ascii": 116,
-    "code": 23,
-    "label": "t"
+    ascii: 116,
+    code: 23,
+    label: 't',
   },
   {
-    "ascii": 117,
-    "code": 24,
-    "label": "u"
+    ascii: 117,
+    code: 24,
+    label: 'u',
   },
   {
-    "ascii": 118,
-    "code": 25,
-    "label": "v"
+    ascii: 118,
+    code: 25,
+    label: 'v',
   },
   {
-    "ascii": 119,
-    "code": 26,
-    "label": "w"
+    ascii: 119,
+    code: 26,
+    label: 'w',
   },
   {
-    "ascii": 120,
-    "code": 27,
-    "label": "x"
+    ascii: 120,
+    code: 27,
+    label: 'x',
   },
   {
-    "ascii": 121,
-    "code": 28,
-    "label": "y"
+    ascii: 121,
+    code: 28,
+    label: 'y',
   },
   {
-    "ascii": 122,
-    "code": 29,
-    "label": "z"
+    ascii: 122,
+    code: 29,
+    label: 'z',
   },
   {
-    "ascii": 123,
-    "code": 36,
-    "label": "7"
+    ascii: 123,
+    code: 36,
+    label: '7',
   },
   {
-    "ascii": 124,
-    "code": 565,
-    "label": "|"
+    ascii: 124,
+    code: 565,
+    label: '|',
   },
   {
-    "ascii": 125,
-    "code": 39,
-    "label": "0"
+    ascii: 125,
+    code: 39,
+    label: '0',
   },
   {
-    "ascii": 126,
-    "code": 50,
-    "label": "~ (dead)"
+    ascii: 126,
+    code: 50,
+    label: '~ (dead)',
   },
   {
-    "ascii": 127,
-    "code": 76,
-    "label": "del"
-  }
+    ascii: 127,
+    code: 76,
+    label: 'del',
+  },
 ];
-    

--- a/src/services/labellang/AsciiLabelPortuguese_osx_iso.ts
+++ b/src/services/labellang/AsciiLabelPortuguese_osx_iso.ts
@@ -1,645 +1,644 @@
 import { AsciiLabel } from './AsciiLabel';
-        
+
 export const AsciiLabelPortuguese_osx_iso: AsciiLabel[] = [
   {
-    "ascii": 0,
-    "code": 0,
-    "label": ""
+    ascii: 0,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 1,
-    "code": 0,
-    "label": ""
+    ascii: 1,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 2,
-    "code": 0,
-    "label": ""
+    ascii: 2,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 3,
-    "code": 0,
-    "label": ""
+    ascii: 3,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 4,
-    "code": 0,
-    "label": ""
+    ascii: 4,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 5,
-    "code": 0,
-    "label": ""
+    ascii: 5,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 6,
-    "code": 0,
-    "label": ""
+    ascii: 6,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 7,
-    "code": 0,
-    "label": ""
+    ascii: 7,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 8,
-    "code": 42,
-    "label": "back space"
+    ascii: 8,
+    code: 42,
+    label: 'back space',
   },
   {
-    "ascii": 9,
-    "code": 43,
-    "label": "tab"
+    ascii: 9,
+    code: 43,
+    label: 'tab',
   },
   {
-    "ascii": 10,
-    "code": 40,
-    "label": "enter"
+    ascii: 10,
+    code: 40,
+    label: 'enter',
   },
   {
-    "ascii": 11,
-    "code": 0,
-    "label": ""
+    ascii: 11,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 12,
-    "code": 0,
-    "label": ""
+    ascii: 12,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 13,
-    "code": 0,
-    "label": ""
+    ascii: 13,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 14,
-    "code": 0,
-    "label": ""
+    ascii: 14,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 15,
-    "code": 0,
-    "label": ""
+    ascii: 15,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 16,
-    "code": 0,
-    "label": ""
+    ascii: 16,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 17,
-    "code": 0,
-    "label": ""
+    ascii: 17,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 18,
-    "code": 0,
-    "label": ""
+    ascii: 18,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 19,
-    "code": 0,
-    "label": ""
+    ascii: 19,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 20,
-    "code": 0,
-    "label": ""
+    ascii: 20,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 21,
-    "code": 0,
-    "label": ""
+    ascii: 21,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 22,
-    "code": 0,
-    "label": ""
+    ascii: 22,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 23,
-    "code": 0,
-    "label": ""
+    ascii: 23,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 24,
-    "code": 0,
-    "label": ""
+    ascii: 24,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 25,
-    "code": 0,
-    "label": ""
+    ascii: 25,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 26,
-    "code": 0,
-    "label": ""
+    ascii: 26,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 27,
-    "code": 41,
-    "label": "esc"
+    ascii: 27,
+    code: 41,
+    label: 'esc',
   },
   {
-    "ascii": 28,
-    "code": 0,
-    "label": ""
+    ascii: 28,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 29,
-    "code": 0,
-    "label": ""
+    ascii: 29,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 30,
-    "code": 0,
-    "label": ""
+    ascii: 30,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 31,
-    "code": 0,
-    "label": ""
+    ascii: 31,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 32,
-    "code": 44,
-    "label": "space"
+    ascii: 32,
+    code: 44,
+    label: 'space',
   },
   {
-    "ascii": 33,
-    "code": 542,
-    "label": "!"
+    ascii: 33,
+    code: 542,
+    label: '!',
   },
   {
-    "ascii": 34,
-    "code": 543,
-    "label": "\""
+    ascii: 34,
+    code: 543,
+    label: '"',
   },
   {
-    "ascii": 35,
-    "code": 544,
-    "label": "#"
+    ascii: 35,
+    code: 544,
+    label: '#',
   },
   {
-    "ascii": 36,
-    "code": 545,
-    "label": "$"
+    ascii: 36,
+    code: 545,
+    label: '$',
   },
   {
-    "ascii": 37,
-    "code": 546,
-    "label": "%"
+    ascii: 37,
+    code: 546,
+    label: '%',
   },
   {
-    "ascii": 38,
-    "code": 547,
-    "label": "&"
+    ascii: 38,
+    code: 547,
+    label: '&',
   },
   {
-    "ascii": 39,
-    "code": 45,
-    "label": "'"
+    ascii: 39,
+    code: 45,
+    label: "'",
   },
   {
-    "ascii": 40,
-    "code": 549,
-    "label": "("
+    ascii: 40,
+    code: 549,
+    label: '(',
   },
   {
-    "ascii": 41,
-    "code": 550,
-    "label": ")"
+    ascii: 41,
+    code: 550,
+    label: ')',
   },
   {
-    "ascii": 42,
-    "code": 558,
-    "label": "*"
+    ascii: 42,
+    code: 558,
+    label: '*',
   },
   {
-    "ascii": 43,
-    "code": 46,
-    "label": "+"
+    ascii: 43,
+    code: 46,
+    label: '+',
   },
   {
-    "ascii": 44,
-    "code": 54,
-    "label": ","
+    ascii: 44,
+    code: 54,
+    label: ',',
   },
   {
-    "ascii": 45,
-    "code": 56,
-    "label": "-"
+    ascii: 45,
+    code: 56,
+    label: '-',
   },
   {
-    "ascii": 46,
-    "code": 55,
-    "label": "."
+    ascii: 46,
+    code: 55,
+    label: '.',
   },
   {
-    "ascii": 47,
-    "code": 548,
-    "label": "/"
+    ascii: 47,
+    code: 548,
+    label: '/',
   },
   {
-    "ascii": 48,
-    "code": 39,
-    "label": "0"
+    ascii: 48,
+    code: 39,
+    label: '0',
   },
   {
-    "ascii": 49,
-    "code": 30,
-    "label": "1"
+    ascii: 49,
+    code: 30,
+    label: '1',
   },
   {
-    "ascii": 50,
-    "code": 31,
-    "label": "2"
+    ascii: 50,
+    code: 31,
+    label: '2',
   },
   {
-    "ascii": 51,
-    "code": 32,
-    "label": "3"
+    ascii: 51,
+    code: 32,
+    label: '3',
   },
   {
-    "ascii": 52,
-    "code": 33,
-    "label": "4"
+    ascii: 52,
+    code: 33,
+    label: '4',
   },
   {
-    "ascii": 53,
-    "code": 34,
-    "label": "5"
+    ascii: 53,
+    code: 34,
+    label: '5',
   },
   {
-    "ascii": 54,
-    "code": 35,
-    "label": "6"
+    ascii: 54,
+    code: 35,
+    label: '6',
   },
   {
-    "ascii": 55,
-    "code": 36,
-    "label": "7"
+    ascii: 55,
+    code: 36,
+    label: '7',
   },
   {
-    "ascii": 56,
-    "code": 37,
-    "label": "8"
+    ascii: 56,
+    code: 37,
+    label: '8',
   },
   {
-    "ascii": 57,
-    "code": 38,
-    "label": "9"
+    ascii: 57,
+    code: 38,
+    label: '9',
   },
   {
-    "ascii": 58,
-    "code": 567,
-    "label": ":"
+    ascii: 58,
+    code: 567,
+    label: ':',
   },
   {
-    "ascii": 59,
-    "code": 566,
-    "label": ";"
+    ascii: 59,
+    code: 566,
+    label: ';',
   },
   {
-    "ascii": 60,
-    "code": 100,
-    "label": "<"
+    ascii: 60,
+    code: 100,
+    label: '<',
   },
   {
-    "ascii": 61,
-    "code": 551,
-    "label": "="
+    ascii: 61,
+    code: 551,
+    label: '=',
   },
   {
-    "ascii": 62,
-    "code": 612,
-    "label": ">"
+    ascii: 62,
+    code: 612,
+    label: '>',
   },
   {
-    "ascii": 63,
-    "code": 557,
-    "label": "?"
+    ascii: 63,
+    code: 557,
+    label: '?',
   },
   {
-    "ascii": 64,
-    "code": 31,
-    "label": "2"
+    ascii: 64,
+    code: 31,
+    label: '2',
   },
   {
-    "ascii": 65,
-    "code": 516,
-    "label": "A"
+    ascii: 65,
+    code: 516,
+    label: 'A',
   },
   {
-    "ascii": 66,
-    "code": 517,
-    "label": "B"
+    ascii: 66,
+    code: 517,
+    label: 'B',
   },
   {
-    "ascii": 67,
-    "code": 518,
-    "label": "C"
+    ascii: 67,
+    code: 518,
+    label: 'C',
   },
   {
-    "ascii": 68,
-    "code": 519,
-    "label": "D"
+    ascii: 68,
+    code: 519,
+    label: 'D',
   },
   {
-    "ascii": 69,
-    "code": 520,
-    "label": "E"
+    ascii: 69,
+    code: 520,
+    label: 'E',
   },
   {
-    "ascii": 70,
-    "code": 521,
-    "label": "F"
+    ascii: 70,
+    code: 521,
+    label: 'F',
   },
   {
-    "ascii": 71,
-    "code": 522,
-    "label": "G"
+    ascii: 71,
+    code: 522,
+    label: 'G',
   },
   {
-    "ascii": 72,
-    "code": 523,
-    "label": "H"
+    ascii: 72,
+    code: 523,
+    label: 'H',
   },
   {
-    "ascii": 73,
-    "code": 524,
-    "label": "I"
+    ascii: 73,
+    code: 524,
+    label: 'I',
   },
   {
-    "ascii": 74,
-    "code": 525,
-    "label": "J"
+    ascii: 74,
+    code: 525,
+    label: 'J',
   },
   {
-    "ascii": 75,
-    "code": 526,
-    "label": "K"
+    ascii: 75,
+    code: 526,
+    label: 'K',
   },
   {
-    "ascii": 76,
-    "code": 527,
-    "label": "L"
+    ascii: 76,
+    code: 527,
+    label: 'L',
   },
   {
-    "ascii": 77,
-    "code": 528,
-    "label": "M"
+    ascii: 77,
+    code: 528,
+    label: 'M',
   },
   {
-    "ascii": 78,
-    "code": 529,
-    "label": "N"
+    ascii: 78,
+    code: 529,
+    label: 'N',
   },
   {
-    "ascii": 79,
-    "code": 530,
-    "label": "O"
+    ascii: 79,
+    code: 530,
+    label: 'O',
   },
   {
-    "ascii": 80,
-    "code": 531,
-    "label": "P"
+    ascii: 80,
+    code: 531,
+    label: 'P',
   },
   {
-    "ascii": 81,
-    "code": 532,
-    "label": "Q"
+    ascii: 81,
+    code: 532,
+    label: 'Q',
   },
   {
-    "ascii": 82,
-    "code": 533,
-    "label": "R"
+    ascii: 82,
+    code: 533,
+    label: 'R',
   },
   {
-    "ascii": 83,
-    "code": 534,
-    "label": "S"
+    ascii: 83,
+    code: 534,
+    label: 'S',
   },
   {
-    "ascii": 84,
-    "code": 535,
-    "label": "T"
+    ascii: 84,
+    code: 535,
+    label: 'T',
   },
   {
-    "ascii": 85,
-    "code": 536,
-    "label": "U"
+    ascii: 85,
+    code: 536,
+    label: 'U',
   },
   {
-    "ascii": 86,
-    "code": 537,
-    "label": "V"
+    ascii: 86,
+    code: 537,
+    label: 'V',
   },
   {
-    "ascii": 87,
-    "code": 538,
-    "label": "W"
+    ascii: 87,
+    code: 538,
+    label: 'W',
   },
   {
-    "ascii": 88,
-    "code": 539,
-    "label": "X"
+    ascii: 88,
+    code: 539,
+    label: 'X',
   },
   {
-    "ascii": 89,
-    "code": 540,
-    "label": "Y"
+    ascii: 89,
+    code: 540,
+    label: 'Y',
   },
   {
-    "ascii": 90,
-    "code": 541,
-    "label": "Z"
+    ascii: 90,
+    code: 541,
+    label: 'Z',
   },
   {
-    "ascii": 91,
-    "code": 37,
-    "label": "8"
+    ascii: 91,
+    code: 37,
+    label: '8',
   },
   {
-    "ascii": 92,
-    "code": 50,
-    "label": "(backslash)"
+    ascii: 92,
+    code: 50,
+    label: '(backslash)',
   },
   {
-    "ascii": 93,
-    "code": 38,
-    "label": "9"
+    ascii: 93,
+    code: 38,
+    label: '9',
   },
   {
-    "ascii": 94,
-    "code": 564,
-    "label": "^ (dead)"
+    ascii: 94,
+    code: 564,
+    label: '^ (dead)',
   },
   {
-    "ascii": 95,
-    "code": 568,
-    "label": "_"
+    ascii: 95,
+    code: 568,
+    label: '_',
   },
   {
-    "ascii": 96,
-    "code": 560,
-    "label": "` (dead)"
+    ascii: 96,
+    code: 560,
+    label: '` (dead)',
   },
   {
-    "ascii": 97,
-    "code": 4,
-    "label": "a"
+    ascii: 97,
+    code: 4,
+    label: 'a',
   },
   {
-    "ascii": 98,
-    "code": 5,
-    "label": "b"
+    ascii: 98,
+    code: 5,
+    label: 'b',
   },
   {
-    "ascii": 99,
-    "code": 6,
-    "label": "c"
+    ascii: 99,
+    code: 6,
+    label: 'c',
   },
   {
-    "ascii": 100,
-    "code": 7,
-    "label": "d"
+    ascii: 100,
+    code: 7,
+    label: 'd',
   },
   {
-    "ascii": 101,
-    "code": 8,
-    "label": "e"
+    ascii: 101,
+    code: 8,
+    label: 'e',
   },
   {
-    "ascii": 102,
-    "code": 9,
-    "label": "f"
+    ascii: 102,
+    code: 9,
+    label: 'f',
   },
   {
-    "ascii": 103,
-    "code": 10,
-    "label": "g"
+    ascii: 103,
+    code: 10,
+    label: 'g',
   },
   {
-    "ascii": 104,
-    "code": 11,
-    "label": "h"
+    ascii: 104,
+    code: 11,
+    label: 'h',
   },
   {
-    "ascii": 105,
-    "code": 12,
-    "label": "i"
+    ascii: 105,
+    code: 12,
+    label: 'i',
   },
   {
-    "ascii": 106,
-    "code": 13,
-    "label": "j"
+    ascii: 106,
+    code: 13,
+    label: 'j',
   },
   {
-    "ascii": 107,
-    "code": 14,
-    "label": "k"
+    ascii: 107,
+    code: 14,
+    label: 'k',
   },
   {
-    "ascii": 108,
-    "code": 15,
-    "label": "l"
+    ascii: 108,
+    code: 15,
+    label: 'l',
   },
   {
-    "ascii": 109,
-    "code": 16,
-    "label": "m"
+    ascii: 109,
+    code: 16,
+    label: 'm',
   },
   {
-    "ascii": 110,
-    "code": 17,
-    "label": "n"
+    ascii: 110,
+    code: 17,
+    label: 'n',
   },
   {
-    "ascii": 111,
-    "code": 18,
-    "label": "o"
+    ascii: 111,
+    code: 18,
+    label: 'o',
   },
   {
-    "ascii": 112,
-    "code": 19,
-    "label": "p"
+    ascii: 112,
+    code: 19,
+    label: 'p',
   },
   {
-    "ascii": 113,
-    "code": 20,
-    "label": "q"
+    ascii: 113,
+    code: 20,
+    label: 'q',
   },
   {
-    "ascii": 114,
-    "code": 21,
-    "label": "r"
+    ascii: 114,
+    code: 21,
+    label: 'r',
   },
   {
-    "ascii": 115,
-    "code": 22,
-    "label": "s"
+    ascii: 115,
+    code: 22,
+    label: 's',
   },
   {
-    "ascii": 116,
-    "code": 23,
-    "label": "t"
+    ascii: 116,
+    code: 23,
+    label: 't',
   },
   {
-    "ascii": 117,
-    "code": 24,
-    "label": "u"
+    ascii: 117,
+    code: 24,
+    label: 'u',
   },
   {
-    "ascii": 118,
-    "code": 25,
-    "label": "v"
+    ascii: 118,
+    code: 25,
+    label: 'v',
   },
   {
-    "ascii": 119,
-    "code": 26,
-    "label": "w"
+    ascii: 119,
+    code: 26,
+    label: 'w',
   },
   {
-    "ascii": 120,
-    "code": 27,
-    "label": "x"
+    ascii: 120,
+    code: 27,
+    label: 'x',
   },
   {
-    "ascii": 121,
-    "code": 28,
-    "label": "y"
+    ascii: 121,
+    code: 28,
+    label: 'y',
   },
   {
-    "ascii": 122,
-    "code": 29,
-    "label": "z"
+    ascii: 122,
+    code: 29,
+    label: 'z',
   },
   {
-    "ascii": 123,
-    "code": 549,
-    "label": "("
+    ascii: 123,
+    code: 549,
+    label: '(',
   },
   {
-    "ascii": 124,
-    "code": 562,
-    "label": "|"
+    ascii: 124,
+    code: 562,
+    label: '|',
   },
   {
-    "ascii": 125,
-    "code": 550,
-    "label": ")"
+    ascii: 125,
+    code: 550,
+    label: ')',
   },
   {
-    "ascii": 126,
-    "code": 52,
-    "label": "~ (dead)"
+    ascii: 126,
+    code: 52,
+    label: '~ (dead)',
   },
   {
-    "ascii": 127,
-    "code": 76,
-    "label": "del"
-  }
+    ascii: 127,
+    code: 76,
+    label: 'del',
+  },
 ];
-    

--- a/src/services/labellang/AsciiLabelRomanian.ts
+++ b/src/services/labellang/AsciiLabelRomanian.ts
@@ -1,645 +1,644 @@
 import { AsciiLabel } from './AsciiLabel';
-        
+
 export const AsciiLabelRomanian: AsciiLabel[] = [
   {
-    "ascii": 0,
-    "code": 0,
-    "label": ""
+    ascii: 0,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 1,
-    "code": 0,
-    "label": ""
+    ascii: 1,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 2,
-    "code": 0,
-    "label": ""
+    ascii: 2,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 3,
-    "code": 0,
-    "label": ""
+    ascii: 3,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 4,
-    "code": 0,
-    "label": ""
+    ascii: 4,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 5,
-    "code": 0,
-    "label": ""
+    ascii: 5,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 6,
-    "code": 0,
-    "label": ""
+    ascii: 6,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 7,
-    "code": 0,
-    "label": ""
+    ascii: 7,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 8,
-    "code": 42,
-    "label": "back space"
+    ascii: 8,
+    code: 42,
+    label: 'back space',
   },
   {
-    "ascii": 9,
-    "code": 43,
-    "label": "tab"
+    ascii: 9,
+    code: 43,
+    label: 'tab',
   },
   {
-    "ascii": 10,
-    "code": 40,
-    "label": "enter"
+    ascii: 10,
+    code: 40,
+    label: 'enter',
   },
   {
-    "ascii": 11,
-    "code": 0,
-    "label": ""
+    ascii: 11,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 12,
-    "code": 0,
-    "label": ""
+    ascii: 12,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 13,
-    "code": 0,
-    "label": ""
+    ascii: 13,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 14,
-    "code": 0,
-    "label": ""
+    ascii: 14,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 15,
-    "code": 0,
-    "label": ""
+    ascii: 15,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 16,
-    "code": 0,
-    "label": ""
+    ascii: 16,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 17,
-    "code": 0,
-    "label": ""
+    ascii: 17,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 18,
-    "code": 0,
-    "label": ""
+    ascii: 18,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 19,
-    "code": 0,
-    "label": ""
+    ascii: 19,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 20,
-    "code": 0,
-    "label": ""
+    ascii: 20,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 21,
-    "code": 0,
-    "label": ""
+    ascii: 21,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 22,
-    "code": 0,
-    "label": ""
+    ascii: 22,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 23,
-    "code": 0,
-    "label": ""
+    ascii: 23,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 24,
-    "code": 0,
-    "label": ""
+    ascii: 24,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 25,
-    "code": 0,
-    "label": ""
+    ascii: 25,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 26,
-    "code": 0,
-    "label": ""
+    ascii: 26,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 27,
-    "code": 41,
-    "label": "esc"
+    ascii: 27,
+    code: 41,
+    label: 'esc',
   },
   {
-    "ascii": 28,
-    "code": 0,
-    "label": ""
+    ascii: 28,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 29,
-    "code": 0,
-    "label": ""
+    ascii: 29,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 30,
-    "code": 0,
-    "label": ""
+    ascii: 30,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 31,
-    "code": 0,
-    "label": ""
+    ascii: 31,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 32,
-    "code": 44,
-    "label": "space"
+    ascii: 32,
+    code: 44,
+    label: 'space',
   },
   {
-    "ascii": 33,
-    "code": 542,
-    "label": "!"
+    ascii: 33,
+    code: 542,
+    label: '!',
   },
   {
-    "ascii": 34,
-    "code": 564,
-    "label": "Ț"
+    ascii: 34,
+    code: 564,
+    label: 'Ț',
   },
   {
-    "ascii": 35,
-    "code": 544,
-    "label": "#"
+    ascii: 35,
+    code: 544,
+    label: '#',
   },
   {
-    "ascii": 36,
-    "code": 545,
-    "label": "$"
+    ascii: 36,
+    code: 545,
+    label: '$',
   },
   {
-    "ascii": 37,
-    "code": 546,
-    "label": "%"
+    ascii: 37,
+    code: 546,
+    label: '%',
   },
   {
-    "ascii": 38,
-    "code": 548,
-    "label": "&"
+    ascii: 38,
+    code: 548,
+    label: '&',
   },
   {
-    "ascii": 39,
-    "code": 52,
-    "label": "Ț"
+    ascii: 39,
+    code: 52,
+    label: 'Ț',
   },
   {
-    "ascii": 40,
-    "code": 550,
-    "label": "("
+    ascii: 40,
+    code: 550,
+    label: '(',
   },
   {
-    "ascii": 41,
-    "code": 551,
-    "label": ")"
+    ascii: 41,
+    code: 551,
+    label: ')',
   },
   {
-    "ascii": 42,
-    "code": 549,
-    "label": "*"
+    ascii: 42,
+    code: 549,
+    label: '*',
   },
   {
-    "ascii": 43,
-    "code": 558,
-    "label": "+"
+    ascii: 43,
+    code: 558,
+    label: '+',
   },
   {
-    "ascii": 44,
-    "code": 54,
-    "label": ","
+    ascii: 44,
+    code: 54,
+    label: ',',
   },
   {
-    "ascii": 45,
-    "code": 45,
-    "label": "-"
+    ascii: 45,
+    code: 45,
+    label: '-',
   },
   {
-    "ascii": 46,
-    "code": 55,
-    "label": "."
+    ascii: 46,
+    code: 55,
+    label: '.',
   },
   {
-    "ascii": 47,
-    "code": 56,
-    "label": "/"
+    ascii: 47,
+    code: 56,
+    label: '/',
   },
   {
-    "ascii": 48,
-    "code": 39,
-    "label": "0"
+    ascii: 48,
+    code: 39,
+    label: '0',
   },
   {
-    "ascii": 49,
-    "code": 30,
-    "label": "1"
+    ascii: 49,
+    code: 30,
+    label: '1',
   },
   {
-    "ascii": 50,
-    "code": 31,
-    "label": "2"
+    ascii: 50,
+    code: 31,
+    label: '2',
   },
   {
-    "ascii": 51,
-    "code": 32,
-    "label": "3"
+    ascii: 51,
+    code: 32,
+    label: '3',
   },
   {
-    "ascii": 52,
-    "code": 33,
-    "label": "4"
+    ascii: 52,
+    code: 33,
+    label: '4',
   },
   {
-    "ascii": 53,
-    "code": 34,
-    "label": "5"
+    ascii: 53,
+    code: 34,
+    label: '5',
   },
   {
-    "ascii": 54,
-    "code": 35,
-    "label": "6"
+    ascii: 54,
+    code: 35,
+    label: '6',
   },
   {
-    "ascii": 55,
-    "code": 36,
-    "label": "7"
+    ascii: 55,
+    code: 36,
+    label: '7',
   },
   {
-    "ascii": 56,
-    "code": 37,
-    "label": "8"
+    ascii: 56,
+    code: 37,
+    label: '8',
   },
   {
-    "ascii": 57,
-    "code": 38,
-    "label": "9"
+    ascii: 57,
+    code: 38,
+    label: '9',
   },
   {
-    "ascii": 58,
-    "code": 567,
-    "label": ":"
+    ascii: 58,
+    code: 567,
+    label: ':',
   },
   {
-    "ascii": 59,
-    "code": 566,
-    "label": ";"
+    ascii: 59,
+    code: 566,
+    label: ';',
   },
   {
-    "ascii": 60,
-    "code": 54,
-    "label": ","
+    ascii: 60,
+    code: 54,
+    label: ',',
   },
   {
-    "ascii": 61,
-    "code": 46,
-    "label": "="
+    ascii: 61,
+    code: 46,
+    label: '=',
   },
   {
-    "ascii": 62,
-    "code": 55,
-    "label": "."
+    ascii: 62,
+    code: 55,
+    label: '.',
   },
   {
-    "ascii": 63,
-    "code": 568,
-    "label": "?"
+    ascii: 63,
+    code: 568,
+    label: '?',
   },
   {
-    "ascii": 64,
-    "code": 543,
-    "label": "@"
+    ascii: 64,
+    code: 543,
+    label: '@',
   },
   {
-    "ascii": 65,
-    "code": 516,
-    "label": "A"
+    ascii: 65,
+    code: 516,
+    label: 'A',
   },
   {
-    "ascii": 66,
-    "code": 517,
-    "label": "B"
+    ascii: 66,
+    code: 517,
+    label: 'B',
   },
   {
-    "ascii": 67,
-    "code": 518,
-    "label": "C"
+    ascii: 67,
+    code: 518,
+    label: 'C',
   },
   {
-    "ascii": 68,
-    "code": 519,
-    "label": "D"
+    ascii: 68,
+    code: 519,
+    label: 'D',
   },
   {
-    "ascii": 69,
-    "code": 520,
-    "label": "E"
+    ascii: 69,
+    code: 520,
+    label: 'E',
   },
   {
-    "ascii": 70,
-    "code": 521,
-    "label": "F"
+    ascii: 70,
+    code: 521,
+    label: 'F',
   },
   {
-    "ascii": 71,
-    "code": 522,
-    "label": "G"
+    ascii: 71,
+    code: 522,
+    label: 'G',
   },
   {
-    "ascii": 72,
-    "code": 523,
-    "label": "H"
+    ascii: 72,
+    code: 523,
+    label: 'H',
   },
   {
-    "ascii": 73,
-    "code": 524,
-    "label": "I"
+    ascii: 73,
+    code: 524,
+    label: 'I',
   },
   {
-    "ascii": 74,
-    "code": 525,
-    "label": "J"
+    ascii: 74,
+    code: 525,
+    label: 'J',
   },
   {
-    "ascii": 75,
-    "code": 526,
-    "label": "K"
+    ascii: 75,
+    code: 526,
+    label: 'K',
   },
   {
-    "ascii": 76,
-    "code": 527,
-    "label": "L"
+    ascii: 76,
+    code: 527,
+    label: 'L',
   },
   {
-    "ascii": 77,
-    "code": 528,
-    "label": "M"
+    ascii: 77,
+    code: 528,
+    label: 'M',
   },
   {
-    "ascii": 78,
-    "code": 529,
-    "label": "N"
+    ascii: 78,
+    code: 529,
+    label: 'N',
   },
   {
-    "ascii": 79,
-    "code": 530,
-    "label": "O"
+    ascii: 79,
+    code: 530,
+    label: 'O',
   },
   {
-    "ascii": 80,
-    "code": 531,
-    "label": "P"
+    ascii: 80,
+    code: 531,
+    label: 'P',
   },
   {
-    "ascii": 81,
-    "code": 532,
-    "label": "Q"
+    ascii: 81,
+    code: 532,
+    label: 'Q',
   },
   {
-    "ascii": 82,
-    "code": 533,
-    "label": "R"
+    ascii: 82,
+    code: 533,
+    label: 'R',
   },
   {
-    "ascii": 83,
-    "code": 534,
-    "label": "S"
+    ascii: 83,
+    code: 534,
+    label: 'S',
   },
   {
-    "ascii": 84,
-    "code": 535,
-    "label": "T"
+    ascii: 84,
+    code: 535,
+    label: 'T',
   },
   {
-    "ascii": 85,
-    "code": 536,
-    "label": "U"
+    ascii: 85,
+    code: 536,
+    label: 'U',
   },
   {
-    "ascii": 86,
-    "code": 537,
-    "label": "V"
+    ascii: 86,
+    code: 537,
+    label: 'V',
   },
   {
-    "ascii": 87,
-    "code": 538,
-    "label": "W"
+    ascii: 87,
+    code: 538,
+    label: 'W',
   },
   {
-    "ascii": 88,
-    "code": 539,
-    "label": "X"
+    ascii: 88,
+    code: 539,
+    label: 'X',
   },
   {
-    "ascii": 89,
-    "code": 540,
-    "label": "Y"
+    ascii: 89,
+    code: 540,
+    label: 'Y',
   },
   {
-    "ascii": 90,
-    "code": 541,
-    "label": "Z"
+    ascii: 90,
+    code: 541,
+    label: 'Z',
   },
   {
-    "ascii": 91,
-    "code": 47,
-    "label": "Ă"
+    ascii: 91,
+    code: 47,
+    label: 'Ă',
   },
   {
-    "ascii": 92,
-    "code": 100,
-    "label": "(backslash)"
+    ascii: 92,
+    code: 100,
+    label: '(backslash)',
   },
   {
-    "ascii": 93,
-    "code": 48,
-    "label": "Î"
+    ascii: 93,
+    code: 48,
+    label: 'Î',
   },
   {
-    "ascii": 94,
-    "code": 547,
-    "label": "^"
+    ascii: 94,
+    code: 547,
+    label: '^',
   },
   {
-    "ascii": 95,
-    "code": 557,
-    "label": "_"
+    ascii: 95,
+    code: 557,
+    label: '_',
   },
   {
-    "ascii": 96,
-    "code": 53,
-    "label": "„"
+    ascii: 96,
+    code: 53,
+    label: '„',
   },
   {
-    "ascii": 97,
-    "code": 4,
-    "label": "a"
+    ascii: 97,
+    code: 4,
+    label: 'a',
   },
   {
-    "ascii": 98,
-    "code": 5,
-    "label": "b"
+    ascii: 98,
+    code: 5,
+    label: 'b',
   },
   {
-    "ascii": 99,
-    "code": 6,
-    "label": "c"
+    ascii: 99,
+    code: 6,
+    label: 'c',
   },
   {
-    "ascii": 100,
-    "code": 7,
-    "label": "d"
+    ascii: 100,
+    code: 7,
+    label: 'd',
   },
   {
-    "ascii": 101,
-    "code": 8,
-    "label": "e"
+    ascii: 101,
+    code: 8,
+    label: 'e',
   },
   {
-    "ascii": 102,
-    "code": 9,
-    "label": "f"
+    ascii: 102,
+    code: 9,
+    label: 'f',
   },
   {
-    "ascii": 103,
-    "code": 10,
-    "label": "g"
+    ascii: 103,
+    code: 10,
+    label: 'g',
   },
   {
-    "ascii": 104,
-    "code": 11,
-    "label": "h"
+    ascii: 104,
+    code: 11,
+    label: 'h',
   },
   {
-    "ascii": 105,
-    "code": 12,
-    "label": "i"
+    ascii: 105,
+    code: 12,
+    label: 'i',
   },
   {
-    "ascii": 106,
-    "code": 13,
-    "label": "j"
+    ascii: 106,
+    code: 13,
+    label: 'j',
   },
   {
-    "ascii": 107,
-    "code": 14,
-    "label": "k"
+    ascii: 107,
+    code: 14,
+    label: 'k',
   },
   {
-    "ascii": 108,
-    "code": 15,
-    "label": "l"
+    ascii: 108,
+    code: 15,
+    label: 'l',
   },
   {
-    "ascii": 109,
-    "code": 16,
-    "label": "m"
+    ascii: 109,
+    code: 16,
+    label: 'm',
   },
   {
-    "ascii": 110,
-    "code": 17,
-    "label": "n"
+    ascii: 110,
+    code: 17,
+    label: 'n',
   },
   {
-    "ascii": 111,
-    "code": 18,
-    "label": "o"
+    ascii: 111,
+    code: 18,
+    label: 'o',
   },
   {
-    "ascii": 112,
-    "code": 19,
-    "label": "p"
+    ascii: 112,
+    code: 19,
+    label: 'p',
   },
   {
-    "ascii": 113,
-    "code": 20,
-    "label": "q"
+    ascii: 113,
+    code: 20,
+    label: 'q',
   },
   {
-    "ascii": 114,
-    "code": 21,
-    "label": "r"
+    ascii: 114,
+    code: 21,
+    label: 'r',
   },
   {
-    "ascii": 115,
-    "code": 22,
-    "label": "s"
+    ascii: 115,
+    code: 22,
+    label: 's',
   },
   {
-    "ascii": 116,
-    "code": 23,
-    "label": "t"
+    ascii: 116,
+    code: 23,
+    label: 't',
   },
   {
-    "ascii": 117,
-    "code": 24,
-    "label": "u"
+    ascii: 117,
+    code: 24,
+    label: 'u',
   },
   {
-    "ascii": 118,
-    "code": 25,
-    "label": "v"
+    ascii: 118,
+    code: 25,
+    label: 'v',
   },
   {
-    "ascii": 119,
-    "code": 26,
-    "label": "w"
+    ascii: 119,
+    code: 26,
+    label: 'w',
   },
   {
-    "ascii": 120,
-    "code": 27,
-    "label": "x"
+    ascii: 120,
+    code: 27,
+    label: 'x',
   },
   {
-    "ascii": 121,
-    "code": 28,
-    "label": "y"
+    ascii: 121,
+    code: 28,
+    label: 'y',
   },
   {
-    "ascii": 122,
-    "code": 29,
-    "label": "z"
+    ascii: 122,
+    code: 29,
+    label: 'z',
   },
   {
-    "ascii": 123,
-    "code": 559,
-    "label": "Ă"
+    ascii: 123,
+    code: 559,
+    label: 'Ă',
   },
   {
-    "ascii": 124,
-    "code": 100,
-    "label": "(backslash)"
+    ascii: 124,
+    code: 100,
+    label: '(backslash)',
   },
   {
-    "ascii": 125,
-    "code": 560,
-    "label": "Î"
+    ascii: 125,
+    code: 560,
+    label: 'Î',
   },
   {
-    "ascii": 126,
-    "code": 565,
-    "label": "”"
+    ascii: 126,
+    code: 565,
+    label: '”',
   },
   {
-    "ascii": 127,
-    "code": 76,
-    "label": "del"
-  }
+    ascii: 127,
+    code: 76,
+    label: 'del',
+  },
 ];
-    

--- a/src/services/labellang/AsciiLabelSerbian_latin.ts
+++ b/src/services/labellang/AsciiLabelSerbian_latin.ts
@@ -1,645 +1,644 @@
 import { AsciiLabel } from './AsciiLabel';
-        
+
 export const AsciiLabelSerbian_latin: AsciiLabel[] = [
   {
-    "ascii": 0,
-    "code": 0,
-    "label": ""
+    ascii: 0,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 1,
-    "code": 0,
-    "label": ""
+    ascii: 1,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 2,
-    "code": 0,
-    "label": ""
+    ascii: 2,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 3,
-    "code": 0,
-    "label": ""
+    ascii: 3,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 4,
-    "code": 0,
-    "label": ""
+    ascii: 4,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 5,
-    "code": 0,
-    "label": ""
+    ascii: 5,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 6,
-    "code": 0,
-    "label": ""
+    ascii: 6,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 7,
-    "code": 0,
-    "label": ""
+    ascii: 7,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 8,
-    "code": 42,
-    "label": "back space"
+    ascii: 8,
+    code: 42,
+    label: 'back space',
   },
   {
-    "ascii": 9,
-    "code": 43,
-    "label": "tab"
+    ascii: 9,
+    code: 43,
+    label: 'tab',
   },
   {
-    "ascii": 10,
-    "code": 40,
-    "label": "enter"
+    ascii: 10,
+    code: 40,
+    label: 'enter',
   },
   {
-    "ascii": 11,
-    "code": 0,
-    "label": ""
+    ascii: 11,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 12,
-    "code": 0,
-    "label": ""
+    ascii: 12,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 13,
-    "code": 0,
-    "label": ""
+    ascii: 13,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 14,
-    "code": 0,
-    "label": ""
+    ascii: 14,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 15,
-    "code": 0,
-    "label": ""
+    ascii: 15,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 16,
-    "code": 0,
-    "label": ""
+    ascii: 16,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 17,
-    "code": 0,
-    "label": ""
+    ascii: 17,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 18,
-    "code": 0,
-    "label": ""
+    ascii: 18,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 19,
-    "code": 0,
-    "label": ""
+    ascii: 19,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 20,
-    "code": 0,
-    "label": ""
+    ascii: 20,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 21,
-    "code": 0,
-    "label": ""
+    ascii: 21,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 22,
-    "code": 0,
-    "label": ""
+    ascii: 22,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 23,
-    "code": 0,
-    "label": ""
+    ascii: 23,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 24,
-    "code": 0,
-    "label": ""
+    ascii: 24,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 25,
-    "code": 0,
-    "label": ""
+    ascii: 25,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 26,
-    "code": 0,
-    "label": ""
+    ascii: 26,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 27,
-    "code": 41,
-    "label": "esc"
+    ascii: 27,
+    code: 41,
+    label: 'esc',
   },
   {
-    "ascii": 28,
-    "code": 0,
-    "label": ""
+    ascii: 28,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 29,
-    "code": 0,
-    "label": ""
+    ascii: 29,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 30,
-    "code": 0,
-    "label": ""
+    ascii: 30,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 31,
-    "code": 0,
-    "label": ""
+    ascii: 31,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 32,
-    "code": 44,
-    "label": "space"
+    ascii: 32,
+    code: 44,
+    label: 'space',
   },
   {
-    "ascii": 33,
-    "code": 542,
-    "label": "!"
+    ascii: 33,
+    code: 542,
+    label: '!',
   },
   {
-    "ascii": 34,
-    "code": 543,
-    "label": "\""
+    ascii: 34,
+    code: 543,
+    label: '"',
   },
   {
-    "ascii": 35,
-    "code": 544,
-    "label": "#"
+    ascii: 35,
+    code: 544,
+    label: '#',
   },
   {
-    "ascii": 36,
-    "code": 545,
-    "label": "$"
+    ascii: 36,
+    code: 545,
+    label: '$',
   },
   {
-    "ascii": 37,
-    "code": 546,
-    "label": "%"
+    ascii: 37,
+    code: 546,
+    label: '%',
   },
   {
-    "ascii": 38,
-    "code": 547,
-    "label": "&"
+    ascii: 38,
+    code: 547,
+    label: '&',
   },
   {
-    "ascii": 39,
-    "code": 45,
-    "label": "'"
+    ascii: 39,
+    code: 45,
+    label: "'",
   },
   {
-    "ascii": 40,
-    "code": 549,
-    "label": "("
+    ascii: 40,
+    code: 549,
+    label: '(',
   },
   {
-    "ascii": 41,
-    "code": 550,
-    "label": ")"
+    ascii: 41,
+    code: 550,
+    label: ')',
   },
   {
-    "ascii": 42,
-    "code": 558,
-    "label": "*"
+    ascii: 42,
+    code: 558,
+    label: '*',
   },
   {
-    "ascii": 43,
-    "code": 46,
-    "label": "+"
+    ascii: 43,
+    code: 46,
+    label: '+',
   },
   {
-    "ascii": 44,
-    "code": 54,
-    "label": ","
+    ascii: 44,
+    code: 54,
+    label: ',',
   },
   {
-    "ascii": 45,
-    "code": 56,
-    "label": "-"
+    ascii: 45,
+    code: 56,
+    label: '-',
   },
   {
-    "ascii": 46,
-    "code": 55,
-    "label": "."
+    ascii: 46,
+    code: 55,
+    label: '.',
   },
   {
-    "ascii": 47,
-    "code": 548,
-    "label": "/"
+    ascii: 47,
+    code: 548,
+    label: '/',
   },
   {
-    "ascii": 48,
-    "code": 39,
-    "label": "0"
+    ascii: 48,
+    code: 39,
+    label: '0',
   },
   {
-    "ascii": 49,
-    "code": 30,
-    "label": "1"
+    ascii: 49,
+    code: 30,
+    label: '1',
   },
   {
-    "ascii": 50,
-    "code": 31,
-    "label": "2"
+    ascii: 50,
+    code: 31,
+    label: '2',
   },
   {
-    "ascii": 51,
-    "code": 32,
-    "label": "3"
+    ascii: 51,
+    code: 32,
+    label: '3',
   },
   {
-    "ascii": 52,
-    "code": 33,
-    "label": "4"
+    ascii: 52,
+    code: 33,
+    label: '4',
   },
   {
-    "ascii": 53,
-    "code": 34,
-    "label": "5"
+    ascii: 53,
+    code: 34,
+    label: '5',
   },
   {
-    "ascii": 54,
-    "code": 35,
-    "label": "6"
+    ascii: 54,
+    code: 35,
+    label: '6',
   },
   {
-    "ascii": 55,
-    "code": 36,
-    "label": "7"
+    ascii: 55,
+    code: 36,
+    label: '7',
   },
   {
-    "ascii": 56,
-    "code": 37,
-    "label": "8"
+    ascii: 56,
+    code: 37,
+    label: '8',
   },
   {
-    "ascii": 57,
-    "code": 38,
-    "label": "9"
+    ascii: 57,
+    code: 38,
+    label: '9',
   },
   {
-    "ascii": 58,
-    "code": 567,
-    "label": ":"
+    ascii: 58,
+    code: 567,
+    label: ':',
   },
   {
-    "ascii": 59,
-    "code": 566,
-    "label": ";"
+    ascii: 59,
+    code: 566,
+    label: ';',
   },
   {
-    "ascii": 60,
-    "code": 100,
-    "label": "<"
+    ascii: 60,
+    code: 100,
+    label: '<',
   },
   {
-    "ascii": 61,
-    "code": 551,
-    "label": "="
+    ascii: 61,
+    code: 551,
+    label: '=',
   },
   {
-    "ascii": 62,
-    "code": 612,
-    "label": ">"
+    ascii: 62,
+    code: 612,
+    label: '>',
   },
   {
-    "ascii": 63,
-    "code": 557,
-    "label": "?"
+    ascii: 63,
+    code: 557,
+    label: '?',
   },
   {
-    "ascii": 64,
-    "code": 25,
-    "label": "v"
+    ascii: 64,
+    code: 25,
+    label: 'v',
   },
   {
-    "ascii": 65,
-    "code": 516,
-    "label": "A"
+    ascii: 65,
+    code: 516,
+    label: 'A',
   },
   {
-    "ascii": 66,
-    "code": 517,
-    "label": "B"
+    ascii: 66,
+    code: 517,
+    label: 'B',
   },
   {
-    "ascii": 67,
-    "code": 518,
-    "label": "C"
+    ascii: 67,
+    code: 518,
+    label: 'C',
   },
   {
-    "ascii": 68,
-    "code": 519,
-    "label": "D"
+    ascii: 68,
+    code: 519,
+    label: 'D',
   },
   {
-    "ascii": 69,
-    "code": 520,
-    "label": "E"
+    ascii: 69,
+    code: 520,
+    label: 'E',
   },
   {
-    "ascii": 70,
-    "code": 521,
-    "label": "F"
+    ascii: 70,
+    code: 521,
+    label: 'F',
   },
   {
-    "ascii": 71,
-    "code": 522,
-    "label": "G"
+    ascii: 71,
+    code: 522,
+    label: 'G',
   },
   {
-    "ascii": 72,
-    "code": 523,
-    "label": "H"
+    ascii: 72,
+    code: 523,
+    label: 'H',
   },
   {
-    "ascii": 73,
-    "code": 524,
-    "label": "I"
+    ascii: 73,
+    code: 524,
+    label: 'I',
   },
   {
-    "ascii": 74,
-    "code": 525,
-    "label": "J"
+    ascii: 74,
+    code: 525,
+    label: 'J',
   },
   {
-    "ascii": 75,
-    "code": 526,
-    "label": "K"
+    ascii: 75,
+    code: 526,
+    label: 'K',
   },
   {
-    "ascii": 76,
-    "code": 527,
-    "label": "L"
+    ascii: 76,
+    code: 527,
+    label: 'L',
   },
   {
-    "ascii": 77,
-    "code": 528,
-    "label": "M"
+    ascii: 77,
+    code: 528,
+    label: 'M',
   },
   {
-    "ascii": 78,
-    "code": 529,
-    "label": "N"
+    ascii: 78,
+    code: 529,
+    label: 'N',
   },
   {
-    "ascii": 79,
-    "code": 530,
-    "label": "O"
+    ascii: 79,
+    code: 530,
+    label: 'O',
   },
   {
-    "ascii": 80,
-    "code": 531,
-    "label": "P"
+    ascii: 80,
+    code: 531,
+    label: 'P',
   },
   {
-    "ascii": 81,
-    "code": 532,
-    "label": "Q"
+    ascii: 81,
+    code: 532,
+    label: 'Q',
   },
   {
-    "ascii": 82,
-    "code": 533,
-    "label": "R"
+    ascii: 82,
+    code: 533,
+    label: 'R',
   },
   {
-    "ascii": 83,
-    "code": 534,
-    "label": "S"
+    ascii: 83,
+    code: 534,
+    label: 'S',
   },
   {
-    "ascii": 84,
-    "code": 535,
-    "label": "T"
+    ascii: 84,
+    code: 535,
+    label: 'T',
   },
   {
-    "ascii": 85,
-    "code": 536,
-    "label": "U"
+    ascii: 85,
+    code: 536,
+    label: 'U',
   },
   {
-    "ascii": 86,
-    "code": 537,
-    "label": "V"
+    ascii: 86,
+    code: 537,
+    label: 'V',
   },
   {
-    "ascii": 87,
-    "code": 538,
-    "label": "W"
+    ascii: 87,
+    code: 538,
+    label: 'W',
   },
   {
-    "ascii": 88,
-    "code": 539,
-    "label": "X"
+    ascii: 88,
+    code: 539,
+    label: 'X',
   },
   {
-    "ascii": 89,
-    "code": 541,
-    "label": "Y"
+    ascii: 89,
+    code: 541,
+    label: 'Y',
   },
   {
-    "ascii": 90,
-    "code": 540,
-    "label": "Z"
+    ascii: 90,
+    code: 540,
+    label: 'Z',
   },
   {
-    "ascii": 91,
-    "code": 9,
-    "label": "f"
+    ascii: 91,
+    code: 9,
+    label: 'f',
   },
   {
-    "ascii": 92,
-    "code": 20,
-    "label": "q"
+    ascii: 92,
+    code: 20,
+    label: 'q',
   },
   {
-    "ascii": 93,
-    "code": 10,
-    "label": "g"
+    ascii: 93,
+    code: 10,
+    label: 'g',
   },
   {
-    "ascii": 94,
-    "code": 32,
-    "label": "3"
+    ascii: 94,
+    code: 32,
+    label: '3',
   },
   {
-    "ascii": 95,
-    "code": 568,
-    "label": "_"
+    ascii: 95,
+    code: 568,
+    label: '_',
   },
   {
-    "ascii": 96,
-    "code": 36,
-    "label": "7"
+    ascii: 96,
+    code: 36,
+    label: '7',
   },
   {
-    "ascii": 97,
-    "code": 4,
-    "label": "a"
+    ascii: 97,
+    code: 4,
+    label: 'a',
   },
   {
-    "ascii": 98,
-    "code": 5,
-    "label": "b"
+    ascii: 98,
+    code: 5,
+    label: 'b',
   },
   {
-    "ascii": 99,
-    "code": 6,
-    "label": "c"
+    ascii: 99,
+    code: 6,
+    label: 'c',
   },
   {
-    "ascii": 100,
-    "code": 7,
-    "label": "d"
+    ascii: 100,
+    code: 7,
+    label: 'd',
   },
   {
-    "ascii": 101,
-    "code": 8,
-    "label": "e"
+    ascii: 101,
+    code: 8,
+    label: 'e',
   },
   {
-    "ascii": 102,
-    "code": 9,
-    "label": "f"
+    ascii: 102,
+    code: 9,
+    label: 'f',
   },
   {
-    "ascii": 103,
-    "code": 10,
-    "label": "g"
+    ascii: 103,
+    code: 10,
+    label: 'g',
   },
   {
-    "ascii": 104,
-    "code": 11,
-    "label": "h"
+    ascii: 104,
+    code: 11,
+    label: 'h',
   },
   {
-    "ascii": 105,
-    "code": 12,
-    "label": "i"
+    ascii: 105,
+    code: 12,
+    label: 'i',
   },
   {
-    "ascii": 106,
-    "code": 13,
-    "label": "j"
+    ascii: 106,
+    code: 13,
+    label: 'j',
   },
   {
-    "ascii": 107,
-    "code": 14,
-    "label": "k"
+    ascii: 107,
+    code: 14,
+    label: 'k',
   },
   {
-    "ascii": 108,
-    "code": 15,
-    "label": "l"
+    ascii: 108,
+    code: 15,
+    label: 'l',
   },
   {
-    "ascii": 109,
-    "code": 16,
-    "label": "m"
+    ascii: 109,
+    code: 16,
+    label: 'm',
   },
   {
-    "ascii": 110,
-    "code": 17,
-    "label": "n"
+    ascii: 110,
+    code: 17,
+    label: 'n',
   },
   {
-    "ascii": 111,
-    "code": 18,
-    "label": "o"
+    ascii: 111,
+    code: 18,
+    label: 'o',
   },
   {
-    "ascii": 112,
-    "code": 19,
-    "label": "p"
+    ascii: 112,
+    code: 19,
+    label: 'p',
   },
   {
-    "ascii": 113,
-    "code": 20,
-    "label": "q"
+    ascii: 113,
+    code: 20,
+    label: 'q',
   },
   {
-    "ascii": 114,
-    "code": 21,
-    "label": "r"
+    ascii: 114,
+    code: 21,
+    label: 'r',
   },
   {
-    "ascii": 115,
-    "code": 22,
-    "label": "s"
+    ascii: 115,
+    code: 22,
+    label: 's',
   },
   {
-    "ascii": 116,
-    "code": 23,
-    "label": "t"
+    ascii: 116,
+    code: 23,
+    label: 't',
   },
   {
-    "ascii": 117,
-    "code": 24,
-    "label": "u"
+    ascii: 117,
+    code: 24,
+    label: 'u',
   },
   {
-    "ascii": 118,
-    "code": 25,
-    "label": "v"
+    ascii: 118,
+    code: 25,
+    label: 'v',
   },
   {
-    "ascii": 119,
-    "code": 26,
-    "label": "w"
+    ascii: 119,
+    code: 26,
+    label: 'w',
   },
   {
-    "ascii": 120,
-    "code": 27,
-    "label": "x"
+    ascii: 120,
+    code: 27,
+    label: 'x',
   },
   {
-    "ascii": 121,
-    "code": 29,
-    "label": "y"
+    ascii: 121,
+    code: 29,
+    label: 'y',
   },
   {
-    "ascii": 122,
-    "code": 28,
-    "label": "z"
+    ascii: 122,
+    code: 28,
+    label: 'z',
   },
   {
-    "ascii": 123,
-    "code": 5,
-    "label": "b"
+    ascii: 123,
+    code: 5,
+    label: 'b',
   },
   {
-    "ascii": 124,
-    "code": 26,
-    "label": "w"
+    ascii: 124,
+    code: 26,
+    label: 'w',
   },
   {
-    "ascii": 125,
-    "code": 17,
-    "label": "n"
+    ascii: 125,
+    code: 17,
+    label: 'n',
   },
   {
-    "ascii": 126,
-    "code": 30,
-    "label": "1"
+    ascii: 126,
+    code: 30,
+    label: '1',
   },
   {
-    "ascii": 127,
-    "code": 76,
-    "label": "del"
-  }
+    ascii: 127,
+    code: 76,
+    label: 'del',
+  },
 ];
-    

--- a/src/services/labellang/AsciiLabelSlovak.ts
+++ b/src/services/labellang/AsciiLabelSlovak.ts
@@ -1,645 +1,644 @@
 import { AsciiLabel } from './AsciiLabel';
-        
+
 export const AsciiLabelSlovak: AsciiLabel[] = [
   {
-    "ascii": 0,
-    "code": 0,
-    "label": ""
+    ascii: 0,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 1,
-    "code": 0,
-    "label": ""
+    ascii: 1,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 2,
-    "code": 0,
-    "label": ""
+    ascii: 2,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 3,
-    "code": 0,
-    "label": ""
+    ascii: 3,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 4,
-    "code": 0,
-    "label": ""
+    ascii: 4,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 5,
-    "code": 0,
-    "label": ""
+    ascii: 5,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 6,
-    "code": 0,
-    "label": ""
+    ascii: 6,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 7,
-    "code": 0,
-    "label": ""
+    ascii: 7,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 8,
-    "code": 42,
-    "label": "back space"
+    ascii: 8,
+    code: 42,
+    label: 'back space',
   },
   {
-    "ascii": 9,
-    "code": 43,
-    "label": "tab"
+    ascii: 9,
+    code: 43,
+    label: 'tab',
   },
   {
-    "ascii": 10,
-    "code": 40,
-    "label": "enter"
+    ascii: 10,
+    code: 40,
+    label: 'enter',
   },
   {
-    "ascii": 11,
-    "code": 0,
-    "label": ""
+    ascii: 11,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 12,
-    "code": 0,
-    "label": ""
+    ascii: 12,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 13,
-    "code": 0,
-    "label": ""
+    ascii: 13,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 14,
-    "code": 0,
-    "label": ""
+    ascii: 14,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 15,
-    "code": 0,
-    "label": ""
+    ascii: 15,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 16,
-    "code": 0,
-    "label": ""
+    ascii: 16,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 17,
-    "code": 0,
-    "label": ""
+    ascii: 17,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 18,
-    "code": 0,
-    "label": ""
+    ascii: 18,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 19,
-    "code": 0,
-    "label": ""
+    ascii: 19,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 20,
-    "code": 0,
-    "label": ""
+    ascii: 20,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 21,
-    "code": 0,
-    "label": ""
+    ascii: 21,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 22,
-    "code": 0,
-    "label": ""
+    ascii: 22,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 23,
-    "code": 0,
-    "label": ""
+    ascii: 23,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 24,
-    "code": 0,
-    "label": ""
+    ascii: 24,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 25,
-    "code": 0,
-    "label": ""
+    ascii: 25,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 26,
-    "code": 0,
-    "label": ""
+    ascii: 26,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 27,
-    "code": 41,
-    "label": "esc"
+    ascii: 27,
+    code: 41,
+    label: 'esc',
   },
   {
-    "ascii": 28,
-    "code": 0,
-    "label": ""
+    ascii: 28,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 29,
-    "code": 0,
-    "label": ""
+    ascii: 29,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 30,
-    "code": 0,
-    "label": ""
+    ascii: 30,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 31,
-    "code": 0,
-    "label": ""
+    ascii: 31,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 32,
-    "code": 44,
-    "label": "space"
+    ascii: 32,
+    code: 44,
+    label: 'space',
   },
   {
-    "ascii": 33,
-    "code": 564,
-    "label": "!"
+    ascii: 33,
+    code: 564,
+    label: '!',
   },
   {
-    "ascii": 34,
-    "code": 563,
-    "label": "\""
+    ascii: 34,
+    code: 563,
+    label: '"',
   },
   {
-    "ascii": 35,
-    "code": 27,
-    "label": "x"
+    ascii: 35,
+    code: 27,
+    label: 'x',
   },
   {
-    "ascii": 36,
-    "code": 51,
-    "label": "ô"
+    ascii: 36,
+    code: 51,
+    label: 'ô',
   },
   {
-    "ascii": 37,
-    "code": 45,
-    "label": "="
+    ascii: 37,
+    code: 45,
+    label: '=',
   },
   {
-    "ascii": 38,
-    "code": 100,
-    "label": "&"
+    ascii: 38,
+    code: 100,
+    label: '&',
   },
   {
-    "ascii": 39,
-    "code": 19,
-    "label": "p"
+    ascii: 39,
+    code: 19,
+    label: 'p',
   },
   {
-    "ascii": 40,
-    "code": 560,
-    "label": "("
+    ascii: 40,
+    code: 560,
+    label: '(',
   },
   {
-    "ascii": 41,
-    "code": 562,
-    "label": ")"
+    ascii: 41,
+    code: 562,
+    label: ')',
   },
   {
-    "ascii": 42,
-    "code": 612,
-    "label": "*"
+    ascii: 42,
+    code: 612,
+    label: '*',
   },
   {
-    "ascii": 43,
-    "code": 30,
-    "label": "+"
+    ascii: 43,
+    code: 30,
+    label: '+',
   },
   {
-    "ascii": 44,
-    "code": 54,
-    "label": ","
+    ascii: 44,
+    code: 54,
+    label: ',',
   },
   {
-    "ascii": 45,
-    "code": 56,
-    "label": "-"
+    ascii: 45,
+    code: 56,
+    label: '-',
   },
   {
-    "ascii": 46,
-    "code": 55,
-    "label": "."
+    ascii: 46,
+    code: 55,
+    label: '.',
   },
   {
-    "ascii": 47,
-    "code": 559,
-    "label": "/"
+    ascii: 47,
+    code: 559,
+    label: '/',
   },
   {
-    "ascii": 48,
-    "code": 551,
-    "label": "0"
+    ascii: 48,
+    code: 551,
+    label: '0',
   },
   {
-    "ascii": 49,
-    "code": 542,
-    "label": "1"
+    ascii: 49,
+    code: 542,
+    label: '1',
   },
   {
-    "ascii": 50,
-    "code": 543,
-    "label": "2"
+    ascii: 50,
+    code: 543,
+    label: '2',
   },
   {
-    "ascii": 51,
-    "code": 544,
-    "label": "3"
+    ascii: 51,
+    code: 544,
+    label: '3',
   },
   {
-    "ascii": 52,
-    "code": 545,
-    "label": "4"
+    ascii: 52,
+    code: 545,
+    label: '4',
   },
   {
-    "ascii": 53,
-    "code": 546,
-    "label": "5"
+    ascii: 53,
+    code: 546,
+    label: '5',
   },
   {
-    "ascii": 54,
-    "code": 547,
-    "label": "6"
+    ascii: 54,
+    code: 547,
+    label: '6',
   },
   {
-    "ascii": 55,
-    "code": 548,
-    "label": "7"
+    ascii: 55,
+    code: 548,
+    label: '7',
   },
   {
-    "ascii": 56,
-    "code": 549,
-    "label": "8"
+    ascii: 56,
+    code: 549,
+    label: '8',
   },
   {
-    "ascii": 57,
-    "code": 550,
-    "label": "9"
+    ascii: 57,
+    code: 550,
+    label: '9',
   },
   {
-    "ascii": 58,
-    "code": 567,
-    "label": ":"
+    ascii: 58,
+    code: 567,
+    label: ':',
   },
   {
-    "ascii": 59,
-    "code": 53,
-    "label": ";"
+    ascii: 59,
+    code: 53,
+    label: ';',
   },
   {
-    "ascii": 60,
-    "code": 100,
-    "label": "&"
+    ascii: 60,
+    code: 100,
+    label: '&',
   },
   {
-    "ascii": 61,
-    "code": 45,
-    "label": "="
+    ascii: 61,
+    code: 45,
+    label: '=',
   },
   {
-    "ascii": 62,
-    "code": 29,
-    "label": "y"
+    ascii: 62,
+    code: 29,
+    label: 'y',
   },
   {
-    "ascii": 63,
-    "code": 566,
-    "label": "?"
+    ascii: 63,
+    code: 566,
+    label: '?',
   },
   {
-    "ascii": 64,
-    "code": 25,
-    "label": "v"
+    ascii: 64,
+    code: 25,
+    label: 'v',
   },
   {
-    "ascii": 65,
-    "code": 516,
-    "label": "A"
+    ascii: 65,
+    code: 516,
+    label: 'A',
   },
   {
-    "ascii": 66,
-    "code": 517,
-    "label": "B"
+    ascii: 66,
+    code: 517,
+    label: 'B',
   },
   {
-    "ascii": 67,
-    "code": 518,
-    "label": "C"
+    ascii: 67,
+    code: 518,
+    label: 'C',
   },
   {
-    "ascii": 68,
-    "code": 519,
-    "label": "D"
+    ascii: 68,
+    code: 519,
+    label: 'D',
   },
   {
-    "ascii": 69,
-    "code": 520,
-    "label": "E"
+    ascii: 69,
+    code: 520,
+    label: 'E',
   },
   {
-    "ascii": 70,
-    "code": 521,
-    "label": "F"
+    ascii: 70,
+    code: 521,
+    label: 'F',
   },
   {
-    "ascii": 71,
-    "code": 522,
-    "label": "G"
+    ascii: 71,
+    code: 522,
+    label: 'G',
   },
   {
-    "ascii": 72,
-    "code": 523,
-    "label": "H"
+    ascii: 72,
+    code: 523,
+    label: 'H',
   },
   {
-    "ascii": 73,
-    "code": 524,
-    "label": "I"
+    ascii: 73,
+    code: 524,
+    label: 'I',
   },
   {
-    "ascii": 74,
-    "code": 525,
-    "label": "J"
+    ascii: 74,
+    code: 525,
+    label: 'J',
   },
   {
-    "ascii": 75,
-    "code": 526,
-    "label": "K"
+    ascii: 75,
+    code: 526,
+    label: 'K',
   },
   {
-    "ascii": 76,
-    "code": 527,
-    "label": "L"
+    ascii: 76,
+    code: 527,
+    label: 'L',
   },
   {
-    "ascii": 77,
-    "code": 528,
-    "label": "M"
+    ascii: 77,
+    code: 528,
+    label: 'M',
   },
   {
-    "ascii": 78,
-    "code": 529,
-    "label": "N"
+    ascii: 78,
+    code: 529,
+    label: 'N',
   },
   {
-    "ascii": 79,
-    "code": 530,
-    "label": "O"
+    ascii: 79,
+    code: 530,
+    label: 'O',
   },
   {
-    "ascii": 80,
-    "code": 531,
-    "label": "P"
+    ascii: 80,
+    code: 531,
+    label: 'P',
   },
   {
-    "ascii": 81,
-    "code": 532,
-    "label": "Q"
+    ascii: 81,
+    code: 532,
+    label: 'Q',
   },
   {
-    "ascii": 82,
-    "code": 533,
-    "label": "R"
+    ascii: 82,
+    code: 533,
+    label: 'R',
   },
   {
-    "ascii": 83,
-    "code": 534,
-    "label": "S"
+    ascii: 83,
+    code: 534,
+    label: 'S',
   },
   {
-    "ascii": 84,
-    "code": 535,
-    "label": "T"
+    ascii: 84,
+    code: 535,
+    label: 'T',
   },
   {
-    "ascii": 85,
-    "code": 536,
-    "label": "U"
+    ascii: 85,
+    code: 536,
+    label: 'U',
   },
   {
-    "ascii": 86,
-    "code": 537,
-    "label": "V"
+    ascii: 86,
+    code: 537,
+    label: 'V',
   },
   {
-    "ascii": 87,
-    "code": 538,
-    "label": "W"
+    ascii: 87,
+    code: 538,
+    label: 'W',
   },
   {
-    "ascii": 88,
-    "code": 539,
-    "label": "X"
+    ascii: 88,
+    code: 539,
+    label: 'X',
   },
   {
-    "ascii": 89,
-    "code": 541,
-    "label": "Y"
+    ascii: 89,
+    code: 541,
+    label: 'Y',
   },
   {
-    "ascii": 90,
-    "code": 540,
-    "label": "Z"
+    ascii: 90,
+    code: 540,
+    label: 'Z',
   },
   {
-    "ascii": 91,
-    "code": 9,
-    "label": "f"
+    ascii: 91,
+    code: 9,
+    label: 'f',
   },
   {
-    "ascii": 92,
-    "code": 20,
-    "label": "q"
+    ascii: 92,
+    code: 20,
+    label: 'q',
   },
   {
-    "ascii": 93,
-    "code": 10,
-    "label": "g"
+    ascii: 93,
+    code: 10,
+    label: 'g',
   },
   {
-    "ascii": 94,
-    "code": 544,
-    "label": "3"
+    ascii: 94,
+    code: 544,
+    label: '3',
   },
   {
-    "ascii": 95,
-    "code": 568,
-    "label": "_"
+    ascii: 95,
+    code: 568,
+    label: '_',
   },
   {
-    "ascii": 96,
-    "code": 548,
-    "label": "7"
+    ascii: 96,
+    code: 548,
+    label: '7',
   },
   {
-    "ascii": 97,
-    "code": 4,
-    "label": "a"
+    ascii: 97,
+    code: 4,
+    label: 'a',
   },
   {
-    "ascii": 98,
-    "code": 5,
-    "label": "b"
+    ascii: 98,
+    code: 5,
+    label: 'b',
   },
   {
-    "ascii": 99,
-    "code": 6,
-    "label": "c"
+    ascii: 99,
+    code: 6,
+    label: 'c',
   },
   {
-    "ascii": 100,
-    "code": 7,
-    "label": "d"
+    ascii: 100,
+    code: 7,
+    label: 'd',
   },
   {
-    "ascii": 101,
-    "code": 8,
-    "label": "e"
+    ascii: 101,
+    code: 8,
+    label: 'e',
   },
   {
-    "ascii": 102,
-    "code": 9,
-    "label": "f"
+    ascii: 102,
+    code: 9,
+    label: 'f',
   },
   {
-    "ascii": 103,
-    "code": 10,
-    "label": "g"
+    ascii: 103,
+    code: 10,
+    label: 'g',
   },
   {
-    "ascii": 104,
-    "code": 11,
-    "label": "h"
+    ascii: 104,
+    code: 11,
+    label: 'h',
   },
   {
-    "ascii": 105,
-    "code": 12,
-    "label": "i"
+    ascii: 105,
+    code: 12,
+    label: 'i',
   },
   {
-    "ascii": 106,
-    "code": 13,
-    "label": "j"
+    ascii: 106,
+    code: 13,
+    label: 'j',
   },
   {
-    "ascii": 107,
-    "code": 14,
-    "label": "k"
+    ascii: 107,
+    code: 14,
+    label: 'k',
   },
   {
-    "ascii": 108,
-    "code": 15,
-    "label": "l"
+    ascii: 108,
+    code: 15,
+    label: 'l',
   },
   {
-    "ascii": 109,
-    "code": 16,
-    "label": "m"
+    ascii: 109,
+    code: 16,
+    label: 'm',
   },
   {
-    "ascii": 110,
-    "code": 17,
-    "label": "n"
+    ascii: 110,
+    code: 17,
+    label: 'n',
   },
   {
-    "ascii": 111,
-    "code": 18,
-    "label": "o"
+    ascii: 111,
+    code: 18,
+    label: 'o',
   },
   {
-    "ascii": 112,
-    "code": 19,
-    "label": "p"
+    ascii: 112,
+    code: 19,
+    label: 'p',
   },
   {
-    "ascii": 113,
-    "code": 20,
-    "label": "q"
+    ascii: 113,
+    code: 20,
+    label: 'q',
   },
   {
-    "ascii": 114,
-    "code": 21,
-    "label": "r"
+    ascii: 114,
+    code: 21,
+    label: 'r',
   },
   {
-    "ascii": 115,
-    "code": 22,
-    "label": "s"
+    ascii: 115,
+    code: 22,
+    label: 's',
   },
   {
-    "ascii": 116,
-    "code": 23,
-    "label": "t"
+    ascii: 116,
+    code: 23,
+    label: 't',
   },
   {
-    "ascii": 117,
-    "code": 24,
-    "label": "u"
+    ascii: 117,
+    code: 24,
+    label: 'u',
   },
   {
-    "ascii": 118,
-    "code": 25,
-    "label": "v"
+    ascii: 118,
+    code: 25,
+    label: 'v',
   },
   {
-    "ascii": 119,
-    "code": 26,
-    "label": "w"
+    ascii: 119,
+    code: 26,
+    label: 'w',
   },
   {
-    "ascii": 120,
-    "code": 27,
-    "label": "x"
+    ascii: 120,
+    code: 27,
+    label: 'x',
   },
   {
-    "ascii": 121,
-    "code": 29,
-    "label": "y"
+    ascii: 121,
+    code: 29,
+    label: 'y',
   },
   {
-    "ascii": 122,
-    "code": 28,
-    "label": "z"
+    ascii: 122,
+    code: 28,
+    label: 'z',
   },
   {
-    "ascii": 123,
-    "code": 5,
-    "label": "b"
+    ascii: 123,
+    code: 5,
+    label: 'b',
   },
   {
-    "ascii": 124,
-    "code": 26,
-    "label": "w"
+    ascii: 124,
+    code: 26,
+    label: 'w',
   },
   {
-    "ascii": 125,
-    "code": 17,
-    "label": "n"
+    ascii: 125,
+    code: 17,
+    label: 'n',
   },
   {
-    "ascii": 126,
-    "code": 542,
-    "label": "1"
+    ascii: 126,
+    code: 542,
+    label: '1',
   },
   {
-    "ascii": 127,
-    "code": 76,
-    "label": "del"
-  }
+    ascii: 127,
+    code: 76,
+    label: 'del',
+  },
 ];
-    

--- a/src/services/labellang/AsciiLabelSlovenian.ts
+++ b/src/services/labellang/AsciiLabelSlovenian.ts
@@ -1,645 +1,644 @@
 import { AsciiLabel } from './AsciiLabel';
-        
+
 export const AsciiLabelSlovenian: AsciiLabel[] = [
   {
-    "ascii": 0,
-    "code": 0,
-    "label": ""
+    ascii: 0,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 1,
-    "code": 0,
-    "label": ""
+    ascii: 1,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 2,
-    "code": 0,
-    "label": ""
+    ascii: 2,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 3,
-    "code": 0,
-    "label": ""
+    ascii: 3,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 4,
-    "code": 0,
-    "label": ""
+    ascii: 4,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 5,
-    "code": 0,
-    "label": ""
+    ascii: 5,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 6,
-    "code": 0,
-    "label": ""
+    ascii: 6,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 7,
-    "code": 0,
-    "label": ""
+    ascii: 7,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 8,
-    "code": 42,
-    "label": "back space"
+    ascii: 8,
+    code: 42,
+    label: 'back space',
   },
   {
-    "ascii": 9,
-    "code": 43,
-    "label": "tab"
+    ascii: 9,
+    code: 43,
+    label: 'tab',
   },
   {
-    "ascii": 10,
-    "code": 40,
-    "label": "enter"
+    ascii: 10,
+    code: 40,
+    label: 'enter',
   },
   {
-    "ascii": 11,
-    "code": 0,
-    "label": ""
+    ascii: 11,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 12,
-    "code": 0,
-    "label": ""
+    ascii: 12,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 13,
-    "code": 0,
-    "label": ""
+    ascii: 13,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 14,
-    "code": 0,
-    "label": ""
+    ascii: 14,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 15,
-    "code": 0,
-    "label": ""
+    ascii: 15,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 16,
-    "code": 0,
-    "label": ""
+    ascii: 16,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 17,
-    "code": 0,
-    "label": ""
+    ascii: 17,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 18,
-    "code": 0,
-    "label": ""
+    ascii: 18,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 19,
-    "code": 0,
-    "label": ""
+    ascii: 19,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 20,
-    "code": 0,
-    "label": ""
+    ascii: 20,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 21,
-    "code": 0,
-    "label": ""
+    ascii: 21,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 22,
-    "code": 0,
-    "label": ""
+    ascii: 22,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 23,
-    "code": 0,
-    "label": ""
+    ascii: 23,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 24,
-    "code": 0,
-    "label": ""
+    ascii: 24,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 25,
-    "code": 0,
-    "label": ""
+    ascii: 25,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 26,
-    "code": 0,
-    "label": ""
+    ascii: 26,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 27,
-    "code": 41,
-    "label": "esc"
+    ascii: 27,
+    code: 41,
+    label: 'esc',
   },
   {
-    "ascii": 28,
-    "code": 0,
-    "label": ""
+    ascii: 28,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 29,
-    "code": 0,
-    "label": ""
+    ascii: 29,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 30,
-    "code": 0,
-    "label": ""
+    ascii: 30,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 31,
-    "code": 0,
-    "label": ""
+    ascii: 31,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 32,
-    "code": 44,
-    "label": "space"
+    ascii: 32,
+    code: 44,
+    label: 'space',
   },
   {
-    "ascii": 33,
-    "code": 542,
-    "label": "!"
+    ascii: 33,
+    code: 542,
+    label: '!',
   },
   {
-    "ascii": 34,
-    "code": 543,
-    "label": "\""
+    ascii: 34,
+    code: 543,
+    label: '"',
   },
   {
-    "ascii": 35,
-    "code": 544,
-    "label": "#"
+    ascii: 35,
+    code: 544,
+    label: '#',
   },
   {
-    "ascii": 36,
-    "code": 545,
-    "label": "$"
+    ascii: 36,
+    code: 545,
+    label: '$',
   },
   {
-    "ascii": 37,
-    "code": 546,
-    "label": "%"
+    ascii: 37,
+    code: 546,
+    label: '%',
   },
   {
-    "ascii": 38,
-    "code": 547,
-    "label": "&"
+    ascii: 38,
+    code: 547,
+    label: '&',
   },
   {
-    "ascii": 39,
-    "code": 45,
-    "label": "'"
+    ascii: 39,
+    code: 45,
+    label: "'",
   },
   {
-    "ascii": 40,
-    "code": 549,
-    "label": "("
+    ascii: 40,
+    code: 549,
+    label: '(',
   },
   {
-    "ascii": 41,
-    "code": 550,
-    "label": ")"
+    ascii: 41,
+    code: 550,
+    label: ')',
   },
   {
-    "ascii": 42,
-    "code": 558,
-    "label": "*"
+    ascii: 42,
+    code: 558,
+    label: '*',
   },
   {
-    "ascii": 43,
-    "code": 46,
-    "label": "+"
+    ascii: 43,
+    code: 46,
+    label: '+',
   },
   {
-    "ascii": 44,
-    "code": 54,
-    "label": ","
+    ascii: 44,
+    code: 54,
+    label: ',',
   },
   {
-    "ascii": 45,
-    "code": 56,
-    "label": "-"
+    ascii: 45,
+    code: 56,
+    label: '-',
   },
   {
-    "ascii": 46,
-    "code": 55,
-    "label": "."
+    ascii: 46,
+    code: 55,
+    label: '.',
   },
   {
-    "ascii": 47,
-    "code": 548,
-    "label": "/"
+    ascii: 47,
+    code: 548,
+    label: '/',
   },
   {
-    "ascii": 48,
-    "code": 39,
-    "label": "0"
+    ascii: 48,
+    code: 39,
+    label: '0',
   },
   {
-    "ascii": 49,
-    "code": 30,
-    "label": "1"
+    ascii: 49,
+    code: 30,
+    label: '1',
   },
   {
-    "ascii": 50,
-    "code": 31,
-    "label": "2"
+    ascii: 50,
+    code: 31,
+    label: '2',
   },
   {
-    "ascii": 51,
-    "code": 32,
-    "label": "3"
+    ascii: 51,
+    code: 32,
+    label: '3',
   },
   {
-    "ascii": 52,
-    "code": 33,
-    "label": "4"
+    ascii: 52,
+    code: 33,
+    label: '4',
   },
   {
-    "ascii": 53,
-    "code": 34,
-    "label": "5"
+    ascii: 53,
+    code: 34,
+    label: '5',
   },
   {
-    "ascii": 54,
-    "code": 35,
-    "label": "6"
+    ascii: 54,
+    code: 35,
+    label: '6',
   },
   {
-    "ascii": 55,
-    "code": 36,
-    "label": "7"
+    ascii: 55,
+    code: 36,
+    label: '7',
   },
   {
-    "ascii": 56,
-    "code": 37,
-    "label": "8"
+    ascii: 56,
+    code: 37,
+    label: '8',
   },
   {
-    "ascii": 57,
-    "code": 38,
-    "label": "9"
+    ascii: 57,
+    code: 38,
+    label: '9',
   },
   {
-    "ascii": 58,
-    "code": 567,
-    "label": ":"
+    ascii: 58,
+    code: 567,
+    label: ':',
   },
   {
-    "ascii": 59,
-    "code": 566,
-    "label": ";"
+    ascii: 59,
+    code: 566,
+    label: ';',
   },
   {
-    "ascii": 60,
-    "code": 100,
-    "label": "<"
+    ascii: 60,
+    code: 100,
+    label: '<',
   },
   {
-    "ascii": 61,
-    "code": 551,
-    "label": "="
+    ascii: 61,
+    code: 551,
+    label: '=',
   },
   {
-    "ascii": 62,
-    "code": 612,
-    "label": ">"
+    ascii: 62,
+    code: 612,
+    label: '>',
   },
   {
-    "ascii": 63,
-    "code": 557,
-    "label": "?"
+    ascii: 63,
+    code: 557,
+    label: '?',
   },
   {
-    "ascii": 64,
-    "code": 25,
-    "label": "v"
+    ascii: 64,
+    code: 25,
+    label: 'v',
   },
   {
-    "ascii": 65,
-    "code": 516,
-    "label": "A"
+    ascii: 65,
+    code: 516,
+    label: 'A',
   },
   {
-    "ascii": 66,
-    "code": 517,
-    "label": "B"
+    ascii: 66,
+    code: 517,
+    label: 'B',
   },
   {
-    "ascii": 67,
-    "code": 518,
-    "label": "C"
+    ascii: 67,
+    code: 518,
+    label: 'C',
   },
   {
-    "ascii": 68,
-    "code": 519,
-    "label": "D"
+    ascii: 68,
+    code: 519,
+    label: 'D',
   },
   {
-    "ascii": 69,
-    "code": 520,
-    "label": "E"
+    ascii: 69,
+    code: 520,
+    label: 'E',
   },
   {
-    "ascii": 70,
-    "code": 521,
-    "label": "F"
+    ascii: 70,
+    code: 521,
+    label: 'F',
   },
   {
-    "ascii": 71,
-    "code": 522,
-    "label": "G"
+    ascii: 71,
+    code: 522,
+    label: 'G',
   },
   {
-    "ascii": 72,
-    "code": 523,
-    "label": "H"
+    ascii: 72,
+    code: 523,
+    label: 'H',
   },
   {
-    "ascii": 73,
-    "code": 524,
-    "label": "I"
+    ascii: 73,
+    code: 524,
+    label: 'I',
   },
   {
-    "ascii": 74,
-    "code": 525,
-    "label": "J"
+    ascii: 74,
+    code: 525,
+    label: 'J',
   },
   {
-    "ascii": 75,
-    "code": 526,
-    "label": "K"
+    ascii: 75,
+    code: 526,
+    label: 'K',
   },
   {
-    "ascii": 76,
-    "code": 527,
-    "label": "L"
+    ascii: 76,
+    code: 527,
+    label: 'L',
   },
   {
-    "ascii": 77,
-    "code": 528,
-    "label": "M"
+    ascii: 77,
+    code: 528,
+    label: 'M',
   },
   {
-    "ascii": 78,
-    "code": 529,
-    "label": "N"
+    ascii: 78,
+    code: 529,
+    label: 'N',
   },
   {
-    "ascii": 79,
-    "code": 530,
-    "label": "O"
+    ascii: 79,
+    code: 530,
+    label: 'O',
   },
   {
-    "ascii": 80,
-    "code": 531,
-    "label": "P"
+    ascii: 80,
+    code: 531,
+    label: 'P',
   },
   {
-    "ascii": 81,
-    "code": 532,
-    "label": "Q"
+    ascii: 81,
+    code: 532,
+    label: 'Q',
   },
   {
-    "ascii": 82,
-    "code": 533,
-    "label": "R"
+    ascii: 82,
+    code: 533,
+    label: 'R',
   },
   {
-    "ascii": 83,
-    "code": 534,
-    "label": "S"
+    ascii: 83,
+    code: 534,
+    label: 'S',
   },
   {
-    "ascii": 84,
-    "code": 535,
-    "label": "T"
+    ascii: 84,
+    code: 535,
+    label: 'T',
   },
   {
-    "ascii": 85,
-    "code": 536,
-    "label": "U"
+    ascii: 85,
+    code: 536,
+    label: 'U',
   },
   {
-    "ascii": 86,
-    "code": 537,
-    "label": "V"
+    ascii: 86,
+    code: 537,
+    label: 'V',
   },
   {
-    "ascii": 87,
-    "code": 538,
-    "label": "W"
+    ascii: 87,
+    code: 538,
+    label: 'W',
   },
   {
-    "ascii": 88,
-    "code": 539,
-    "label": "X"
+    ascii: 88,
+    code: 539,
+    label: 'X',
   },
   {
-    "ascii": 89,
-    "code": 541,
-    "label": "Y"
+    ascii: 89,
+    code: 541,
+    label: 'Y',
   },
   {
-    "ascii": 90,
-    "code": 540,
-    "label": "Z"
+    ascii: 90,
+    code: 540,
+    label: 'Z',
   },
   {
-    "ascii": 91,
-    "code": 9,
-    "label": "f"
+    ascii: 91,
+    code: 9,
+    label: 'f',
   },
   {
-    "ascii": 92,
-    "code": 20,
-    "label": "q"
+    ascii: 92,
+    code: 20,
+    label: 'q',
   },
   {
-    "ascii": 93,
-    "code": 10,
-    "label": "g"
+    ascii: 93,
+    code: 10,
+    label: 'g',
   },
   {
-    "ascii": 94,
-    "code": 32,
-    "label": "3"
+    ascii: 94,
+    code: 32,
+    label: '3',
   },
   {
-    "ascii": 95,
-    "code": 568,
-    "label": "_"
+    ascii: 95,
+    code: 568,
+    label: '_',
   },
   {
-    "ascii": 96,
-    "code": 36,
-    "label": "7"
+    ascii: 96,
+    code: 36,
+    label: '7',
   },
   {
-    "ascii": 97,
-    "code": 4,
-    "label": "a"
+    ascii: 97,
+    code: 4,
+    label: 'a',
   },
   {
-    "ascii": 98,
-    "code": 5,
-    "label": "b"
+    ascii: 98,
+    code: 5,
+    label: 'b',
   },
   {
-    "ascii": 99,
-    "code": 6,
-    "label": "c"
+    ascii: 99,
+    code: 6,
+    label: 'c',
   },
   {
-    "ascii": 100,
-    "code": 7,
-    "label": "d"
+    ascii: 100,
+    code: 7,
+    label: 'd',
   },
   {
-    "ascii": 101,
-    "code": 8,
-    "label": "e"
+    ascii: 101,
+    code: 8,
+    label: 'e',
   },
   {
-    "ascii": 102,
-    "code": 9,
-    "label": "f"
+    ascii: 102,
+    code: 9,
+    label: 'f',
   },
   {
-    "ascii": 103,
-    "code": 10,
-    "label": "g"
+    ascii: 103,
+    code: 10,
+    label: 'g',
   },
   {
-    "ascii": 104,
-    "code": 11,
-    "label": "h"
+    ascii: 104,
+    code: 11,
+    label: 'h',
   },
   {
-    "ascii": 105,
-    "code": 12,
-    "label": "i"
+    ascii: 105,
+    code: 12,
+    label: 'i',
   },
   {
-    "ascii": 106,
-    "code": 13,
-    "label": "j"
+    ascii: 106,
+    code: 13,
+    label: 'j',
   },
   {
-    "ascii": 107,
-    "code": 14,
-    "label": "k"
+    ascii: 107,
+    code: 14,
+    label: 'k',
   },
   {
-    "ascii": 108,
-    "code": 15,
-    "label": "l"
+    ascii: 108,
+    code: 15,
+    label: 'l',
   },
   {
-    "ascii": 109,
-    "code": 16,
-    "label": "m"
+    ascii: 109,
+    code: 16,
+    label: 'm',
   },
   {
-    "ascii": 110,
-    "code": 17,
-    "label": "n"
+    ascii: 110,
+    code: 17,
+    label: 'n',
   },
   {
-    "ascii": 111,
-    "code": 18,
-    "label": "o"
+    ascii: 111,
+    code: 18,
+    label: 'o',
   },
   {
-    "ascii": 112,
-    "code": 19,
-    "label": "p"
+    ascii: 112,
+    code: 19,
+    label: 'p',
   },
   {
-    "ascii": 113,
-    "code": 20,
-    "label": "q"
+    ascii: 113,
+    code: 20,
+    label: 'q',
   },
   {
-    "ascii": 114,
-    "code": 21,
-    "label": "r"
+    ascii: 114,
+    code: 21,
+    label: 'r',
   },
   {
-    "ascii": 115,
-    "code": 22,
-    "label": "s"
+    ascii: 115,
+    code: 22,
+    label: 's',
   },
   {
-    "ascii": 116,
-    "code": 23,
-    "label": "t"
+    ascii: 116,
+    code: 23,
+    label: 't',
   },
   {
-    "ascii": 117,
-    "code": 24,
-    "label": "u"
+    ascii: 117,
+    code: 24,
+    label: 'u',
   },
   {
-    "ascii": 118,
-    "code": 25,
-    "label": "v"
+    ascii: 118,
+    code: 25,
+    label: 'v',
   },
   {
-    "ascii": 119,
-    "code": 26,
-    "label": "w"
+    ascii: 119,
+    code: 26,
+    label: 'w',
   },
   {
-    "ascii": 120,
-    "code": 27,
-    "label": "x"
+    ascii: 120,
+    code: 27,
+    label: 'x',
   },
   {
-    "ascii": 121,
-    "code": 29,
-    "label": "y"
+    ascii: 121,
+    code: 29,
+    label: 'y',
   },
   {
-    "ascii": 122,
-    "code": 28,
-    "label": "z"
+    ascii: 122,
+    code: 28,
+    label: 'z',
   },
   {
-    "ascii": 123,
-    "code": 5,
-    "label": "b"
+    ascii: 123,
+    code: 5,
+    label: 'b',
   },
   {
-    "ascii": 124,
-    "code": 26,
-    "label": "w"
+    ascii: 124,
+    code: 26,
+    label: 'w',
   },
   {
-    "ascii": 125,
-    "code": 17,
-    "label": "n"
+    ascii: 125,
+    code: 17,
+    label: 'n',
   },
   {
-    "ascii": 126,
-    "code": 30,
-    "label": "1"
+    ascii: 126,
+    code: 30,
+    label: '1',
   },
   {
-    "ascii": 127,
-    "code": 76,
-    "label": "del"
-  }
+    ascii: 127,
+    code: 76,
+    label: 'del',
+  },
 ];
-    

--- a/src/services/labellang/AsciiLabelSpanish.ts
+++ b/src/services/labellang/AsciiLabelSpanish.ts
@@ -1,645 +1,644 @@
 import { AsciiLabel } from './AsciiLabel';
-        
+
 export const AsciiLabelSpanish: AsciiLabel[] = [
   {
-    "ascii": 0,
-    "code": 0,
-    "label": ""
+    ascii: 0,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 1,
-    "code": 0,
-    "label": ""
+    ascii: 1,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 2,
-    "code": 0,
-    "label": ""
+    ascii: 2,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 3,
-    "code": 0,
-    "label": ""
+    ascii: 3,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 4,
-    "code": 0,
-    "label": ""
+    ascii: 4,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 5,
-    "code": 0,
-    "label": ""
+    ascii: 5,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 6,
-    "code": 0,
-    "label": ""
+    ascii: 6,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 7,
-    "code": 0,
-    "label": ""
+    ascii: 7,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 8,
-    "code": 42,
-    "label": "back space"
+    ascii: 8,
+    code: 42,
+    label: 'back space',
   },
   {
-    "ascii": 9,
-    "code": 43,
-    "label": "tab"
+    ascii: 9,
+    code: 43,
+    label: 'tab',
   },
   {
-    "ascii": 10,
-    "code": 40,
-    "label": "enter"
+    ascii: 10,
+    code: 40,
+    label: 'enter',
   },
   {
-    "ascii": 11,
-    "code": 0,
-    "label": ""
+    ascii: 11,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 12,
-    "code": 0,
-    "label": ""
+    ascii: 12,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 13,
-    "code": 0,
-    "label": ""
+    ascii: 13,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 14,
-    "code": 0,
-    "label": ""
+    ascii: 14,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 15,
-    "code": 0,
-    "label": ""
+    ascii: 15,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 16,
-    "code": 0,
-    "label": ""
+    ascii: 16,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 17,
-    "code": 0,
-    "label": ""
+    ascii: 17,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 18,
-    "code": 0,
-    "label": ""
+    ascii: 18,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 19,
-    "code": 0,
-    "label": ""
+    ascii: 19,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 20,
-    "code": 0,
-    "label": ""
+    ascii: 20,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 21,
-    "code": 0,
-    "label": ""
+    ascii: 21,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 22,
-    "code": 0,
-    "label": ""
+    ascii: 22,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 23,
-    "code": 0,
-    "label": ""
+    ascii: 23,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 24,
-    "code": 0,
-    "label": ""
+    ascii: 24,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 25,
-    "code": 0,
-    "label": ""
+    ascii: 25,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 26,
-    "code": 0,
-    "label": ""
+    ascii: 26,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 27,
-    "code": 41,
-    "label": "esc"
+    ascii: 27,
+    code: 41,
+    label: 'esc',
   },
   {
-    "ascii": 28,
-    "code": 0,
-    "label": ""
+    ascii: 28,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 29,
-    "code": 0,
-    "label": ""
+    ascii: 29,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 30,
-    "code": 0,
-    "label": ""
+    ascii: 30,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 31,
-    "code": 0,
-    "label": ""
+    ascii: 31,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 32,
-    "code": 44,
-    "label": "space"
+    ascii: 32,
+    code: 44,
+    label: 'space',
   },
   {
-    "ascii": 33,
-    "code": 542,
-    "label": "!"
+    ascii: 33,
+    code: 542,
+    label: '!',
   },
   {
-    "ascii": 34,
-    "code": 543,
-    "label": "\""
+    ascii: 34,
+    code: 543,
+    label: '"',
   },
   {
-    "ascii": 35,
-    "code": 32,
-    "label": "3"
+    ascii: 35,
+    code: 32,
+    label: '3',
   },
   {
-    "ascii": 36,
-    "code": 545,
-    "label": "$"
+    ascii: 36,
+    code: 545,
+    label: '$',
   },
   {
-    "ascii": 37,
-    "code": 546,
-    "label": "%"
+    ascii: 37,
+    code: 546,
+    label: '%',
   },
   {
-    "ascii": 38,
-    "code": 547,
-    "label": "&"
+    ascii: 38,
+    code: 547,
+    label: '&',
   },
   {
-    "ascii": 39,
-    "code": 45,
-    "label": "'"
+    ascii: 39,
+    code: 45,
+    label: "'",
   },
   {
-    "ascii": 40,
-    "code": 549,
-    "label": "("
+    ascii: 40,
+    code: 549,
+    label: '(',
   },
   {
-    "ascii": 41,
-    "code": 550,
-    "label": ")"
+    ascii: 41,
+    code: 550,
+    label: ')',
   },
   {
-    "ascii": 42,
-    "code": 560,
-    "label": "*"
+    ascii: 42,
+    code: 560,
+    label: '*',
   },
   {
-    "ascii": 43,
-    "code": 48,
-    "label": "+"
+    ascii: 43,
+    code: 48,
+    label: '+',
   },
   {
-    "ascii": 44,
-    "code": 54,
-    "label": ","
+    ascii: 44,
+    code: 54,
+    label: ',',
   },
   {
-    "ascii": 45,
-    "code": 56,
-    "label": "-"
+    ascii: 45,
+    code: 56,
+    label: '-',
   },
   {
-    "ascii": 46,
-    "code": 55,
-    "label": "."
+    ascii: 46,
+    code: 55,
+    label: '.',
   },
   {
-    "ascii": 47,
-    "code": 548,
-    "label": "/"
+    ascii: 47,
+    code: 548,
+    label: '/',
   },
   {
-    "ascii": 48,
-    "code": 39,
-    "label": "0"
+    ascii: 48,
+    code: 39,
+    label: '0',
   },
   {
-    "ascii": 49,
-    "code": 30,
-    "label": "1"
+    ascii: 49,
+    code: 30,
+    label: '1',
   },
   {
-    "ascii": 50,
-    "code": 31,
-    "label": "2"
+    ascii: 50,
+    code: 31,
+    label: '2',
   },
   {
-    "ascii": 51,
-    "code": 32,
-    "label": "3"
+    ascii: 51,
+    code: 32,
+    label: '3',
   },
   {
-    "ascii": 52,
-    "code": 33,
-    "label": "4"
+    ascii: 52,
+    code: 33,
+    label: '4',
   },
   {
-    "ascii": 53,
-    "code": 34,
-    "label": "5"
+    ascii: 53,
+    code: 34,
+    label: '5',
   },
   {
-    "ascii": 54,
-    "code": 35,
-    "label": "6"
+    ascii: 54,
+    code: 35,
+    label: '6',
   },
   {
-    "ascii": 55,
-    "code": 36,
-    "label": "7"
+    ascii: 55,
+    code: 36,
+    label: '7',
   },
   {
-    "ascii": 56,
-    "code": 37,
-    "label": "8"
+    ascii: 56,
+    code: 37,
+    label: '8',
   },
   {
-    "ascii": 57,
-    "code": 38,
-    "label": "9"
+    ascii: 57,
+    code: 38,
+    label: '9',
   },
   {
-    "ascii": 58,
-    "code": 567,
-    "label": ":"
+    ascii: 58,
+    code: 567,
+    label: ':',
   },
   {
-    "ascii": 59,
-    "code": 566,
-    "label": ";"
+    ascii: 59,
+    code: 566,
+    label: ';',
   },
   {
-    "ascii": 60,
-    "code": 100,
-    "label": "<"
+    ascii: 60,
+    code: 100,
+    label: '<',
   },
   {
-    "ascii": 61,
-    "code": 551,
-    "label": "="
+    ascii: 61,
+    code: 551,
+    label: '=',
   },
   {
-    "ascii": 62,
-    "code": 612,
-    "label": ">"
+    ascii: 62,
+    code: 612,
+    label: '>',
   },
   {
-    "ascii": 63,
-    "code": 557,
-    "label": "?"
+    ascii: 63,
+    code: 557,
+    label: '?',
   },
   {
-    "ascii": 64,
-    "code": 31,
-    "label": "2"
+    ascii: 64,
+    code: 31,
+    label: '2',
   },
   {
-    "ascii": 65,
-    "code": 516,
-    "label": "A"
+    ascii: 65,
+    code: 516,
+    label: 'A',
   },
   {
-    "ascii": 66,
-    "code": 517,
-    "label": "B"
+    ascii: 66,
+    code: 517,
+    label: 'B',
   },
   {
-    "ascii": 67,
-    "code": 518,
-    "label": "C"
+    ascii: 67,
+    code: 518,
+    label: 'C',
   },
   {
-    "ascii": 68,
-    "code": 519,
-    "label": "D"
+    ascii: 68,
+    code: 519,
+    label: 'D',
   },
   {
-    "ascii": 69,
-    "code": 520,
-    "label": "E"
+    ascii: 69,
+    code: 520,
+    label: 'E',
   },
   {
-    "ascii": 70,
-    "code": 521,
-    "label": "F"
+    ascii: 70,
+    code: 521,
+    label: 'F',
   },
   {
-    "ascii": 71,
-    "code": 522,
-    "label": "G"
+    ascii: 71,
+    code: 522,
+    label: 'G',
   },
   {
-    "ascii": 72,
-    "code": 523,
-    "label": "H"
+    ascii: 72,
+    code: 523,
+    label: 'H',
   },
   {
-    "ascii": 73,
-    "code": 524,
-    "label": "I"
+    ascii: 73,
+    code: 524,
+    label: 'I',
   },
   {
-    "ascii": 74,
-    "code": 525,
-    "label": "J"
+    ascii: 74,
+    code: 525,
+    label: 'J',
   },
   {
-    "ascii": 75,
-    "code": 526,
-    "label": "K"
+    ascii: 75,
+    code: 526,
+    label: 'K',
   },
   {
-    "ascii": 76,
-    "code": 527,
-    "label": "L"
+    ascii: 76,
+    code: 527,
+    label: 'L',
   },
   {
-    "ascii": 77,
-    "code": 528,
-    "label": "M"
+    ascii: 77,
+    code: 528,
+    label: 'M',
   },
   {
-    "ascii": 78,
-    "code": 529,
-    "label": "N"
+    ascii: 78,
+    code: 529,
+    label: 'N',
   },
   {
-    "ascii": 79,
-    "code": 530,
-    "label": "O"
+    ascii: 79,
+    code: 530,
+    label: 'O',
   },
   {
-    "ascii": 80,
-    "code": 531,
-    "label": "P"
+    ascii: 80,
+    code: 531,
+    label: 'P',
   },
   {
-    "ascii": 81,
-    "code": 532,
-    "label": "Q"
+    ascii: 81,
+    code: 532,
+    label: 'Q',
   },
   {
-    "ascii": 82,
-    "code": 533,
-    "label": "R"
+    ascii: 82,
+    code: 533,
+    label: 'R',
   },
   {
-    "ascii": 83,
-    "code": 534,
-    "label": "S"
+    ascii: 83,
+    code: 534,
+    label: 'S',
   },
   {
-    "ascii": 84,
-    "code": 535,
-    "label": "T"
+    ascii: 84,
+    code: 535,
+    label: 'T',
   },
   {
-    "ascii": 85,
-    "code": 536,
-    "label": "U"
+    ascii: 85,
+    code: 536,
+    label: 'U',
   },
   {
-    "ascii": 86,
-    "code": 537,
-    "label": "V"
+    ascii: 86,
+    code: 537,
+    label: 'V',
   },
   {
-    "ascii": 87,
-    "code": 538,
-    "label": "W"
+    ascii: 87,
+    code: 538,
+    label: 'W',
   },
   {
-    "ascii": 88,
-    "code": 539,
-    "label": "X"
+    ascii: 88,
+    code: 539,
+    label: 'X',
   },
   {
-    "ascii": 89,
-    "code": 540,
-    "label": "Y"
+    ascii: 89,
+    code: 540,
+    label: 'Y',
   },
   {
-    "ascii": 90,
-    "code": 541,
-    "label": "Z"
+    ascii: 90,
+    code: 541,
+    label: 'Z',
   },
   {
-    "ascii": 91,
-    "code": 47,
-    "label": "` (dead)"
+    ascii: 91,
+    code: 47,
+    label: '` (dead)',
   },
   {
-    "ascii": 92,
-    "code": 53,
-    "label": "º"
+    ascii: 92,
+    code: 53,
+    label: 'º',
   },
   {
-    "ascii": 93,
-    "code": 48,
-    "label": "+"
+    ascii: 93,
+    code: 48,
+    label: '+',
   },
   {
-    "ascii": 94,
-    "code": 559,
-    "label": "^ (dead)"
+    ascii: 94,
+    code: 559,
+    label: '^ (dead)',
   },
   {
-    "ascii": 95,
-    "code": 568,
-    "label": "_"
+    ascii: 95,
+    code: 568,
+    label: '_',
   },
   {
-    "ascii": 96,
-    "code": 47,
-    "label": "` (dead)"
+    ascii: 96,
+    code: 47,
+    label: '` (dead)',
   },
   {
-    "ascii": 97,
-    "code": 4,
-    "label": "a"
+    ascii: 97,
+    code: 4,
+    label: 'a',
   },
   {
-    "ascii": 98,
-    "code": 5,
-    "label": "b"
+    ascii: 98,
+    code: 5,
+    label: 'b',
   },
   {
-    "ascii": 99,
-    "code": 6,
-    "label": "c"
+    ascii: 99,
+    code: 6,
+    label: 'c',
   },
   {
-    "ascii": 100,
-    "code": 7,
-    "label": "d"
+    ascii: 100,
+    code: 7,
+    label: 'd',
   },
   {
-    "ascii": 101,
-    "code": 8,
-    "label": "e"
+    ascii: 101,
+    code: 8,
+    label: 'e',
   },
   {
-    "ascii": 102,
-    "code": 9,
-    "label": "f"
+    ascii: 102,
+    code: 9,
+    label: 'f',
   },
   {
-    "ascii": 103,
-    "code": 10,
-    "label": "g"
+    ascii: 103,
+    code: 10,
+    label: 'g',
   },
   {
-    "ascii": 104,
-    "code": 11,
-    "label": "h"
+    ascii: 104,
+    code: 11,
+    label: 'h',
   },
   {
-    "ascii": 105,
-    "code": 12,
-    "label": "i"
+    ascii: 105,
+    code: 12,
+    label: 'i',
   },
   {
-    "ascii": 106,
-    "code": 13,
-    "label": "j"
+    ascii: 106,
+    code: 13,
+    label: 'j',
   },
   {
-    "ascii": 107,
-    "code": 14,
-    "label": "k"
+    ascii: 107,
+    code: 14,
+    label: 'k',
   },
   {
-    "ascii": 108,
-    "code": 15,
-    "label": "l"
+    ascii: 108,
+    code: 15,
+    label: 'l',
   },
   {
-    "ascii": 109,
-    "code": 16,
-    "label": "m"
+    ascii: 109,
+    code: 16,
+    label: 'm',
   },
   {
-    "ascii": 110,
-    "code": 17,
-    "label": "n"
+    ascii: 110,
+    code: 17,
+    label: 'n',
   },
   {
-    "ascii": 111,
-    "code": 18,
-    "label": "o"
+    ascii: 111,
+    code: 18,
+    label: 'o',
   },
   {
-    "ascii": 112,
-    "code": 19,
-    "label": "p"
+    ascii: 112,
+    code: 19,
+    label: 'p',
   },
   {
-    "ascii": 113,
-    "code": 20,
-    "label": "q"
+    ascii: 113,
+    code: 20,
+    label: 'q',
   },
   {
-    "ascii": 114,
-    "code": 21,
-    "label": "r"
+    ascii: 114,
+    code: 21,
+    label: 'r',
   },
   {
-    "ascii": 115,
-    "code": 22,
-    "label": "s"
+    ascii: 115,
+    code: 22,
+    label: 's',
   },
   {
-    "ascii": 116,
-    "code": 23,
-    "label": "t"
+    ascii: 116,
+    code: 23,
+    label: 't',
   },
   {
-    "ascii": 117,
-    "code": 24,
-    "label": "u"
+    ascii: 117,
+    code: 24,
+    label: 'u',
   },
   {
-    "ascii": 118,
-    "code": 25,
-    "label": "v"
+    ascii: 118,
+    code: 25,
+    label: 'v',
   },
   {
-    "ascii": 119,
-    "code": 26,
-    "label": "w"
+    ascii: 119,
+    code: 26,
+    label: 'w',
   },
   {
-    "ascii": 120,
-    "code": 27,
-    "label": "x"
+    ascii: 120,
+    code: 27,
+    label: 'x',
   },
   {
-    "ascii": 121,
-    "code": 28,
-    "label": "y"
+    ascii: 121,
+    code: 28,
+    label: 'y',
   },
   {
-    "ascii": 122,
-    "code": 29,
-    "label": "z"
+    ascii: 122,
+    code: 29,
+    label: 'z',
   },
   {
-    "ascii": 123,
-    "code": 52,
-    "label": "´ (dead)"
+    ascii: 123,
+    code: 52,
+    label: '´ (dead)',
   },
   {
-    "ascii": 124,
-    "code": 30,
-    "label": "1"
+    ascii: 124,
+    code: 30,
+    label: '1',
   },
   {
-    "ascii": 125,
-    "code": 50,
-    "label": "Ç"
+    ascii: 125,
+    code: 50,
+    label: 'Ç',
   },
   {
-    "ascii": 126,
-    "code": 33,
-    "label": "4"
+    ascii: 126,
+    code: 33,
+    label: '4',
   },
   {
-    "ascii": 127,
-    "code": 76,
-    "label": "del"
-  }
+    ascii: 127,
+    code: 76,
+    label: 'del',
+  },
 ];
-    

--- a/src/services/labellang/AsciiLabelSpanish_dvorak.ts
+++ b/src/services/labellang/AsciiLabelSpanish_dvorak.ts
@@ -1,645 +1,644 @@
 import { AsciiLabel } from './AsciiLabel';
-        
+
 export const AsciiLabelSpanish_dvorak: AsciiLabel[] = [
   {
-    "ascii": 0,
-    "code": 0,
-    "label": ""
+    ascii: 0,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 1,
-    "code": 0,
-    "label": ""
+    ascii: 1,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 2,
-    "code": 0,
-    "label": ""
+    ascii: 2,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 3,
-    "code": 0,
-    "label": ""
+    ascii: 3,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 4,
-    "code": 0,
-    "label": ""
+    ascii: 4,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 5,
-    "code": 0,
-    "label": ""
+    ascii: 5,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 6,
-    "code": 0,
-    "label": ""
+    ascii: 6,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 7,
-    "code": 0,
-    "label": ""
+    ascii: 7,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 8,
-    "code": 42,
-    "label": "back space"
+    ascii: 8,
+    code: 42,
+    label: 'back space',
   },
   {
-    "ascii": 9,
-    "code": 43,
-    "label": "tab"
+    ascii: 9,
+    code: 43,
+    label: 'tab',
   },
   {
-    "ascii": 10,
-    "code": 40,
-    "label": "enter"
+    ascii: 10,
+    code: 40,
+    label: 'enter',
   },
   {
-    "ascii": 11,
-    "code": 0,
-    "label": ""
+    ascii: 11,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 12,
-    "code": 0,
-    "label": ""
+    ascii: 12,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 13,
-    "code": 0,
-    "label": ""
+    ascii: 13,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 14,
-    "code": 0,
-    "label": ""
+    ascii: 14,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 15,
-    "code": 0,
-    "label": ""
+    ascii: 15,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 16,
-    "code": 0,
-    "label": ""
+    ascii: 16,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 17,
-    "code": 0,
-    "label": ""
+    ascii: 17,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 18,
-    "code": 0,
-    "label": ""
+    ascii: 18,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 19,
-    "code": 0,
-    "label": ""
+    ascii: 19,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 20,
-    "code": 0,
-    "label": ""
+    ascii: 20,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 21,
-    "code": 0,
-    "label": ""
+    ascii: 21,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 22,
-    "code": 0,
-    "label": ""
+    ascii: 22,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 23,
-    "code": 0,
-    "label": ""
+    ascii: 23,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 24,
-    "code": 0,
-    "label": ""
+    ascii: 24,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 25,
-    "code": 0,
-    "label": ""
+    ascii: 25,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 26,
-    "code": 0,
-    "label": ""
+    ascii: 26,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 27,
-    "code": 41,
-    "label": "esc"
+    ascii: 27,
+    code: 41,
+    label: 'esc',
   },
   {
-    "ascii": 28,
-    "code": 0,
-    "label": ""
+    ascii: 28,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 29,
-    "code": 0,
-    "label": ""
+    ascii: 29,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 30,
-    "code": 0,
-    "label": ""
+    ascii: 30,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 31,
-    "code": 0,
-    "label": ""
+    ascii: 31,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 32,
-    "code": 44,
-    "label": "space"
+    ascii: 32,
+    code: 44,
+    label: 'space',
   },
   {
-    "ascii": 33,
-    "code": 542,
-    "label": "!"
+    ascii: 33,
+    code: 542,
+    label: '!',
   },
   {
-    "ascii": 34,
-    "code": 543,
-    "label": "\""
+    ascii: 34,
+    code: 543,
+    label: '"',
   },
   {
-    "ascii": 35,
-    "code": 32,
-    "label": "3"
+    ascii: 35,
+    code: 32,
+    label: '3',
   },
   {
-    "ascii": 36,
-    "code": 545,
-    "label": "$"
+    ascii: 36,
+    code: 545,
+    label: '$',
   },
   {
-    "ascii": 37,
-    "code": 546,
-    "label": "%"
+    ascii: 37,
+    code: 546,
+    label: '%',
   },
   {
-    "ascii": 38,
-    "code": 547,
-    "label": "&"
+    ascii: 38,
+    code: 547,
+    label: '&',
   },
   {
-    "ascii": 39,
-    "code": 45,
-    "label": "'"
+    ascii: 39,
+    code: 45,
+    label: "'",
   },
   {
-    "ascii": 40,
-    "code": 549,
-    "label": "("
+    ascii: 40,
+    code: 549,
+    label: '(',
   },
   {
-    "ascii": 41,
-    "code": 550,
-    "label": ")"
+    ascii: 41,
+    code: 550,
+    label: ')',
   },
   {
-    "ascii": 42,
-    "code": 560,
-    "label": "*"
+    ascii: 42,
+    code: 560,
+    label: '*',
   },
   {
-    "ascii": 43,
-    "code": 48,
-    "label": "+"
+    ascii: 43,
+    code: 48,
+    label: '+',
   },
   {
-    "ascii": 44,
-    "code": 26,
-    "label": ","
+    ascii: 44,
+    code: 26,
+    label: ',',
   },
   {
-    "ascii": 45,
-    "code": 29,
-    "label": "-"
+    ascii: 45,
+    code: 29,
+    label: '-',
   },
   {
-    "ascii": 46,
-    "code": 20,
-    "label": "."
+    ascii: 46,
+    code: 20,
+    label: '.',
   },
   {
-    "ascii": 47,
-    "code": 548,
-    "label": "/"
+    ascii: 47,
+    code: 548,
+    label: '/',
   },
   {
-    "ascii": 48,
-    "code": 39,
-    "label": "0"
+    ascii: 48,
+    code: 39,
+    label: '0',
   },
   {
-    "ascii": 49,
-    "code": 30,
-    "label": "1"
+    ascii: 49,
+    code: 30,
+    label: '1',
   },
   {
-    "ascii": 50,
-    "code": 31,
-    "label": "2"
+    ascii: 50,
+    code: 31,
+    label: '2',
   },
   {
-    "ascii": 51,
-    "code": 32,
-    "label": "3"
+    ascii: 51,
+    code: 32,
+    label: '3',
   },
   {
-    "ascii": 52,
-    "code": 33,
-    "label": "4"
+    ascii: 52,
+    code: 33,
+    label: '4',
   },
   {
-    "ascii": 53,
-    "code": 34,
-    "label": "5"
+    ascii: 53,
+    code: 34,
+    label: '5',
   },
   {
-    "ascii": 54,
-    "code": 35,
-    "label": "6"
+    ascii: 54,
+    code: 35,
+    label: '6',
   },
   {
-    "ascii": 55,
-    "code": 36,
-    "label": "7"
+    ascii: 55,
+    code: 36,
+    label: '7',
   },
   {
-    "ascii": 56,
-    "code": 37,
-    "label": "8"
+    ascii: 56,
+    code: 37,
+    label: '8',
   },
   {
-    "ascii": 57,
-    "code": 38,
-    "label": "9"
+    ascii: 57,
+    code: 38,
+    label: '9',
   },
   {
-    "ascii": 58,
-    "code": 532,
-    "label": "."
+    ascii: 58,
+    code: 532,
+    label: '.',
   },
   {
-    "ascii": 59,
-    "code": 538,
-    "label": ","
+    ascii: 59,
+    code: 538,
+    label: ',',
   },
   {
-    "ascii": 60,
-    "code": 100,
-    "label": "<"
+    ascii: 60,
+    code: 100,
+    label: '<',
   },
   {
-    "ascii": 61,
-    "code": 551,
-    "label": "="
+    ascii: 61,
+    code: 551,
+    label: '=',
   },
   {
-    "ascii": 62,
-    "code": 612,
-    "label": ">"
+    ascii: 62,
+    code: 612,
+    label: '>',
   },
   {
-    "ascii": 63,
-    "code": 557,
-    "label": "?"
+    ascii: 63,
+    code: 557,
+    label: '?',
   },
   {
-    "ascii": 64,
-    "code": 31,
-    "label": "2"
+    ascii: 64,
+    code: 31,
+    label: '2',
   },
   {
-    "ascii": 65,
-    "code": 516,
-    "label": "A"
+    ascii: 65,
+    code: 516,
+    label: 'A',
   },
   {
-    "ascii": 66,
-    "code": 529,
-    "label": "B"
+    ascii: 66,
+    code: 529,
+    label: 'B',
   },
   {
-    "ascii": 67,
-    "code": 524,
-    "label": "C"
+    ascii: 67,
+    code: 524,
+    label: 'C',
   },
   {
-    "ascii": 68,
-    "code": 523,
-    "label": "D"
+    ascii: 68,
+    code: 523,
+    label: 'D',
   },
   {
-    "ascii": 69,
-    "code": 519,
-    "label": "E"
+    ascii: 69,
+    code: 519,
+    label: 'E',
   },
   {
-    "ascii": 70,
-    "code": 540,
-    "label": "F"
+    ascii: 70,
+    code: 540,
+    label: 'F',
   },
   {
-    "ascii": 71,
-    "code": 536,
-    "label": "G"
+    ascii: 71,
+    code: 536,
+    label: 'G',
   },
   {
-    "ascii": 72,
-    "code": 530,
-    "label": "H"
+    ascii: 72,
+    code: 530,
+    label: 'H',
   },
   {
-    "ascii": 73,
-    "code": 522,
-    "label": "I"
+    ascii: 73,
+    code: 522,
+    label: 'I',
   },
   {
-    "ascii": 74,
-    "code": 518,
-    "label": "J"
+    ascii: 74,
+    code: 518,
+    label: 'J',
   },
   {
-    "ascii": 75,
-    "code": 537,
-    "label": "K"
+    ascii: 75,
+    code: 537,
+    label: 'K',
   },
   {
-    "ascii": 76,
-    "code": 531,
-    "label": "L"
+    ascii: 76,
+    code: 531,
+    label: 'L',
   },
   {
-    "ascii": 77,
-    "code": 528,
-    "label": "M"
+    ascii: 77,
+    code: 528,
+    label: 'M',
   },
   {
-    "ascii": 78,
-    "code": 527,
-    "label": "N"
+    ascii: 78,
+    code: 527,
+    label: 'N',
   },
   {
-    "ascii": 79,
-    "code": 534,
-    "label": "O"
+    ascii: 79,
+    code: 534,
+    label: 'O',
   },
   {
-    "ascii": 80,
-    "code": 533,
-    "label": "P"
+    ascii: 80,
+    code: 533,
+    label: 'P',
   },
   {
-    "ascii": 81,
-    "code": 539,
-    "label": "Q"
+    ascii: 81,
+    code: 539,
+    label: 'Q',
   },
   {
-    "ascii": 82,
-    "code": 525,
-    "label": "R"
+    ascii: 82,
+    code: 525,
+    label: 'R',
   },
   {
-    "ascii": 83,
-    "code": 563,
-    "label": "S"
+    ascii: 83,
+    code: 563,
+    label: 'S',
   },
   {
-    "ascii": 84,
-    "code": 526,
-    "label": "T"
+    ascii: 84,
+    code: 526,
+    label: 'T',
   },
   {
-    "ascii": 85,
-    "code": 521,
-    "label": "U"
+    ascii: 85,
+    code: 521,
+    label: 'U',
   },
   {
-    "ascii": 86,
-    "code": 567,
-    "label": ":"
+    ascii: 86,
+    code: 567,
+    label: ':',
   },
   {
-    "ascii": 87,
-    "code": 566,
-    "label": ";"
+    ascii: 87,
+    code: 566,
+    label: ';',
   },
   {
-    "ascii": 88,
-    "code": 517,
-    "label": "X"
+    ascii: 88,
+    code: 517,
+    label: 'X',
   },
   {
-    "ascii": 89,
-    "code": 535,
-    "label": "Y"
+    ascii: 89,
+    code: 535,
+    label: 'Y',
   },
   {
-    "ascii": 90,
-    "code": 568,
-    "label": "Z"
+    ascii: 90,
+    code: 568,
+    label: 'Z',
   },
   {
-    "ascii": 91,
-    "code": 47,
-    "label": "` (dead)"
+    ascii: 91,
+    code: 47,
+    label: '` (dead)',
   },
   {
-    "ascii": 92,
-    "code": 53,
-    "label": "º"
+    ascii: 92,
+    code: 53,
+    label: 'º',
   },
   {
-    "ascii": 93,
-    "code": 48,
-    "label": "+"
+    ascii: 93,
+    code: 48,
+    label: '+',
   },
   {
-    "ascii": 94,
-    "code": 559,
-    "label": "^ (dead)"
+    ascii: 94,
+    code: 559,
+    label: '^ (dead)',
   },
   {
-    "ascii": 95,
-    "code": 541,
-    "label": "_"
+    ascii: 95,
+    code: 541,
+    label: '_',
   },
   {
-    "ascii": 96,
-    "code": 47,
-    "label": "` (dead)"
+    ascii: 96,
+    code: 47,
+    label: '` (dead)',
   },
   {
-    "ascii": 97,
-    "code": 4,
-    "label": "a"
+    ascii: 97,
+    code: 4,
+    label: 'a',
   },
   {
-    "ascii": 98,
-    "code": 17,
-    "label": "b"
+    ascii: 98,
+    code: 17,
+    label: 'b',
   },
   {
-    "ascii": 99,
-    "code": 12,
-    "label": "c"
+    ascii: 99,
+    code: 12,
+    label: 'c',
   },
   {
-    "ascii": 100,
-    "code": 11,
-    "label": "d"
+    ascii: 100,
+    code: 11,
+    label: 'd',
   },
   {
-    "ascii": 101,
-    "code": 7,
-    "label": "e"
+    ascii: 101,
+    code: 7,
+    label: 'e',
   },
   {
-    "ascii": 102,
-    "code": 28,
-    "label": "f"
+    ascii: 102,
+    code: 28,
+    label: 'f',
   },
   {
-    "ascii": 103,
-    "code": 24,
-    "label": "g"
+    ascii: 103,
+    code: 24,
+    label: 'g',
   },
   {
-    "ascii": 104,
-    "code": 18,
-    "label": "h"
+    ascii: 104,
+    code: 18,
+    label: 'h',
   },
   {
-    "ascii": 105,
-    "code": 10,
-    "label": "i"
+    ascii: 105,
+    code: 10,
+    label: 'i',
   },
   {
-    "ascii": 106,
-    "code": 6,
-    "label": "j"
+    ascii: 106,
+    code: 6,
+    label: 'j',
   },
   {
-    "ascii": 107,
-    "code": 25,
-    "label": "k"
+    ascii: 107,
+    code: 25,
+    label: 'k',
   },
   {
-    "ascii": 108,
-    "code": 19,
-    "label": "l"
+    ascii: 108,
+    code: 19,
+    label: 'l',
   },
   {
-    "ascii": 109,
-    "code": 16,
-    "label": "m"
+    ascii: 109,
+    code: 16,
+    label: 'm',
   },
   {
-    "ascii": 110,
-    "code": 15,
-    "label": "n"
+    ascii: 110,
+    code: 15,
+    label: 'n',
   },
   {
-    "ascii": 111,
-    "code": 22,
-    "label": "o"
+    ascii: 111,
+    code: 22,
+    label: 'o',
   },
   {
-    "ascii": 112,
-    "code": 21,
-    "label": "p"
+    ascii: 112,
+    code: 21,
+    label: 'p',
   },
   {
-    "ascii": 113,
-    "code": 27,
-    "label": "q"
+    ascii: 113,
+    code: 27,
+    label: 'q',
   },
   {
-    "ascii": 114,
-    "code": 13,
-    "label": "r"
+    ascii: 114,
+    code: 13,
+    label: 'r',
   },
   {
-    "ascii": 115,
-    "code": 51,
-    "label": "s"
+    ascii: 115,
+    code: 51,
+    label: 's',
   },
   {
-    "ascii": 116,
-    "code": 14,
-    "label": "t"
+    ascii: 116,
+    code: 14,
+    label: 't',
   },
   {
-    "ascii": 117,
-    "code": 9,
-    "label": "u"
+    ascii: 117,
+    code: 9,
+    label: 'u',
   },
   {
-    "ascii": 118,
-    "code": 55,
-    "label": "v"
+    ascii: 118,
+    code: 55,
+    label: 'v',
   },
   {
-    "ascii": 119,
-    "code": 54,
-    "label": "w"
+    ascii: 119,
+    code: 54,
+    label: 'w',
   },
   {
-    "ascii": 120,
-    "code": 5,
-    "label": "x"
+    ascii: 120,
+    code: 5,
+    label: 'x',
   },
   {
-    "ascii": 121,
-    "code": 23,
-    "label": "y"
+    ascii: 121,
+    code: 23,
+    label: 'y',
   },
   {
-    "ascii": 122,
-    "code": 56,
-    "label": "z"
+    ascii: 122,
+    code: 56,
+    label: 'z',
   },
   {
-    "ascii": 123,
-    "code": 52,
-    "label": "´ (dead)"
+    ascii: 123,
+    code: 52,
+    label: '´ (dead)',
   },
   {
-    "ascii": 124,
-    "code": 30,
-    "label": "1"
+    ascii: 124,
+    code: 30,
+    label: '1',
   },
   {
-    "ascii": 125,
-    "code": 50,
-    "label": "Ç"
+    ascii: 125,
+    code: 50,
+    label: 'Ç',
   },
   {
-    "ascii": 126,
-    "code": 33,
-    "label": "4"
+    ascii: 126,
+    code: 33,
+    label: '4',
   },
   {
-    "ascii": 127,
-    "code": 76,
-    "label": "del"
-  }
+    ascii: 127,
+    code: 76,
+    label: 'del',
+  },
 ];
-    

--- a/src/services/labellang/AsciiLabelSwedish.ts
+++ b/src/services/labellang/AsciiLabelSwedish.ts
@@ -1,645 +1,644 @@
 import { AsciiLabel } from './AsciiLabel';
-        
+
 export const AsciiLabelSwedish: AsciiLabel[] = [
   {
-    "ascii": 0,
-    "code": 0,
-    "label": ""
+    ascii: 0,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 1,
-    "code": 0,
-    "label": ""
+    ascii: 1,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 2,
-    "code": 0,
-    "label": ""
+    ascii: 2,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 3,
-    "code": 0,
-    "label": ""
+    ascii: 3,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 4,
-    "code": 0,
-    "label": ""
+    ascii: 4,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 5,
-    "code": 0,
-    "label": ""
+    ascii: 5,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 6,
-    "code": 0,
-    "label": ""
+    ascii: 6,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 7,
-    "code": 0,
-    "label": ""
+    ascii: 7,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 8,
-    "code": 42,
-    "label": "back space"
+    ascii: 8,
+    code: 42,
+    label: 'back space',
   },
   {
-    "ascii": 9,
-    "code": 43,
-    "label": "tab"
+    ascii: 9,
+    code: 43,
+    label: 'tab',
   },
   {
-    "ascii": 10,
-    "code": 40,
-    "label": "enter"
+    ascii: 10,
+    code: 40,
+    label: 'enter',
   },
   {
-    "ascii": 11,
-    "code": 0,
-    "label": ""
+    ascii: 11,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 12,
-    "code": 0,
-    "label": ""
+    ascii: 12,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 13,
-    "code": 0,
-    "label": ""
+    ascii: 13,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 14,
-    "code": 0,
-    "label": ""
+    ascii: 14,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 15,
-    "code": 0,
-    "label": ""
+    ascii: 15,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 16,
-    "code": 0,
-    "label": ""
+    ascii: 16,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 17,
-    "code": 0,
-    "label": ""
+    ascii: 17,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 18,
-    "code": 0,
-    "label": ""
+    ascii: 18,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 19,
-    "code": 0,
-    "label": ""
+    ascii: 19,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 20,
-    "code": 0,
-    "label": ""
+    ascii: 20,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 21,
-    "code": 0,
-    "label": ""
+    ascii: 21,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 22,
-    "code": 0,
-    "label": ""
+    ascii: 22,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 23,
-    "code": 0,
-    "label": ""
+    ascii: 23,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 24,
-    "code": 0,
-    "label": ""
+    ascii: 24,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 25,
-    "code": 0,
-    "label": ""
+    ascii: 25,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 26,
-    "code": 0,
-    "label": ""
+    ascii: 26,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 27,
-    "code": 41,
-    "label": "esc"
+    ascii: 27,
+    code: 41,
+    label: 'esc',
   },
   {
-    "ascii": 28,
-    "code": 0,
-    "label": ""
+    ascii: 28,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 29,
-    "code": 0,
-    "label": ""
+    ascii: 29,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 30,
-    "code": 0,
-    "label": ""
+    ascii: 30,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 31,
-    "code": 0,
-    "label": ""
+    ascii: 31,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 32,
-    "code": 44,
-    "label": "space"
+    ascii: 32,
+    code: 44,
+    label: 'space',
   },
   {
-    "ascii": 33,
-    "code": 542,
-    "label": "!"
+    ascii: 33,
+    code: 542,
+    label: '!',
   },
   {
-    "ascii": 34,
-    "code": 543,
-    "label": "\""
+    ascii: 34,
+    code: 543,
+    label: '"',
   },
   {
-    "ascii": 35,
-    "code": 544,
-    "label": "#"
+    ascii: 35,
+    code: 544,
+    label: '#',
   },
   {
-    "ascii": 36,
-    "code": 33,
-    "label": "4"
+    ascii: 36,
+    code: 33,
+    label: '4',
   },
   {
-    "ascii": 37,
-    "code": 546,
-    "label": "%"
+    ascii: 37,
+    code: 546,
+    label: '%',
   },
   {
-    "ascii": 38,
-    "code": 547,
-    "label": "&"
+    ascii: 38,
+    code: 547,
+    label: '&',
   },
   {
-    "ascii": 39,
-    "code": 50,
-    "label": "'"
+    ascii: 39,
+    code: 50,
+    label: "'",
   },
   {
-    "ascii": 40,
-    "code": 549,
-    "label": "("
+    ascii: 40,
+    code: 549,
+    label: '(',
   },
   {
-    "ascii": 41,
-    "code": 550,
-    "label": ")"
+    ascii: 41,
+    code: 550,
+    label: ')',
   },
   {
-    "ascii": 42,
-    "code": 562,
-    "label": "*"
+    ascii: 42,
+    code: 562,
+    label: '*',
   },
   {
-    "ascii": 43,
-    "code": 45,
-    "label": "+"
+    ascii: 43,
+    code: 45,
+    label: '+',
   },
   {
-    "ascii": 44,
-    "code": 54,
-    "label": ","
+    ascii: 44,
+    code: 54,
+    label: ',',
   },
   {
-    "ascii": 45,
-    "code": 56,
-    "label": "-"
+    ascii: 45,
+    code: 56,
+    label: '-',
   },
   {
-    "ascii": 46,
-    "code": 55,
-    "label": "."
+    ascii: 46,
+    code: 55,
+    label: '.',
   },
   {
-    "ascii": 47,
-    "code": 548,
-    "label": "/"
+    ascii: 47,
+    code: 548,
+    label: '/',
   },
   {
-    "ascii": 48,
-    "code": 39,
-    "label": "0"
+    ascii: 48,
+    code: 39,
+    label: '0',
   },
   {
-    "ascii": 49,
-    "code": 30,
-    "label": "1"
+    ascii: 49,
+    code: 30,
+    label: '1',
   },
   {
-    "ascii": 50,
-    "code": 31,
-    "label": "2"
+    ascii: 50,
+    code: 31,
+    label: '2',
   },
   {
-    "ascii": 51,
-    "code": 32,
-    "label": "3"
+    ascii: 51,
+    code: 32,
+    label: '3',
   },
   {
-    "ascii": 52,
-    "code": 33,
-    "label": "4"
+    ascii: 52,
+    code: 33,
+    label: '4',
   },
   {
-    "ascii": 53,
-    "code": 34,
-    "label": "5"
+    ascii: 53,
+    code: 34,
+    label: '5',
   },
   {
-    "ascii": 54,
-    "code": 35,
-    "label": "6"
+    ascii: 54,
+    code: 35,
+    label: '6',
   },
   {
-    "ascii": 55,
-    "code": 36,
-    "label": "7"
+    ascii: 55,
+    code: 36,
+    label: '7',
   },
   {
-    "ascii": 56,
-    "code": 37,
-    "label": "8"
+    ascii: 56,
+    code: 37,
+    label: '8',
   },
   {
-    "ascii": 57,
-    "code": 38,
-    "label": "9"
+    ascii: 57,
+    code: 38,
+    label: '9',
   },
   {
-    "ascii": 58,
-    "code": 567,
-    "label": ":"
+    ascii: 58,
+    code: 567,
+    label: ':',
   },
   {
-    "ascii": 59,
-    "code": 566,
-    "label": ";"
+    ascii: 59,
+    code: 566,
+    label: ';',
   },
   {
-    "ascii": 60,
-    "code": 100,
-    "label": "<"
+    ascii: 60,
+    code: 100,
+    label: '<',
   },
   {
-    "ascii": 61,
-    "code": 551,
-    "label": "="
+    ascii: 61,
+    code: 551,
+    label: '=',
   },
   {
-    "ascii": 62,
-    "code": 612,
-    "label": ">"
+    ascii: 62,
+    code: 612,
+    label: '>',
   },
   {
-    "ascii": 63,
-    "code": 557,
-    "label": "?"
+    ascii: 63,
+    code: 557,
+    label: '?',
   },
   {
-    "ascii": 64,
-    "code": 31,
-    "label": "2"
+    ascii: 64,
+    code: 31,
+    label: '2',
   },
   {
-    "ascii": 65,
-    "code": 516,
-    "label": "A"
+    ascii: 65,
+    code: 516,
+    label: 'A',
   },
   {
-    "ascii": 66,
-    "code": 517,
-    "label": "B"
+    ascii: 66,
+    code: 517,
+    label: 'B',
   },
   {
-    "ascii": 67,
-    "code": 518,
-    "label": "C"
+    ascii: 67,
+    code: 518,
+    label: 'C',
   },
   {
-    "ascii": 68,
-    "code": 519,
-    "label": "D"
+    ascii: 68,
+    code: 519,
+    label: 'D',
   },
   {
-    "ascii": 69,
-    "code": 520,
-    "label": "E"
+    ascii: 69,
+    code: 520,
+    label: 'E',
   },
   {
-    "ascii": 70,
-    "code": 521,
-    "label": "F"
+    ascii: 70,
+    code: 521,
+    label: 'F',
   },
   {
-    "ascii": 71,
-    "code": 522,
-    "label": "G"
+    ascii: 71,
+    code: 522,
+    label: 'G',
   },
   {
-    "ascii": 72,
-    "code": 523,
-    "label": "H"
+    ascii: 72,
+    code: 523,
+    label: 'H',
   },
   {
-    "ascii": 73,
-    "code": 524,
-    "label": "I"
+    ascii: 73,
+    code: 524,
+    label: 'I',
   },
   {
-    "ascii": 74,
-    "code": 525,
-    "label": "J"
+    ascii: 74,
+    code: 525,
+    label: 'J',
   },
   {
-    "ascii": 75,
-    "code": 526,
-    "label": "K"
+    ascii: 75,
+    code: 526,
+    label: 'K',
   },
   {
-    "ascii": 76,
-    "code": 527,
-    "label": "L"
+    ascii: 76,
+    code: 527,
+    label: 'L',
   },
   {
-    "ascii": 77,
-    "code": 528,
-    "label": "M"
+    ascii: 77,
+    code: 528,
+    label: 'M',
   },
   {
-    "ascii": 78,
-    "code": 529,
-    "label": "N"
+    ascii: 78,
+    code: 529,
+    label: 'N',
   },
   {
-    "ascii": 79,
-    "code": 530,
-    "label": "O"
+    ascii: 79,
+    code: 530,
+    label: 'O',
   },
   {
-    "ascii": 80,
-    "code": 531,
-    "label": "P"
+    ascii: 80,
+    code: 531,
+    label: 'P',
   },
   {
-    "ascii": 81,
-    "code": 532,
-    "label": "Q"
+    ascii: 81,
+    code: 532,
+    label: 'Q',
   },
   {
-    "ascii": 82,
-    "code": 533,
-    "label": "R"
+    ascii: 82,
+    code: 533,
+    label: 'R',
   },
   {
-    "ascii": 83,
-    "code": 534,
-    "label": "S"
+    ascii: 83,
+    code: 534,
+    label: 'S',
   },
   {
-    "ascii": 84,
-    "code": 535,
-    "label": "T"
+    ascii: 84,
+    code: 535,
+    label: 'T',
   },
   {
-    "ascii": 85,
-    "code": 536,
-    "label": "U"
+    ascii: 85,
+    code: 536,
+    label: 'U',
   },
   {
-    "ascii": 86,
-    "code": 537,
-    "label": "V"
+    ascii: 86,
+    code: 537,
+    label: 'V',
   },
   {
-    "ascii": 87,
-    "code": 538,
-    "label": "W"
+    ascii: 87,
+    code: 538,
+    label: 'W',
   },
   {
-    "ascii": 88,
-    "code": 539,
-    "label": "X"
+    ascii: 88,
+    code: 539,
+    label: 'X',
   },
   {
-    "ascii": 89,
-    "code": 540,
-    "label": "Y"
+    ascii: 89,
+    code: 540,
+    label: 'Y',
   },
   {
-    "ascii": 90,
-    "code": 541,
-    "label": "Z"
+    ascii: 90,
+    code: 541,
+    label: 'Z',
   },
   {
-    "ascii": 91,
-    "code": 37,
-    "label": "8"
+    ascii: 91,
+    code: 37,
+    label: '8',
   },
   {
-    "ascii": 92,
-    "code": 45,
-    "label": "+"
+    ascii: 92,
+    code: 45,
+    label: '+',
   },
   {
-    "ascii": 93,
-    "code": 38,
-    "label": "9"
+    ascii: 93,
+    code: 38,
+    label: '9',
   },
   {
-    "ascii": 94,
-    "code": 560,
-    "label": "^ (dead)"
+    ascii: 94,
+    code: 560,
+    label: '^ (dead)',
   },
   {
-    "ascii": 95,
-    "code": 568,
-    "label": "_"
+    ascii: 95,
+    code: 568,
+    label: '_',
   },
   {
-    "ascii": 96,
-    "code": 558,
-    "label": "` (dead)"
+    ascii: 96,
+    code: 558,
+    label: '` (dead)',
   },
   {
-    "ascii": 97,
-    "code": 4,
-    "label": "a"
+    ascii: 97,
+    code: 4,
+    label: 'a',
   },
   {
-    "ascii": 98,
-    "code": 5,
-    "label": "b"
+    ascii: 98,
+    code: 5,
+    label: 'b',
   },
   {
-    "ascii": 99,
-    "code": 6,
-    "label": "c"
+    ascii: 99,
+    code: 6,
+    label: 'c',
   },
   {
-    "ascii": 100,
-    "code": 7,
-    "label": "d"
+    ascii: 100,
+    code: 7,
+    label: 'd',
   },
   {
-    "ascii": 101,
-    "code": 8,
-    "label": "e"
+    ascii: 101,
+    code: 8,
+    label: 'e',
   },
   {
-    "ascii": 102,
-    "code": 9,
-    "label": "f"
+    ascii: 102,
+    code: 9,
+    label: 'f',
   },
   {
-    "ascii": 103,
-    "code": 10,
-    "label": "g"
+    ascii: 103,
+    code: 10,
+    label: 'g',
   },
   {
-    "ascii": 104,
-    "code": 11,
-    "label": "h"
+    ascii: 104,
+    code: 11,
+    label: 'h',
   },
   {
-    "ascii": 105,
-    "code": 12,
-    "label": "i"
+    ascii: 105,
+    code: 12,
+    label: 'i',
   },
   {
-    "ascii": 106,
-    "code": 13,
-    "label": "j"
+    ascii: 106,
+    code: 13,
+    label: 'j',
   },
   {
-    "ascii": 107,
-    "code": 14,
-    "label": "k"
+    ascii: 107,
+    code: 14,
+    label: 'k',
   },
   {
-    "ascii": 108,
-    "code": 15,
-    "label": "l"
+    ascii: 108,
+    code: 15,
+    label: 'l',
   },
   {
-    "ascii": 109,
-    "code": 16,
-    "label": "m"
+    ascii: 109,
+    code: 16,
+    label: 'm',
   },
   {
-    "ascii": 110,
-    "code": 17,
-    "label": "n"
+    ascii: 110,
+    code: 17,
+    label: 'n',
   },
   {
-    "ascii": 111,
-    "code": 18,
-    "label": "o"
+    ascii: 111,
+    code: 18,
+    label: 'o',
   },
   {
-    "ascii": 112,
-    "code": 19,
-    "label": "p"
+    ascii: 112,
+    code: 19,
+    label: 'p',
   },
   {
-    "ascii": 113,
-    "code": 20,
-    "label": "q"
+    ascii: 113,
+    code: 20,
+    label: 'q',
   },
   {
-    "ascii": 114,
-    "code": 21,
-    "label": "r"
+    ascii: 114,
+    code: 21,
+    label: 'r',
   },
   {
-    "ascii": 115,
-    "code": 22,
-    "label": "s"
+    ascii: 115,
+    code: 22,
+    label: 's',
   },
   {
-    "ascii": 116,
-    "code": 23,
-    "label": "t"
+    ascii: 116,
+    code: 23,
+    label: 't',
   },
   {
-    "ascii": 117,
-    "code": 24,
-    "label": "u"
+    ascii: 117,
+    code: 24,
+    label: 'u',
   },
   {
-    "ascii": 118,
-    "code": 25,
-    "label": "v"
+    ascii: 118,
+    code: 25,
+    label: 'v',
   },
   {
-    "ascii": 119,
-    "code": 26,
-    "label": "w"
+    ascii: 119,
+    code: 26,
+    label: 'w',
   },
   {
-    "ascii": 120,
-    "code": 27,
-    "label": "x"
+    ascii: 120,
+    code: 27,
+    label: 'x',
   },
   {
-    "ascii": 121,
-    "code": 28,
-    "label": "y"
+    ascii: 121,
+    code: 28,
+    label: 'y',
   },
   {
-    "ascii": 122,
-    "code": 29,
-    "label": "z"
+    ascii: 122,
+    code: 29,
+    label: 'z',
   },
   {
-    "ascii": 123,
-    "code": 36,
-    "label": "7"
+    ascii: 123,
+    code: 36,
+    label: '7',
   },
   {
-    "ascii": 124,
-    "code": 100,
-    "label": "<"
+    ascii: 124,
+    code: 100,
+    label: '<',
   },
   {
-    "ascii": 125,
-    "code": 39,
-    "label": "0"
+    ascii: 125,
+    code: 39,
+    label: '0',
   },
   {
-    "ascii": 126,
-    "code": 48,
-    "label": "¨ (dead)"
+    ascii: 126,
+    code: 48,
+    label: '¨ (dead)',
   },
   {
-    "ascii": 127,
-    "code": 76,
-    "label": "del"
-  }
+    ascii: 127,
+    code: 76,
+    label: 'del',
+  },
 ];
-    

--- a/src/services/labellang/AsciiLabelTurkish_f.ts
+++ b/src/services/labellang/AsciiLabelTurkish_f.ts
@@ -1,645 +1,644 @@
 import { AsciiLabel } from './AsciiLabel';
-        
+
 export const AsciiLabelTurkish_f: AsciiLabel[] = [
   {
-    "ascii": 0,
-    "code": 0,
-    "label": ""
+    ascii: 0,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 1,
-    "code": 0,
-    "label": ""
+    ascii: 1,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 2,
-    "code": 0,
-    "label": ""
+    ascii: 2,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 3,
-    "code": 0,
-    "label": ""
+    ascii: 3,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 4,
-    "code": 0,
-    "label": ""
+    ascii: 4,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 5,
-    "code": 0,
-    "label": ""
+    ascii: 5,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 6,
-    "code": 0,
-    "label": ""
+    ascii: 6,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 7,
-    "code": 0,
-    "label": ""
+    ascii: 7,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 8,
-    "code": 42,
-    "label": "back space"
+    ascii: 8,
+    code: 42,
+    label: 'back space',
   },
   {
-    "ascii": 9,
-    "code": 43,
-    "label": "tab"
+    ascii: 9,
+    code: 43,
+    label: 'tab',
   },
   {
-    "ascii": 10,
-    "code": 40,
-    "label": "enter"
+    ascii: 10,
+    code: 40,
+    label: 'enter',
   },
   {
-    "ascii": 11,
-    "code": 0,
-    "label": ""
+    ascii: 11,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 12,
-    "code": 0,
-    "label": ""
+    ascii: 12,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 13,
-    "code": 0,
-    "label": ""
+    ascii: 13,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 14,
-    "code": 0,
-    "label": ""
+    ascii: 14,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 15,
-    "code": 0,
-    "label": ""
+    ascii: 15,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 16,
-    "code": 0,
-    "label": ""
+    ascii: 16,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 17,
-    "code": 0,
-    "label": ""
+    ascii: 17,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 18,
-    "code": 0,
-    "label": ""
+    ascii: 18,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 19,
-    "code": 0,
-    "label": ""
+    ascii: 19,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 20,
-    "code": 0,
-    "label": ""
+    ascii: 20,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 21,
-    "code": 0,
-    "label": ""
+    ascii: 21,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 22,
-    "code": 0,
-    "label": ""
+    ascii: 22,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 23,
-    "code": 0,
-    "label": ""
+    ascii: 23,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 24,
-    "code": 0,
-    "label": ""
+    ascii: 24,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 25,
-    "code": 0,
-    "label": ""
+    ascii: 25,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 26,
-    "code": 0,
-    "label": ""
+    ascii: 26,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 27,
-    "code": 41,
-    "label": "esc"
+    ascii: 27,
+    code: 41,
+    label: 'esc',
   },
   {
-    "ascii": 28,
-    "code": 0,
-    "label": ""
+    ascii: 28,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 29,
-    "code": 0,
-    "label": ""
+    ascii: 29,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 30,
-    "code": 0,
-    "label": ""
+    ascii: 30,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 31,
-    "code": 0,
-    "label": ""
+    ascii: 31,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 32,
-    "code": 44,
-    "label": "space"
+    ascii: 32,
+    code: 44,
+    label: 'space',
   },
   {
-    "ascii": 33,
-    "code": 542,
-    "label": "!"
+    ascii: 33,
+    code: 542,
+    label: '!',
   },
   {
-    "ascii": 34,
-    "code": 543,
-    "label": "\""
+    ascii: 34,
+    code: 543,
+    label: '"',
   },
   {
-    "ascii": 35,
-    "code": 32,
-    "label": "3"
+    ascii: 35,
+    code: 32,
+    label: '3',
   },
   {
-    "ascii": 36,
-    "code": 545,
-    "label": "$"
+    ascii: 36,
+    code: 545,
+    label: '$',
   },
   {
-    "ascii": 37,
-    "code": 546,
-    "label": "%"
+    ascii: 37,
+    code: 546,
+    label: '%',
   },
   {
-    "ascii": 38,
-    "code": 547,
-    "label": "&"
+    ascii: 38,
+    code: 547,
+    label: '&',
   },
   {
-    "ascii": 39,
-    "code": 548,
-    "label": "'"
+    ascii: 39,
+    code: 548,
+    label: "'",
   },
   {
-    "ascii": 40,
-    "code": 549,
-    "label": "("
+    ascii: 40,
+    code: 549,
+    label: '(',
   },
   {
-    "ascii": 41,
-    "code": 550,
-    "label": ")"
+    ascii: 41,
+    code: 550,
+    label: ')',
   },
   {
-    "ascii": 42,
-    "code": 565,
-    "label": "*"
+    ascii: 42,
+    code: 565,
+    label: '*',
   },
   {
-    "ascii": 43,
-    "code": 53,
-    "label": "+"
+    ascii: 43,
+    code: 53,
+    label: '+',
   },
   {
-    "ascii": 44,
-    "code": 56,
-    "label": ","
+    ascii: 44,
+    code: 56,
+    label: ',',
   },
   {
-    "ascii": 45,
-    "code": 46,
-    "label": "-"
+    ascii: 45,
+    code: 46,
+    label: '-',
   },
   {
-    "ascii": 46,
-    "code": 55,
-    "label": "."
+    ascii: 46,
+    code: 55,
+    label: '.',
   },
   {
-    "ascii": 47,
-    "code": 45,
-    "label": "/"
+    ascii: 47,
+    code: 45,
+    label: '/',
   },
   {
-    "ascii": 48,
-    "code": 39,
-    "label": "0"
+    ascii: 48,
+    code: 39,
+    label: '0',
   },
   {
-    "ascii": 49,
-    "code": 30,
-    "label": "1"
+    ascii: 49,
+    code: 30,
+    label: '1',
   },
   {
-    "ascii": 50,
-    "code": 31,
-    "label": "2"
+    ascii: 50,
+    code: 31,
+    label: '2',
   },
   {
-    "ascii": 51,
-    "code": 32,
-    "label": "3"
+    ascii: 51,
+    code: 32,
+    label: '3',
   },
   {
-    "ascii": 52,
-    "code": 33,
-    "label": "4"
+    ascii: 52,
+    code: 33,
+    label: '4',
   },
   {
-    "ascii": 53,
-    "code": 34,
-    "label": "5"
+    ascii: 53,
+    code: 34,
+    label: '5',
   },
   {
-    "ascii": 54,
-    "code": 35,
-    "label": "6"
+    ascii: 54,
+    code: 35,
+    label: '6',
   },
   {
-    "ascii": 55,
-    "code": 36,
-    "label": "7"
+    ascii: 55,
+    code: 36,
+    label: '7',
   },
   {
-    "ascii": 56,
-    "code": 37,
-    "label": "8"
+    ascii: 56,
+    code: 37,
+    label: '8',
   },
   {
-    "ascii": 57,
-    "code": 38,
-    "label": "9"
+    ascii: 57,
+    code: 38,
+    label: '9',
   },
   {
-    "ascii": 58,
-    "code": 567,
-    "label": ":"
+    ascii: 58,
+    code: 567,
+    label: ':',
   },
   {
-    "ascii": 59,
-    "code": 568,
-    "label": ";"
+    ascii: 59,
+    code: 568,
+    label: ';',
   },
   {
-    "ascii": 60,
-    "code": 100,
-    "label": "<"
+    ascii: 60,
+    code: 100,
+    label: '<',
   },
   {
-    "ascii": 61,
-    "code": 551,
-    "label": "="
+    ascii: 61,
+    code: 551,
+    label: '=',
   },
   {
-    "ascii": 62,
-    "code": 612,
-    "label": ">"
+    ascii: 62,
+    code: 612,
+    label: '>',
   },
   {
-    "ascii": 63,
-    "code": 557,
-    "label": "?"
+    ascii: 63,
+    code: 557,
+    label: '?',
   },
   {
-    "ascii": 64,
-    "code": 20,
-    "label": "f"
+    ascii: 64,
+    code: 20,
+    label: 'f',
   },
   {
-    "ascii": 65,
-    "code": 521,
-    "label": "A"
+    ascii: 65,
+    code: 521,
+    label: 'A',
   },
   {
-    "ascii": 66,
-    "code": 566,
-    "label": "B"
+    ascii: 66,
+    code: 566,
+    label: 'B',
   },
   {
-    "ascii": 67,
-    "code": 537,
-    "label": "C"
+    ascii: 67,
+    code: 537,
+    label: 'C',
   },
   {
-    "ascii": 68,
-    "code": 540,
-    "label": "D"
+    ascii: 68,
+    code: 540,
+    label: 'D',
   },
   {
-    "ascii": 69,
-    "code": 519,
-    "label": "E"
+    ascii: 69,
+    code: 519,
+    label: 'E',
   },
   {
-    "ascii": 70,
-    "code": 532,
-    "label": "F"
+    ascii: 70,
+    code: 532,
+    label: 'F',
   },
   {
-    "ascii": 71,
-    "code": 538,
-    "label": "G"
+    ascii: 71,
+    code: 538,
+    label: 'G',
   },
   {
-    "ascii": 72,
-    "code": 530,
-    "label": "H"
+    ascii: 72,
+    code: 530,
+    label: 'H',
   },
   {
-    "ascii": 73,
-    "code": 533,
-    "label": "I"
+    ascii: 73,
+    code: 533,
+    label: 'I',
   },
   {
-    "ascii": 74,
-    "code": 541,
-    "label": "J"
+    ascii: 74,
+    code: 541,
+    label: 'J',
   },
   {
-    "ascii": 75,
-    "code": 525,
-    "label": "K"
+    ascii: 75,
+    code: 525,
+    label: 'K',
   },
   {
-    "ascii": 76,
-    "code": 527,
-    "label": "L"
+    ascii: 76,
+    code: 527,
+    label: 'L',
   },
   {
-    "ascii": 77,
-    "code": 526,
-    "label": "M"
+    ascii: 77,
+    code: 526,
+    label: 'M',
   },
   {
-    "ascii": 78,
-    "code": 524,
-    "label": "N"
+    ascii: 78,
+    code: 524,
+    label: 'N',
   },
   {
-    "ascii": 79,
-    "code": 535,
-    "label": "O"
+    ascii: 79,
+    code: 535,
+    label: 'O',
   },
   {
-    "ascii": 80,
-    "code": 531,
-    "label": "P"
+    ascii: 80,
+    code: 531,
+    label: 'P',
   },
   {
-    "ascii": 81,
-    "code": 559,
-    "label": "Q"
+    ascii: 81,
+    code: 559,
+    label: 'Q',
   },
   {
-    "ascii": 82,
-    "code": 536,
-    "label": "R"
+    ascii: 82,
+    code: 536,
+    label: 'R',
   },
   {
-    "ascii": 83,
-    "code": 528,
-    "label": "S"
+    ascii: 83,
+    code: 528,
+    label: 'S',
   },
   {
-    "ascii": 84,
-    "code": 523,
-    "label": "T"
+    ascii: 84,
+    code: 523,
+    label: 'T',
   },
   {
-    "ascii": 85,
-    "code": 516,
-    "label": "U"
+    ascii: 85,
+    code: 516,
+    label: 'U',
   },
   {
-    "ascii": 86,
-    "code": 518,
-    "label": "V"
+    ascii: 86,
+    code: 518,
+    label: 'V',
   },
   {
-    "ascii": 87,
-    "code": 560,
-    "label": "W"
+    ascii: 87,
+    code: 560,
+    label: 'W',
   },
   {
-    "ascii": 88,
-    "code": 562,
-    "label": "X"
+    ascii: 88,
+    code: 562,
+    label: 'X',
   },
   {
-    "ascii": 89,
-    "code": 563,
-    "label": "Y"
+    ascii: 89,
+    code: 563,
+    label: 'Y',
   },
   {
-    "ascii": 90,
-    "code": 529,
-    "label": "Z"
+    ascii: 90,
+    code: 529,
+    label: 'Z',
   },
   {
-    "ascii": 91,
-    "code": 37,
-    "label": "8"
+    ascii: 91,
+    code: 37,
+    label: '8',
   },
   {
-    "ascii": 92,
-    "code": 45,
-    "label": "/"
+    ascii: 92,
+    code: 45,
+    label: '/',
   },
   {
-    "ascii": 93,
-    "code": 38,
-    "label": "9"
+    ascii: 93,
+    code: 38,
+    label: '9',
   },
   {
-    "ascii": 94,
-    "code": 544,
-    "label": "^ (dead)"
+    ascii: 94,
+    code: 544,
+    label: '^ (dead)',
   },
   {
-    "ascii": 95,
-    "code": 558,
-    "label": "_"
+    ascii: 95,
+    code: 558,
+    label: '_',
   },
   {
-    "ascii": 96,
-    "code": 50,
-    "label": "x"
+    ascii: 96,
+    code: 50,
+    label: 'x',
   },
   {
-    "ascii": 97,
-    "code": 9,
-    "label": "a"
+    ascii: 97,
+    code: 9,
+    label: 'a',
   },
   {
-    "ascii": 98,
-    "code": 54,
-    "label": "b"
+    ascii: 98,
+    code: 54,
+    label: 'b',
   },
   {
-    "ascii": 99,
-    "code": 25,
-    "label": "c"
+    ascii: 99,
+    code: 25,
+    label: 'c',
   },
   {
-    "ascii": 100,
-    "code": 28,
-    "label": "d"
+    ascii: 100,
+    code: 28,
+    label: 'd',
   },
   {
-    "ascii": 101,
-    "code": 7,
-    "label": "e"
+    ascii: 101,
+    code: 7,
+    label: 'e',
   },
   {
-    "ascii": 102,
-    "code": 20,
-    "label": "f"
+    ascii: 102,
+    code: 20,
+    label: 'f',
   },
   {
-    "ascii": 103,
-    "code": 26,
-    "label": "g"
+    ascii: 103,
+    code: 26,
+    label: 'g',
   },
   {
-    "ascii": 104,
-    "code": 18,
-    "label": "h"
+    ascii: 104,
+    code: 18,
+    label: 'h',
   },
   {
-    "ascii": 105,
-    "code": 21,
-    "label": "i"
+    ascii: 105,
+    code: 21,
+    label: 'i',
   },
   {
-    "ascii": 106,
-    "code": 29,
-    "label": "j"
+    ascii: 106,
+    code: 29,
+    label: 'j',
   },
   {
-    "ascii": 107,
-    "code": 13,
-    "label": "k"
+    ascii: 107,
+    code: 13,
+    label: 'k',
   },
   {
-    "ascii": 108,
-    "code": 15,
-    "label": "l"
+    ascii: 108,
+    code: 15,
+    label: 'l',
   },
   {
-    "ascii": 109,
-    "code": 14,
-    "label": "m"
+    ascii: 109,
+    code: 14,
+    label: 'm',
   },
   {
-    "ascii": 110,
-    "code": 12,
-    "label": "n"
+    ascii: 110,
+    code: 12,
+    label: 'n',
   },
   {
-    "ascii": 111,
-    "code": 23,
-    "label": "o"
+    ascii: 111,
+    code: 23,
+    label: 'o',
   },
   {
-    "ascii": 112,
-    "code": 19,
-    "label": "p"
+    ascii: 112,
+    code: 19,
+    label: 'p',
   },
   {
-    "ascii": 113,
-    "code": 47,
-    "label": "q"
+    ascii: 113,
+    code: 47,
+    label: 'q',
   },
   {
-    "ascii": 114,
-    "code": 24,
-    "label": "r"
+    ascii: 114,
+    code: 24,
+    label: 'r',
   },
   {
-    "ascii": 115,
-    "code": 16,
-    "label": "s"
+    ascii: 115,
+    code: 16,
+    label: 's',
   },
   {
-    "ascii": 116,
-    "code": 11,
-    "label": "t"
+    ascii: 116,
+    code: 11,
+    label: 't',
   },
   {
-    "ascii": 117,
-    "code": 4,
-    "label": "u"
+    ascii: 117,
+    code: 4,
+    label: 'u',
   },
   {
-    "ascii": 118,
-    "code": 6,
-    "label": "v"
+    ascii: 118,
+    code: 6,
+    label: 'v',
   },
   {
-    "ascii": 119,
-    "code": 48,
-    "label": "w"
+    ascii: 119,
+    code: 48,
+    label: 'w',
   },
   {
-    "ascii": 120,
-    "code": 50,
-    "label": "x"
+    ascii: 120,
+    code: 50,
+    label: 'x',
   },
   {
-    "ascii": 121,
-    "code": 51,
-    "label": "y"
+    ascii: 121,
+    code: 51,
+    label: 'y',
   },
   {
-    "ascii": 122,
-    "code": 17,
-    "label": "z"
+    ascii: 122,
+    code: 17,
+    label: 'z',
   },
   {
-    "ascii": 123,
-    "code": 36,
-    "label": "7"
+    ascii: 123,
+    code: 36,
+    label: '7',
   },
   {
-    "ascii": 124,
-    "code": 46,
-    "label": "-"
+    ascii: 124,
+    code: 46,
+    label: '-',
   },
   {
-    "ascii": 125,
-    "code": 39,
-    "label": "0"
+    ascii: 125,
+    code: 39,
+    label: '0',
   },
   {
-    "ascii": 126,
-    "code": 48,
-    "label": "w"
+    ascii: 126,
+    code: 48,
+    label: 'w',
   },
   {
-    "ascii": 127,
-    "code": 76,
-    "label": "del"
-  }
+    ascii: 127,
+    code: 76,
+    label: 'del',
+  },
 ];
-    

--- a/src/services/labellang/AsciiLabelTurkish_q.ts
+++ b/src/services/labellang/AsciiLabelTurkish_q.ts
@@ -1,645 +1,644 @@
 import { AsciiLabel } from './AsciiLabel';
-        
+
 export const AsciiLabelTurkish_q: AsciiLabel[] = [
   {
-    "ascii": 0,
-    "code": 0,
-    "label": ""
+    ascii: 0,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 1,
-    "code": 0,
-    "label": ""
+    ascii: 1,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 2,
-    "code": 0,
-    "label": ""
+    ascii: 2,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 3,
-    "code": 0,
-    "label": ""
+    ascii: 3,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 4,
-    "code": 0,
-    "label": ""
+    ascii: 4,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 5,
-    "code": 0,
-    "label": ""
+    ascii: 5,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 6,
-    "code": 0,
-    "label": ""
+    ascii: 6,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 7,
-    "code": 0,
-    "label": ""
+    ascii: 7,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 8,
-    "code": 42,
-    "label": "back space"
+    ascii: 8,
+    code: 42,
+    label: 'back space',
   },
   {
-    "ascii": 9,
-    "code": 43,
-    "label": "tab"
+    ascii: 9,
+    code: 43,
+    label: 'tab',
   },
   {
-    "ascii": 10,
-    "code": 40,
-    "label": "enter"
+    ascii: 10,
+    code: 40,
+    label: 'enter',
   },
   {
-    "ascii": 11,
-    "code": 0,
-    "label": ""
+    ascii: 11,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 12,
-    "code": 0,
-    "label": ""
+    ascii: 12,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 13,
-    "code": 0,
-    "label": ""
+    ascii: 13,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 14,
-    "code": 0,
-    "label": ""
+    ascii: 14,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 15,
-    "code": 0,
-    "label": ""
+    ascii: 15,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 16,
-    "code": 0,
-    "label": ""
+    ascii: 16,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 17,
-    "code": 0,
-    "label": ""
+    ascii: 17,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 18,
-    "code": 0,
-    "label": ""
+    ascii: 18,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 19,
-    "code": 0,
-    "label": ""
+    ascii: 19,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 20,
-    "code": 0,
-    "label": ""
+    ascii: 20,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 21,
-    "code": 0,
-    "label": ""
+    ascii: 21,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 22,
-    "code": 0,
-    "label": ""
+    ascii: 22,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 23,
-    "code": 0,
-    "label": ""
+    ascii: 23,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 24,
-    "code": 0,
-    "label": ""
+    ascii: 24,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 25,
-    "code": 0,
-    "label": ""
+    ascii: 25,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 26,
-    "code": 0,
-    "label": ""
+    ascii: 26,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 27,
-    "code": 41,
-    "label": "esc"
+    ascii: 27,
+    code: 41,
+    label: 'esc',
   },
   {
-    "ascii": 28,
-    "code": 0,
-    "label": ""
+    ascii: 28,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 29,
-    "code": 0,
-    "label": ""
+    ascii: 29,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 30,
-    "code": 0,
-    "label": ""
+    ascii: 30,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 31,
-    "code": 0,
-    "label": ""
+    ascii: 31,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 32,
-    "code": 44,
-    "label": "space"
+    ascii: 32,
+    code: 44,
+    label: 'space',
   },
   {
-    "ascii": 33,
-    "code": 542,
-    "label": "!"
+    ascii: 33,
+    code: 542,
+    label: '!',
   },
   {
-    "ascii": 34,
-    "code": 53,
-    "label": "\""
+    ascii: 34,
+    code: 53,
+    label: '"',
   },
   {
-    "ascii": 35,
-    "code": 32,
-    "label": "3"
+    ascii: 35,
+    code: 32,
+    label: '3',
   },
   {
-    "ascii": 36,
-    "code": 33,
-    "label": "4"
+    ascii: 36,
+    code: 33,
+    label: '4',
   },
   {
-    "ascii": 37,
-    "code": 546,
-    "label": "%"
+    ascii: 37,
+    code: 546,
+    label: '%',
   },
   {
-    "ascii": 38,
-    "code": 547,
-    "label": "&"
+    ascii: 38,
+    code: 547,
+    label: '&',
   },
   {
-    "ascii": 39,
-    "code": 543,
-    "label": "'"
+    ascii: 39,
+    code: 543,
+    label: "'",
   },
   {
-    "ascii": 40,
-    "code": 549,
-    "label": "("
+    ascii: 40,
+    code: 549,
+    label: '(',
   },
   {
-    "ascii": 41,
-    "code": 550,
-    "label": ")"
+    ascii: 41,
+    code: 550,
+    label: ')',
   },
   {
-    "ascii": 42,
-    "code": 45,
-    "label": "*"
+    ascii: 42,
+    code: 45,
+    label: '*',
   },
   {
-    "ascii": 43,
-    "code": 545,
-    "label": "+"
+    ascii: 43,
+    code: 545,
+    label: '+',
   },
   {
-    "ascii": 44,
-    "code": 50,
-    "label": ","
+    ascii: 44,
+    code: 50,
+    label: ',',
   },
   {
-    "ascii": 45,
-    "code": 46,
-    "label": "-"
+    ascii: 45,
+    code: 46,
+    label: '-',
   },
   {
-    "ascii": 46,
-    "code": 56,
-    "label": "."
+    ascii: 46,
+    code: 56,
+    label: '.',
   },
   {
-    "ascii": 47,
-    "code": 548,
-    "label": "/"
+    ascii: 47,
+    code: 548,
+    label: '/',
   },
   {
-    "ascii": 48,
-    "code": 39,
-    "label": "0"
+    ascii: 48,
+    code: 39,
+    label: '0',
   },
   {
-    "ascii": 49,
-    "code": 30,
-    "label": "1"
+    ascii: 49,
+    code: 30,
+    label: '1',
   },
   {
-    "ascii": 50,
-    "code": 31,
-    "label": "2"
+    ascii: 50,
+    code: 31,
+    label: '2',
   },
   {
-    "ascii": 51,
-    "code": 32,
-    "label": "3"
+    ascii: 51,
+    code: 32,
+    label: '3',
   },
   {
-    "ascii": 52,
-    "code": 33,
-    "label": "4"
+    ascii: 52,
+    code: 33,
+    label: '4',
   },
   {
-    "ascii": 53,
-    "code": 34,
-    "label": "5"
+    ascii: 53,
+    code: 34,
+    label: '5',
   },
   {
-    "ascii": 54,
-    "code": 35,
-    "label": "6"
+    ascii: 54,
+    code: 35,
+    label: '6',
   },
   {
-    "ascii": 55,
-    "code": 36,
-    "label": "7"
+    ascii: 55,
+    code: 36,
+    label: '7',
   },
   {
-    "ascii": 56,
-    "code": 37,
-    "label": "8"
+    ascii: 56,
+    code: 37,
+    label: '8',
   },
   {
-    "ascii": 57,
-    "code": 38,
-    "label": "9"
+    ascii: 57,
+    code: 38,
+    label: '9',
   },
   {
-    "ascii": 58,
-    "code": 568,
-    "label": ":"
+    ascii: 58,
+    code: 568,
+    label: ':',
   },
   {
-    "ascii": 59,
-    "code": 562,
-    "label": ";"
+    ascii: 59,
+    code: 562,
+    label: ';',
   },
   {
-    "ascii": 60,
-    "code": 100,
-    "label": "<"
+    ascii: 60,
+    code: 100,
+    label: '<',
   },
   {
-    "ascii": 61,
-    "code": 551,
-    "label": "="
+    ascii: 61,
+    code: 551,
+    label: '=',
   },
   {
-    "ascii": 62,
-    "code": 612,
-    "label": ">"
+    ascii: 62,
+    code: 612,
+    label: '>',
   },
   {
-    "ascii": 63,
-    "code": 557,
-    "label": "?"
+    ascii: 63,
+    code: 557,
+    label: '?',
   },
   {
-    "ascii": 64,
-    "code": 20,
-    "label": "q"
+    ascii: 64,
+    code: 20,
+    label: 'q',
   },
   {
-    "ascii": 65,
-    "code": 516,
-    "label": "A"
+    ascii: 65,
+    code: 516,
+    label: 'A',
   },
   {
-    "ascii": 66,
-    "code": 517,
-    "label": "B"
+    ascii: 66,
+    code: 517,
+    label: 'B',
   },
   {
-    "ascii": 67,
-    "code": 518,
-    "label": "C"
+    ascii: 67,
+    code: 518,
+    label: 'C',
   },
   {
-    "ascii": 68,
-    "code": 519,
-    "label": "D"
+    ascii: 68,
+    code: 519,
+    label: 'D',
   },
   {
-    "ascii": 69,
-    "code": 520,
-    "label": "E"
+    ascii: 69,
+    code: 520,
+    label: 'E',
   },
   {
-    "ascii": 70,
-    "code": 521,
-    "label": "F"
+    ascii: 70,
+    code: 521,
+    label: 'F',
   },
   {
-    "ascii": 71,
-    "code": 522,
-    "label": "G"
+    ascii: 71,
+    code: 522,
+    label: 'G',
   },
   {
-    "ascii": 72,
-    "code": 523,
-    "label": "H"
+    ascii: 72,
+    code: 523,
+    label: 'H',
   },
   {
-    "ascii": 73,
-    "code": 524,
-    "label": "I"
+    ascii: 73,
+    code: 524,
+    label: 'I',
   },
   {
-    "ascii": 74,
-    "code": 525,
-    "label": "J"
+    ascii: 74,
+    code: 525,
+    label: 'J',
   },
   {
-    "ascii": 75,
-    "code": 526,
-    "label": "K"
+    ascii: 75,
+    code: 526,
+    label: 'K',
   },
   {
-    "ascii": 76,
-    "code": 527,
-    "label": "L"
+    ascii: 76,
+    code: 527,
+    label: 'L',
   },
   {
-    "ascii": 77,
-    "code": 528,
-    "label": "M"
+    ascii: 77,
+    code: 528,
+    label: 'M',
   },
   {
-    "ascii": 78,
-    "code": 529,
-    "label": "N"
+    ascii: 78,
+    code: 529,
+    label: 'N',
   },
   {
-    "ascii": 79,
-    "code": 530,
-    "label": "O"
+    ascii: 79,
+    code: 530,
+    label: 'O',
   },
   {
-    "ascii": 80,
-    "code": 531,
-    "label": "P"
+    ascii: 80,
+    code: 531,
+    label: 'P',
   },
   {
-    "ascii": 81,
-    "code": 532,
-    "label": "Q"
+    ascii: 81,
+    code: 532,
+    label: 'Q',
   },
   {
-    "ascii": 82,
-    "code": 533,
-    "label": "R"
+    ascii: 82,
+    code: 533,
+    label: 'R',
   },
   {
-    "ascii": 83,
-    "code": 534,
-    "label": "S"
+    ascii: 83,
+    code: 534,
+    label: 'S',
   },
   {
-    "ascii": 84,
-    "code": 535,
-    "label": "T"
+    ascii: 84,
+    code: 535,
+    label: 'T',
   },
   {
-    "ascii": 85,
-    "code": 536,
-    "label": "U"
+    ascii: 85,
+    code: 536,
+    label: 'U',
   },
   {
-    "ascii": 86,
-    "code": 537,
-    "label": "V"
+    ascii: 86,
+    code: 537,
+    label: 'V',
   },
   {
-    "ascii": 87,
-    "code": 538,
-    "label": "W"
+    ascii: 87,
+    code: 538,
+    label: 'W',
   },
   {
-    "ascii": 88,
-    "code": 539,
-    "label": "X"
+    ascii: 88,
+    code: 539,
+    label: 'X',
   },
   {
-    "ascii": 89,
-    "code": 540,
-    "label": "Y"
+    ascii: 89,
+    code: 540,
+    label: 'Y',
   },
   {
-    "ascii": 90,
-    "code": 541,
-    "label": "Z"
+    ascii: 90,
+    code: 541,
+    label: 'Z',
   },
   {
-    "ascii": 91,
-    "code": 37,
-    "label": "8"
+    ascii: 91,
+    code: 37,
+    label: '8',
   },
   {
-    "ascii": 92,
-    "code": 45,
-    "label": "*"
+    ascii: 92,
+    code: 45,
+    label: '*',
   },
   {
-    "ascii": 93,
-    "code": 38,
-    "label": "9"
+    ascii: 93,
+    code: 38,
+    label: '9',
   },
   {
-    "ascii": 94,
-    "code": 544,
-    "label": "^ (dead)"
+    ascii: 94,
+    code: 544,
+    label: '^ (dead)',
   },
   {
-    "ascii": 95,
-    "code": 558,
-    "label": "_"
+    ascii: 95,
+    code: 558,
+    label: '_',
   },
   {
-    "ascii": 96,
-    "code": 50,
-    "label": ","
+    ascii: 96,
+    code: 50,
+    label: ',',
   },
   {
-    "ascii": 97,
-    "code": 4,
-    "label": "a"
+    ascii: 97,
+    code: 4,
+    label: 'a',
   },
   {
-    "ascii": 98,
-    "code": 5,
-    "label": "b"
+    ascii: 98,
+    code: 5,
+    label: 'b',
   },
   {
-    "ascii": 99,
-    "code": 6,
-    "label": "c"
+    ascii: 99,
+    code: 6,
+    label: 'c',
   },
   {
-    "ascii": 100,
-    "code": 7,
-    "label": "d"
+    ascii: 100,
+    code: 7,
+    label: 'd',
   },
   {
-    "ascii": 101,
-    "code": 8,
-    "label": "e"
+    ascii: 101,
+    code: 8,
+    label: 'e',
   },
   {
-    "ascii": 102,
-    "code": 9,
-    "label": "f"
+    ascii: 102,
+    code: 9,
+    label: 'f',
   },
   {
-    "ascii": 103,
-    "code": 10,
-    "label": "g"
+    ascii: 103,
+    code: 10,
+    label: 'g',
   },
   {
-    "ascii": 104,
-    "code": 11,
-    "label": "h"
+    ascii: 104,
+    code: 11,
+    label: 'h',
   },
   {
-    "ascii": 105,
-    "code": 12,
-    "label": "i"
+    ascii: 105,
+    code: 12,
+    label: 'i',
   },
   {
-    "ascii": 106,
-    "code": 13,
-    "label": "j"
+    ascii: 106,
+    code: 13,
+    label: 'j',
   },
   {
-    "ascii": 107,
-    "code": 14,
-    "label": "k"
+    ascii: 107,
+    code: 14,
+    label: 'k',
   },
   {
-    "ascii": 108,
-    "code": 15,
-    "label": "l"
+    ascii: 108,
+    code: 15,
+    label: 'l',
   },
   {
-    "ascii": 109,
-    "code": 16,
-    "label": "m"
+    ascii: 109,
+    code: 16,
+    label: 'm',
   },
   {
-    "ascii": 110,
-    "code": 17,
-    "label": "n"
+    ascii: 110,
+    code: 17,
+    label: 'n',
   },
   {
-    "ascii": 111,
-    "code": 18,
-    "label": "o"
+    ascii: 111,
+    code: 18,
+    label: 'o',
   },
   {
-    "ascii": 112,
-    "code": 19,
-    "label": "p"
+    ascii: 112,
+    code: 19,
+    label: 'p',
   },
   {
-    "ascii": 113,
-    "code": 20,
-    "label": "q"
+    ascii: 113,
+    code: 20,
+    label: 'q',
   },
   {
-    "ascii": 114,
-    "code": 21,
-    "label": "r"
+    ascii: 114,
+    code: 21,
+    label: 'r',
   },
   {
-    "ascii": 115,
-    "code": 22,
-    "label": "s"
+    ascii: 115,
+    code: 22,
+    label: 's',
   },
   {
-    "ascii": 116,
-    "code": 23,
-    "label": "t"
+    ascii: 116,
+    code: 23,
+    label: 't',
   },
   {
-    "ascii": 117,
-    "code": 24,
-    "label": "u"
+    ascii: 117,
+    code: 24,
+    label: 'u',
   },
   {
-    "ascii": 118,
-    "code": 25,
-    "label": "v"
+    ascii: 118,
+    code: 25,
+    label: 'v',
   },
   {
-    "ascii": 119,
-    "code": 26,
-    "label": "w"
+    ascii: 119,
+    code: 26,
+    label: 'w',
   },
   {
-    "ascii": 120,
-    "code": 27,
-    "label": "x"
+    ascii: 120,
+    code: 27,
+    label: 'x',
   },
   {
-    "ascii": 121,
-    "code": 28,
-    "label": "y"
+    ascii: 121,
+    code: 28,
+    label: 'y',
   },
   {
-    "ascii": 122,
-    "code": 29,
-    "label": "z"
+    ascii: 122,
+    code: 29,
+    label: 'z',
   },
   {
-    "ascii": 123,
-    "code": 36,
-    "label": "7"
+    ascii: 123,
+    code: 36,
+    label: '7',
   },
   {
-    "ascii": 124,
-    "code": 46,
-    "label": "-"
+    ascii: 124,
+    code: 46,
+    label: '-',
   },
   {
-    "ascii": 125,
-    "code": 39,
-    "label": "0"
+    ascii: 125,
+    code: 39,
+    label: '0',
   },
   {
-    "ascii": 126,
-    "code": 48,
-    "label": "Ü"
+    ascii: 126,
+    code: 48,
+    label: 'Ü',
   },
   {
-    "ascii": 127,
-    "code": 76,
-    "label": "del"
-  }
+    ascii: 127,
+    code: 76,
+    label: 'del',
+  },
 ];
-    

--- a/src/services/labellang/AsciiLabelUk.ts
+++ b/src/services/labellang/AsciiLabelUk.ts
@@ -1,645 +1,644 @@
 import { AsciiLabel } from './AsciiLabel';
-        
+
 export const AsciiLabelUk: AsciiLabel[] = [
   {
-    "ascii": 0,
-    "code": 0,
-    "label": ""
+    ascii: 0,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 1,
-    "code": 0,
-    "label": ""
+    ascii: 1,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 2,
-    "code": 0,
-    "label": ""
+    ascii: 2,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 3,
-    "code": 0,
-    "label": ""
+    ascii: 3,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 4,
-    "code": 0,
-    "label": ""
+    ascii: 4,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 5,
-    "code": 0,
-    "label": ""
+    ascii: 5,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 6,
-    "code": 0,
-    "label": ""
+    ascii: 6,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 7,
-    "code": 0,
-    "label": ""
+    ascii: 7,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 8,
-    "code": 42,
-    "label": "back space"
+    ascii: 8,
+    code: 42,
+    label: 'back space',
   },
   {
-    "ascii": 9,
-    "code": 43,
-    "label": "tab"
+    ascii: 9,
+    code: 43,
+    label: 'tab',
   },
   {
-    "ascii": 10,
-    "code": 40,
-    "label": "enter"
+    ascii: 10,
+    code: 40,
+    label: 'enter',
   },
   {
-    "ascii": 11,
-    "code": 0,
-    "label": ""
+    ascii: 11,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 12,
-    "code": 0,
-    "label": ""
+    ascii: 12,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 13,
-    "code": 0,
-    "label": ""
+    ascii: 13,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 14,
-    "code": 0,
-    "label": ""
+    ascii: 14,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 15,
-    "code": 0,
-    "label": ""
+    ascii: 15,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 16,
-    "code": 0,
-    "label": ""
+    ascii: 16,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 17,
-    "code": 0,
-    "label": ""
+    ascii: 17,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 18,
-    "code": 0,
-    "label": ""
+    ascii: 18,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 19,
-    "code": 0,
-    "label": ""
+    ascii: 19,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 20,
-    "code": 0,
-    "label": ""
+    ascii: 20,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 21,
-    "code": 0,
-    "label": ""
+    ascii: 21,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 22,
-    "code": 0,
-    "label": ""
+    ascii: 22,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 23,
-    "code": 0,
-    "label": ""
+    ascii: 23,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 24,
-    "code": 0,
-    "label": ""
+    ascii: 24,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 25,
-    "code": 0,
-    "label": ""
+    ascii: 25,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 26,
-    "code": 0,
-    "label": ""
+    ascii: 26,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 27,
-    "code": 41,
-    "label": "esc"
+    ascii: 27,
+    code: 41,
+    label: 'esc',
   },
   {
-    "ascii": 28,
-    "code": 0,
-    "label": ""
+    ascii: 28,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 29,
-    "code": 0,
-    "label": ""
+    ascii: 29,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 30,
-    "code": 0,
-    "label": ""
+    ascii: 30,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 31,
-    "code": 0,
-    "label": ""
+    ascii: 31,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 32,
-    "code": 44,
-    "label": "space"
+    ascii: 32,
+    code: 44,
+    label: 'space',
   },
   {
-    "ascii": 33,
-    "code": 542,
-    "label": "!"
+    ascii: 33,
+    code: 542,
+    label: '!',
   },
   {
-    "ascii": 34,
-    "code": 543,
-    "label": "\""
+    ascii: 34,
+    code: 543,
+    label: '"',
   },
   {
-    "ascii": 35,
-    "code": 50,
-    "label": "#"
+    ascii: 35,
+    code: 50,
+    label: '#',
   },
   {
-    "ascii": 36,
-    "code": 545,
-    "label": "$"
+    ascii: 36,
+    code: 545,
+    label: '$',
   },
   {
-    "ascii": 37,
-    "code": 546,
-    "label": "%"
+    ascii: 37,
+    code: 546,
+    label: '%',
   },
   {
-    "ascii": 38,
-    "code": 548,
-    "label": "&"
+    ascii: 38,
+    code: 548,
+    label: '&',
   },
   {
-    "ascii": 39,
-    "code": 52,
-    "label": "'"
+    ascii: 39,
+    code: 52,
+    label: "'",
   },
   {
-    "ascii": 40,
-    "code": 550,
-    "label": "("
+    ascii: 40,
+    code: 550,
+    label: '(',
   },
   {
-    "ascii": 41,
-    "code": 551,
-    "label": ")"
+    ascii: 41,
+    code: 551,
+    label: ')',
   },
   {
-    "ascii": 42,
-    "code": 549,
-    "label": "*"
+    ascii: 42,
+    code: 549,
+    label: '*',
   },
   {
-    "ascii": 43,
-    "code": 558,
-    "label": "+"
+    ascii: 43,
+    code: 558,
+    label: '+',
   },
   {
-    "ascii": 44,
-    "code": 54,
-    "label": ","
+    ascii: 44,
+    code: 54,
+    label: ',',
   },
   {
-    "ascii": 45,
-    "code": 45,
-    "label": "-"
+    ascii: 45,
+    code: 45,
+    label: '-',
   },
   {
-    "ascii": 46,
-    "code": 55,
-    "label": "."
+    ascii: 46,
+    code: 55,
+    label: '.',
   },
   {
-    "ascii": 47,
-    "code": 56,
-    "label": "/"
+    ascii: 47,
+    code: 56,
+    label: '/',
   },
   {
-    "ascii": 48,
-    "code": 39,
-    "label": "0"
+    ascii: 48,
+    code: 39,
+    label: '0',
   },
   {
-    "ascii": 49,
-    "code": 30,
-    "label": "1"
+    ascii: 49,
+    code: 30,
+    label: '1',
   },
   {
-    "ascii": 50,
-    "code": 31,
-    "label": "2"
+    ascii: 50,
+    code: 31,
+    label: '2',
   },
   {
-    "ascii": 51,
-    "code": 32,
-    "label": "3"
+    ascii: 51,
+    code: 32,
+    label: '3',
   },
   {
-    "ascii": 52,
-    "code": 33,
-    "label": "4"
+    ascii: 52,
+    code: 33,
+    label: '4',
   },
   {
-    "ascii": 53,
-    "code": 34,
-    "label": "5"
+    ascii: 53,
+    code: 34,
+    label: '5',
   },
   {
-    "ascii": 54,
-    "code": 35,
-    "label": "6"
+    ascii: 54,
+    code: 35,
+    label: '6',
   },
   {
-    "ascii": 55,
-    "code": 36,
-    "label": "7"
+    ascii: 55,
+    code: 36,
+    label: '7',
   },
   {
-    "ascii": 56,
-    "code": 37,
-    "label": "8"
+    ascii: 56,
+    code: 37,
+    label: '8',
   },
   {
-    "ascii": 57,
-    "code": 38,
-    "label": "9"
+    ascii: 57,
+    code: 38,
+    label: '9',
   },
   {
-    "ascii": 58,
-    "code": 563,
-    "label": ":"
+    ascii: 58,
+    code: 563,
+    label: ':',
   },
   {
-    "ascii": 59,
-    "code": 51,
-    "label": ";"
+    ascii: 59,
+    code: 51,
+    label: ';',
   },
   {
-    "ascii": 60,
-    "code": 566,
-    "label": "<"
+    ascii: 60,
+    code: 566,
+    label: '<',
   },
   {
-    "ascii": 61,
-    "code": 46,
-    "label": "="
+    ascii: 61,
+    code: 46,
+    label: '=',
   },
   {
-    "ascii": 62,
-    "code": 567,
-    "label": ">"
+    ascii: 62,
+    code: 567,
+    label: '>',
   },
   {
-    "ascii": 63,
-    "code": 568,
-    "label": "?"
+    ascii: 63,
+    code: 568,
+    label: '?',
   },
   {
-    "ascii": 64,
-    "code": 564,
-    "label": "@"
+    ascii: 64,
+    code: 564,
+    label: '@',
   },
   {
-    "ascii": 65,
-    "code": 516,
-    "label": "A"
+    ascii: 65,
+    code: 516,
+    label: 'A',
   },
   {
-    "ascii": 66,
-    "code": 517,
-    "label": "B"
+    ascii: 66,
+    code: 517,
+    label: 'B',
   },
   {
-    "ascii": 67,
-    "code": 518,
-    "label": "C"
+    ascii: 67,
+    code: 518,
+    label: 'C',
   },
   {
-    "ascii": 68,
-    "code": 519,
-    "label": "D"
+    ascii: 68,
+    code: 519,
+    label: 'D',
   },
   {
-    "ascii": 69,
-    "code": 520,
-    "label": "E"
+    ascii: 69,
+    code: 520,
+    label: 'E',
   },
   {
-    "ascii": 70,
-    "code": 521,
-    "label": "F"
+    ascii: 70,
+    code: 521,
+    label: 'F',
   },
   {
-    "ascii": 71,
-    "code": 522,
-    "label": "G"
+    ascii: 71,
+    code: 522,
+    label: 'G',
   },
   {
-    "ascii": 72,
-    "code": 523,
-    "label": "H"
+    ascii: 72,
+    code: 523,
+    label: 'H',
   },
   {
-    "ascii": 73,
-    "code": 524,
-    "label": "I"
+    ascii: 73,
+    code: 524,
+    label: 'I',
   },
   {
-    "ascii": 74,
-    "code": 525,
-    "label": "J"
+    ascii: 74,
+    code: 525,
+    label: 'J',
   },
   {
-    "ascii": 75,
-    "code": 526,
-    "label": "K"
+    ascii: 75,
+    code: 526,
+    label: 'K',
   },
   {
-    "ascii": 76,
-    "code": 527,
-    "label": "L"
+    ascii: 76,
+    code: 527,
+    label: 'L',
   },
   {
-    "ascii": 77,
-    "code": 528,
-    "label": "M"
+    ascii: 77,
+    code: 528,
+    label: 'M',
   },
   {
-    "ascii": 78,
-    "code": 529,
-    "label": "N"
+    ascii: 78,
+    code: 529,
+    label: 'N',
   },
   {
-    "ascii": 79,
-    "code": 530,
-    "label": "O"
+    ascii: 79,
+    code: 530,
+    label: 'O',
   },
   {
-    "ascii": 80,
-    "code": 531,
-    "label": "P"
+    ascii: 80,
+    code: 531,
+    label: 'P',
   },
   {
-    "ascii": 81,
-    "code": 532,
-    "label": "Q"
+    ascii: 81,
+    code: 532,
+    label: 'Q',
   },
   {
-    "ascii": 82,
-    "code": 533,
-    "label": "R"
+    ascii: 82,
+    code: 533,
+    label: 'R',
   },
   {
-    "ascii": 83,
-    "code": 534,
-    "label": "S"
+    ascii: 83,
+    code: 534,
+    label: 'S',
   },
   {
-    "ascii": 84,
-    "code": 535,
-    "label": "T"
+    ascii: 84,
+    code: 535,
+    label: 'T',
   },
   {
-    "ascii": 85,
-    "code": 536,
-    "label": "U"
+    ascii: 85,
+    code: 536,
+    label: 'U',
   },
   {
-    "ascii": 86,
-    "code": 537,
-    "label": "V"
+    ascii: 86,
+    code: 537,
+    label: 'V',
   },
   {
-    "ascii": 87,
-    "code": 538,
-    "label": "W"
+    ascii: 87,
+    code: 538,
+    label: 'W',
   },
   {
-    "ascii": 88,
-    "code": 539,
-    "label": "X"
+    ascii: 88,
+    code: 539,
+    label: 'X',
   },
   {
-    "ascii": 89,
-    "code": 540,
-    "label": "Y"
+    ascii: 89,
+    code: 540,
+    label: 'Y',
   },
   {
-    "ascii": 90,
-    "code": 541,
-    "label": "Z"
+    ascii: 90,
+    code: 541,
+    label: 'Z',
   },
   {
-    "ascii": 91,
-    "code": 47,
-    "label": "["
+    ascii: 91,
+    code: 47,
+    label: '[',
   },
   {
-    "ascii": 92,
-    "code": 100,
-    "label": "(backslash)"
+    ascii: 92,
+    code: 100,
+    label: '(backslash)',
   },
   {
-    "ascii": 93,
-    "code": 48,
-    "label": "]"
+    ascii: 93,
+    code: 48,
+    label: ']',
   },
   {
-    "ascii": 94,
-    "code": 547,
-    "label": "^"
+    ascii: 94,
+    code: 547,
+    label: '^',
   },
   {
-    "ascii": 95,
-    "code": 557,
-    "label": "_"
+    ascii: 95,
+    code: 557,
+    label: '_',
   },
   {
-    "ascii": 96,
-    "code": 53,
-    "label": "`"
+    ascii: 96,
+    code: 53,
+    label: '`',
   },
   {
-    "ascii": 97,
-    "code": 4,
-    "label": "a"
+    ascii: 97,
+    code: 4,
+    label: 'a',
   },
   {
-    "ascii": 98,
-    "code": 5,
-    "label": "b"
+    ascii: 98,
+    code: 5,
+    label: 'b',
   },
   {
-    "ascii": 99,
-    "code": 6,
-    "label": "c"
+    ascii: 99,
+    code: 6,
+    label: 'c',
   },
   {
-    "ascii": 100,
-    "code": 7,
-    "label": "d"
+    ascii: 100,
+    code: 7,
+    label: 'd',
   },
   {
-    "ascii": 101,
-    "code": 8,
-    "label": "e"
+    ascii: 101,
+    code: 8,
+    label: 'e',
   },
   {
-    "ascii": 102,
-    "code": 9,
-    "label": "f"
+    ascii: 102,
+    code: 9,
+    label: 'f',
   },
   {
-    "ascii": 103,
-    "code": 10,
-    "label": "g"
+    ascii: 103,
+    code: 10,
+    label: 'g',
   },
   {
-    "ascii": 104,
-    "code": 11,
-    "label": "h"
+    ascii: 104,
+    code: 11,
+    label: 'h',
   },
   {
-    "ascii": 105,
-    "code": 12,
-    "label": "i"
+    ascii: 105,
+    code: 12,
+    label: 'i',
   },
   {
-    "ascii": 106,
-    "code": 13,
-    "label": "j"
+    ascii: 106,
+    code: 13,
+    label: 'j',
   },
   {
-    "ascii": 107,
-    "code": 14,
-    "label": "k"
+    ascii: 107,
+    code: 14,
+    label: 'k',
   },
   {
-    "ascii": 108,
-    "code": 15,
-    "label": "l"
+    ascii: 108,
+    code: 15,
+    label: 'l',
   },
   {
-    "ascii": 109,
-    "code": 16,
-    "label": "m"
+    ascii: 109,
+    code: 16,
+    label: 'm',
   },
   {
-    "ascii": 110,
-    "code": 17,
-    "label": "n"
+    ascii: 110,
+    code: 17,
+    label: 'n',
   },
   {
-    "ascii": 111,
-    "code": 18,
-    "label": "o"
+    ascii: 111,
+    code: 18,
+    label: 'o',
   },
   {
-    "ascii": 112,
-    "code": 19,
-    "label": "p"
+    ascii: 112,
+    code: 19,
+    label: 'p',
   },
   {
-    "ascii": 113,
-    "code": 20,
-    "label": "q"
+    ascii: 113,
+    code: 20,
+    label: 'q',
   },
   {
-    "ascii": 114,
-    "code": 21,
-    "label": "r"
+    ascii: 114,
+    code: 21,
+    label: 'r',
   },
   {
-    "ascii": 115,
-    "code": 22,
-    "label": "s"
+    ascii: 115,
+    code: 22,
+    label: 's',
   },
   {
-    "ascii": 116,
-    "code": 23,
-    "label": "t"
+    ascii: 116,
+    code: 23,
+    label: 't',
   },
   {
-    "ascii": 117,
-    "code": 24,
-    "label": "u"
+    ascii: 117,
+    code: 24,
+    label: 'u',
   },
   {
-    "ascii": 118,
-    "code": 25,
-    "label": "v"
+    ascii: 118,
+    code: 25,
+    label: 'v',
   },
   {
-    "ascii": 119,
-    "code": 26,
-    "label": "w"
+    ascii: 119,
+    code: 26,
+    label: 'w',
   },
   {
-    "ascii": 120,
-    "code": 27,
-    "label": "x"
+    ascii: 120,
+    code: 27,
+    label: 'x',
   },
   {
-    "ascii": 121,
-    "code": 28,
-    "label": "y"
+    ascii: 121,
+    code: 28,
+    label: 'y',
   },
   {
-    "ascii": 122,
-    "code": 29,
-    "label": "z"
+    ascii: 122,
+    code: 29,
+    label: 'z',
   },
   {
-    "ascii": 123,
-    "code": 559,
-    "label": "{"
+    ascii: 123,
+    code: 559,
+    label: '{',
   },
   {
-    "ascii": 124,
-    "code": 612,
-    "label": "|"
+    ascii: 124,
+    code: 612,
+    label: '|',
   },
   {
-    "ascii": 125,
-    "code": 560,
-    "label": "}"
+    ascii: 125,
+    code: 560,
+    label: '}',
   },
   {
-    "ascii": 126,
-    "code": 562,
-    "label": "~"
+    ascii: 126,
+    code: 562,
+    label: '~',
   },
   {
-    "ascii": 127,
-    "code": 76,
-    "label": "del"
-  }
+    ascii: 127,
+    code: 76,
+    label: 'del',
+  },
 ];
-    

--- a/src/services/labellang/AsciiLabelUs_international.ts
+++ b/src/services/labellang/AsciiLabelUs_international.ts
@@ -1,645 +1,644 @@
 import { AsciiLabel } from './AsciiLabel';
-        
+
 export const AsciiLabelUs_international: AsciiLabel[] = [
   {
-    "ascii": 0,
-    "code": 0,
-    "label": ""
+    ascii: 0,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 1,
-    "code": 0,
-    "label": ""
+    ascii: 1,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 2,
-    "code": 0,
-    "label": ""
+    ascii: 2,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 3,
-    "code": 0,
-    "label": ""
+    ascii: 3,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 4,
-    "code": 0,
-    "label": ""
+    ascii: 4,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 5,
-    "code": 0,
-    "label": ""
+    ascii: 5,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 6,
-    "code": 0,
-    "label": ""
+    ascii: 6,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 7,
-    "code": 0,
-    "label": ""
+    ascii: 7,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 8,
-    "code": 42,
-    "label": "back space"
+    ascii: 8,
+    code: 42,
+    label: 'back space',
   },
   {
-    "ascii": 9,
-    "code": 43,
-    "label": "tab"
+    ascii: 9,
+    code: 43,
+    label: 'tab',
   },
   {
-    "ascii": 10,
-    "code": 40,
-    "label": "enter"
+    ascii: 10,
+    code: 40,
+    label: 'enter',
   },
   {
-    "ascii": 11,
-    "code": 0,
-    "label": ""
+    ascii: 11,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 12,
-    "code": 0,
-    "label": ""
+    ascii: 12,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 13,
-    "code": 0,
-    "label": ""
+    ascii: 13,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 14,
-    "code": 0,
-    "label": ""
+    ascii: 14,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 15,
-    "code": 0,
-    "label": ""
+    ascii: 15,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 16,
-    "code": 0,
-    "label": ""
+    ascii: 16,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 17,
-    "code": 0,
-    "label": ""
+    ascii: 17,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 18,
-    "code": 0,
-    "label": ""
+    ascii: 18,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 19,
-    "code": 0,
-    "label": ""
+    ascii: 19,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 20,
-    "code": 0,
-    "label": ""
+    ascii: 20,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 21,
-    "code": 0,
-    "label": ""
+    ascii: 21,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 22,
-    "code": 0,
-    "label": ""
+    ascii: 22,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 23,
-    "code": 0,
-    "label": ""
+    ascii: 23,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 24,
-    "code": 0,
-    "label": ""
+    ascii: 24,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 25,
-    "code": 0,
-    "label": ""
+    ascii: 25,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 26,
-    "code": 0,
-    "label": ""
+    ascii: 26,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 27,
-    "code": 41,
-    "label": "esc"
+    ascii: 27,
+    code: 41,
+    label: 'esc',
   },
   {
-    "ascii": 28,
-    "code": 0,
-    "label": ""
+    ascii: 28,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 29,
-    "code": 0,
-    "label": ""
+    ascii: 29,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 30,
-    "code": 0,
-    "label": ""
+    ascii: 30,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 31,
-    "code": 0,
-    "label": ""
+    ascii: 31,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 32,
-    "code": 44,
-    "label": "space"
+    ascii: 32,
+    code: 44,
+    label: 'space',
   },
   {
-    "ascii": 33,
-    "code": 542,
-    "label": "!"
+    ascii: 33,
+    code: 542,
+    label: '!',
   },
   {
-    "ascii": 34,
-    "code": 564,
-    "label": "¨ (dead)"
+    ascii: 34,
+    code: 564,
+    label: '¨ (dead)',
   },
   {
-    "ascii": 35,
-    "code": 544,
-    "label": "#"
+    ascii: 35,
+    code: 544,
+    label: '#',
   },
   {
-    "ascii": 36,
-    "code": 545,
-    "label": "$"
+    ascii: 36,
+    code: 545,
+    label: '$',
   },
   {
-    "ascii": 37,
-    "code": 546,
-    "label": "%"
+    ascii: 37,
+    code: 546,
+    label: '%',
   },
   {
-    "ascii": 38,
-    "code": 548,
-    "label": "&"
+    ascii: 38,
+    code: 548,
+    label: '&',
   },
   {
-    "ascii": 39,
-    "code": 52,
-    "label": "´ (dead)"
+    ascii: 39,
+    code: 52,
+    label: '´ (dead)',
   },
   {
-    "ascii": 40,
-    "code": 550,
-    "label": "("
+    ascii: 40,
+    code: 550,
+    label: '(',
   },
   {
-    "ascii": 41,
-    "code": 551,
-    "label": ")"
+    ascii: 41,
+    code: 551,
+    label: ')',
   },
   {
-    "ascii": 42,
-    "code": 549,
-    "label": "*"
+    ascii: 42,
+    code: 549,
+    label: '*',
   },
   {
-    "ascii": 43,
-    "code": 558,
-    "label": "+"
+    ascii: 43,
+    code: 558,
+    label: '+',
   },
   {
-    "ascii": 44,
-    "code": 54,
-    "label": ","
+    ascii: 44,
+    code: 54,
+    label: ',',
   },
   {
-    "ascii": 45,
-    "code": 45,
-    "label": "-"
+    ascii: 45,
+    code: 45,
+    label: '-',
   },
   {
-    "ascii": 46,
-    "code": 55,
-    "label": "."
+    ascii: 46,
+    code: 55,
+    label: '.',
   },
   {
-    "ascii": 47,
-    "code": 56,
-    "label": "/"
+    ascii: 47,
+    code: 56,
+    label: '/',
   },
   {
-    "ascii": 48,
-    "code": 39,
-    "label": "0"
+    ascii: 48,
+    code: 39,
+    label: '0',
   },
   {
-    "ascii": 49,
-    "code": 30,
-    "label": "1"
+    ascii: 49,
+    code: 30,
+    label: '1',
   },
   {
-    "ascii": 50,
-    "code": 31,
-    "label": "2"
+    ascii: 50,
+    code: 31,
+    label: '2',
   },
   {
-    "ascii": 51,
-    "code": 32,
-    "label": "3"
+    ascii: 51,
+    code: 32,
+    label: '3',
   },
   {
-    "ascii": 52,
-    "code": 33,
-    "label": "4"
+    ascii: 52,
+    code: 33,
+    label: '4',
   },
   {
-    "ascii": 53,
-    "code": 34,
-    "label": "5"
+    ascii: 53,
+    code: 34,
+    label: '5',
   },
   {
-    "ascii": 54,
-    "code": 35,
-    "label": "6"
+    ascii: 54,
+    code: 35,
+    label: '6',
   },
   {
-    "ascii": 55,
-    "code": 36,
-    "label": "7"
+    ascii: 55,
+    code: 36,
+    label: '7',
   },
   {
-    "ascii": 56,
-    "code": 37,
-    "label": "8"
+    ascii: 56,
+    code: 37,
+    label: '8',
   },
   {
-    "ascii": 57,
-    "code": 38,
-    "label": "9"
+    ascii: 57,
+    code: 38,
+    label: '9',
   },
   {
-    "ascii": 58,
-    "code": 563,
-    "label": ":"
+    ascii: 58,
+    code: 563,
+    label: ':',
   },
   {
-    "ascii": 59,
-    "code": 51,
-    "label": ";"
+    ascii: 59,
+    code: 51,
+    label: ';',
   },
   {
-    "ascii": 60,
-    "code": 566,
-    "label": "<"
+    ascii: 60,
+    code: 566,
+    label: '<',
   },
   {
-    "ascii": 61,
-    "code": 46,
-    "label": "="
+    ascii: 61,
+    code: 46,
+    label: '=',
   },
   {
-    "ascii": 62,
-    "code": 567,
-    "label": ">"
+    ascii: 62,
+    code: 567,
+    label: '>',
   },
   {
-    "ascii": 63,
-    "code": 568,
-    "label": "?"
+    ascii: 63,
+    code: 568,
+    label: '?',
   },
   {
-    "ascii": 64,
-    "code": 543,
-    "label": "@"
+    ascii: 64,
+    code: 543,
+    label: '@',
   },
   {
-    "ascii": 65,
-    "code": 516,
-    "label": "A"
+    ascii: 65,
+    code: 516,
+    label: 'A',
   },
   {
-    "ascii": 66,
-    "code": 517,
-    "label": "B"
+    ascii: 66,
+    code: 517,
+    label: 'B',
   },
   {
-    "ascii": 67,
-    "code": 518,
-    "label": "C"
+    ascii: 67,
+    code: 518,
+    label: 'C',
   },
   {
-    "ascii": 68,
-    "code": 519,
-    "label": "D"
+    ascii: 68,
+    code: 519,
+    label: 'D',
   },
   {
-    "ascii": 69,
-    "code": 520,
-    "label": "E"
+    ascii: 69,
+    code: 520,
+    label: 'E',
   },
   {
-    "ascii": 70,
-    "code": 521,
-    "label": "F"
+    ascii: 70,
+    code: 521,
+    label: 'F',
   },
   {
-    "ascii": 71,
-    "code": 522,
-    "label": "G"
+    ascii: 71,
+    code: 522,
+    label: 'G',
   },
   {
-    "ascii": 72,
-    "code": 523,
-    "label": "H"
+    ascii: 72,
+    code: 523,
+    label: 'H',
   },
   {
-    "ascii": 73,
-    "code": 524,
-    "label": "I"
+    ascii: 73,
+    code: 524,
+    label: 'I',
   },
   {
-    "ascii": 74,
-    "code": 525,
-    "label": "J"
+    ascii: 74,
+    code: 525,
+    label: 'J',
   },
   {
-    "ascii": 75,
-    "code": 526,
-    "label": "K"
+    ascii: 75,
+    code: 526,
+    label: 'K',
   },
   {
-    "ascii": 76,
-    "code": 527,
-    "label": "L"
+    ascii: 76,
+    code: 527,
+    label: 'L',
   },
   {
-    "ascii": 77,
-    "code": 528,
-    "label": "M"
+    ascii: 77,
+    code: 528,
+    label: 'M',
   },
   {
-    "ascii": 78,
-    "code": 529,
-    "label": "N"
+    ascii: 78,
+    code: 529,
+    label: 'N',
   },
   {
-    "ascii": 79,
-    "code": 530,
-    "label": "O"
+    ascii: 79,
+    code: 530,
+    label: 'O',
   },
   {
-    "ascii": 80,
-    "code": 531,
-    "label": "P"
+    ascii: 80,
+    code: 531,
+    label: 'P',
   },
   {
-    "ascii": 81,
-    "code": 532,
-    "label": "Q"
+    ascii: 81,
+    code: 532,
+    label: 'Q',
   },
   {
-    "ascii": 82,
-    "code": 533,
-    "label": "R"
+    ascii: 82,
+    code: 533,
+    label: 'R',
   },
   {
-    "ascii": 83,
-    "code": 534,
-    "label": "S"
+    ascii: 83,
+    code: 534,
+    label: 'S',
   },
   {
-    "ascii": 84,
-    "code": 535,
-    "label": "T"
+    ascii: 84,
+    code: 535,
+    label: 'T',
   },
   {
-    "ascii": 85,
-    "code": 536,
-    "label": "U"
+    ascii: 85,
+    code: 536,
+    label: 'U',
   },
   {
-    "ascii": 86,
-    "code": 537,
-    "label": "V"
+    ascii: 86,
+    code: 537,
+    label: 'V',
   },
   {
-    "ascii": 87,
-    "code": 538,
-    "label": "W"
+    ascii: 87,
+    code: 538,
+    label: 'W',
   },
   {
-    "ascii": 88,
-    "code": 539,
-    "label": "X"
+    ascii: 88,
+    code: 539,
+    label: 'X',
   },
   {
-    "ascii": 89,
-    "code": 540,
-    "label": "Y"
+    ascii: 89,
+    code: 540,
+    label: 'Y',
   },
   {
-    "ascii": 90,
-    "code": 541,
-    "label": "Z"
+    ascii: 90,
+    code: 541,
+    label: 'Z',
   },
   {
-    "ascii": 91,
-    "code": 47,
-    "label": "["
+    ascii: 91,
+    code: 47,
+    label: '[',
   },
   {
-    "ascii": 92,
-    "code": 49,
-    "label": "(backslash)"
+    ascii: 92,
+    code: 49,
+    label: '(backslash)',
   },
   {
-    "ascii": 93,
-    "code": 48,
-    "label": "]"
+    ascii: 93,
+    code: 48,
+    label: ']',
   },
   {
-    "ascii": 94,
-    "code": 547,
-    "label": "^ (dead)"
+    ascii: 94,
+    code: 547,
+    label: '^ (dead)',
   },
   {
-    "ascii": 95,
-    "code": 557,
-    "label": "_"
+    ascii: 95,
+    code: 557,
+    label: '_',
   },
   {
-    "ascii": 96,
-    "code": 53,
-    "label": "` (dead)"
+    ascii: 96,
+    code: 53,
+    label: '` (dead)',
   },
   {
-    "ascii": 97,
-    "code": 4,
-    "label": "a"
+    ascii: 97,
+    code: 4,
+    label: 'a',
   },
   {
-    "ascii": 98,
-    "code": 5,
-    "label": "b"
+    ascii: 98,
+    code: 5,
+    label: 'b',
   },
   {
-    "ascii": 99,
-    "code": 6,
-    "label": "c"
+    ascii: 99,
+    code: 6,
+    label: 'c',
   },
   {
-    "ascii": 100,
-    "code": 7,
-    "label": "d"
+    ascii: 100,
+    code: 7,
+    label: 'd',
   },
   {
-    "ascii": 101,
-    "code": 8,
-    "label": "e"
+    ascii: 101,
+    code: 8,
+    label: 'e',
   },
   {
-    "ascii": 102,
-    "code": 9,
-    "label": "f"
+    ascii: 102,
+    code: 9,
+    label: 'f',
   },
   {
-    "ascii": 103,
-    "code": 10,
-    "label": "g"
+    ascii: 103,
+    code: 10,
+    label: 'g',
   },
   {
-    "ascii": 104,
-    "code": 11,
-    "label": "h"
+    ascii: 104,
+    code: 11,
+    label: 'h',
   },
   {
-    "ascii": 105,
-    "code": 12,
-    "label": "i"
+    ascii: 105,
+    code: 12,
+    label: 'i',
   },
   {
-    "ascii": 106,
-    "code": 13,
-    "label": "j"
+    ascii: 106,
+    code: 13,
+    label: 'j',
   },
   {
-    "ascii": 107,
-    "code": 14,
-    "label": "k"
+    ascii: 107,
+    code: 14,
+    label: 'k',
   },
   {
-    "ascii": 108,
-    "code": 15,
-    "label": "l"
+    ascii: 108,
+    code: 15,
+    label: 'l',
   },
   {
-    "ascii": 109,
-    "code": 16,
-    "label": "m"
+    ascii: 109,
+    code: 16,
+    label: 'm',
   },
   {
-    "ascii": 110,
-    "code": 17,
-    "label": "n"
+    ascii: 110,
+    code: 17,
+    label: 'n',
   },
   {
-    "ascii": 111,
-    "code": 18,
-    "label": "o"
+    ascii: 111,
+    code: 18,
+    label: 'o',
   },
   {
-    "ascii": 112,
-    "code": 19,
-    "label": "p"
+    ascii: 112,
+    code: 19,
+    label: 'p',
   },
   {
-    "ascii": 113,
-    "code": 20,
-    "label": "q"
+    ascii: 113,
+    code: 20,
+    label: 'q',
   },
   {
-    "ascii": 114,
-    "code": 21,
-    "label": "r"
+    ascii: 114,
+    code: 21,
+    label: 'r',
   },
   {
-    "ascii": 115,
-    "code": 22,
-    "label": "s"
+    ascii: 115,
+    code: 22,
+    label: 's',
   },
   {
-    "ascii": 116,
-    "code": 23,
-    "label": "t"
+    ascii: 116,
+    code: 23,
+    label: 't',
   },
   {
-    "ascii": 117,
-    "code": 24,
-    "label": "u"
+    ascii: 117,
+    code: 24,
+    label: 'u',
   },
   {
-    "ascii": 118,
-    "code": 25,
-    "label": "v"
+    ascii: 118,
+    code: 25,
+    label: 'v',
   },
   {
-    "ascii": 119,
-    "code": 26,
-    "label": "w"
+    ascii: 119,
+    code: 26,
+    label: 'w',
   },
   {
-    "ascii": 120,
-    "code": 27,
-    "label": "x"
+    ascii: 120,
+    code: 27,
+    label: 'x',
   },
   {
-    "ascii": 121,
-    "code": 28,
-    "label": "y"
+    ascii: 121,
+    code: 28,
+    label: 'y',
   },
   {
-    "ascii": 122,
-    "code": 29,
-    "label": "z"
+    ascii: 122,
+    code: 29,
+    label: 'z',
   },
   {
-    "ascii": 123,
-    "code": 559,
-    "label": "{"
+    ascii: 123,
+    code: 559,
+    label: '{',
   },
   {
-    "ascii": 124,
-    "code": 561,
-    "label": "|"
+    ascii: 124,
+    code: 561,
+    label: '|',
   },
   {
-    "ascii": 125,
-    "code": 560,
-    "label": "}"
+    ascii: 125,
+    code: 560,
+    label: '}',
   },
   {
-    "ascii": 126,
-    "code": 565,
-    "label": "~ (dead)"
+    ascii: 126,
+    code: 565,
+    label: '~ (dead)',
   },
   {
-    "ascii": 127,
-    "code": 76,
-    "label": "del"
-  }
+    ascii: 127,
+    code: 76,
+    label: 'del',
+  },
 ];
-    

--- a/src/services/labellang/AsciiLabelWorkman.ts
+++ b/src/services/labellang/AsciiLabelWorkman.ts
@@ -1,645 +1,644 @@
 import { AsciiLabel } from './AsciiLabel';
-        
+
 export const AsciiLabelWorkman: AsciiLabel[] = [
   {
-    "ascii": 0,
-    "code": 0,
-    "label": ""
+    ascii: 0,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 1,
-    "code": 0,
-    "label": ""
+    ascii: 1,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 2,
-    "code": 0,
-    "label": ""
+    ascii: 2,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 3,
-    "code": 0,
-    "label": ""
+    ascii: 3,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 4,
-    "code": 0,
-    "label": ""
+    ascii: 4,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 5,
-    "code": 0,
-    "label": ""
+    ascii: 5,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 6,
-    "code": 0,
-    "label": ""
+    ascii: 6,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 7,
-    "code": 0,
-    "label": ""
+    ascii: 7,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 8,
-    "code": 42,
-    "label": "back space"
+    ascii: 8,
+    code: 42,
+    label: 'back space',
   },
   {
-    "ascii": 9,
-    "code": 43,
-    "label": "tab"
+    ascii: 9,
+    code: 43,
+    label: 'tab',
   },
   {
-    "ascii": 10,
-    "code": 40,
-    "label": "enter"
+    ascii: 10,
+    code: 40,
+    label: 'enter',
   },
   {
-    "ascii": 11,
-    "code": 0,
-    "label": ""
+    ascii: 11,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 12,
-    "code": 0,
-    "label": ""
+    ascii: 12,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 13,
-    "code": 0,
-    "label": ""
+    ascii: 13,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 14,
-    "code": 0,
-    "label": ""
+    ascii: 14,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 15,
-    "code": 0,
-    "label": ""
+    ascii: 15,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 16,
-    "code": 0,
-    "label": ""
+    ascii: 16,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 17,
-    "code": 0,
-    "label": ""
+    ascii: 17,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 18,
-    "code": 0,
-    "label": ""
+    ascii: 18,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 19,
-    "code": 0,
-    "label": ""
+    ascii: 19,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 20,
-    "code": 0,
-    "label": ""
+    ascii: 20,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 21,
-    "code": 0,
-    "label": ""
+    ascii: 21,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 22,
-    "code": 0,
-    "label": ""
+    ascii: 22,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 23,
-    "code": 0,
-    "label": ""
+    ascii: 23,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 24,
-    "code": 0,
-    "label": ""
+    ascii: 24,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 25,
-    "code": 0,
-    "label": ""
+    ascii: 25,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 26,
-    "code": 0,
-    "label": ""
+    ascii: 26,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 27,
-    "code": 41,
-    "label": "esc"
+    ascii: 27,
+    code: 41,
+    label: 'esc',
   },
   {
-    "ascii": 28,
-    "code": 0,
-    "label": ""
+    ascii: 28,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 29,
-    "code": 0,
-    "label": ""
+    ascii: 29,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 30,
-    "code": 0,
-    "label": ""
+    ascii: 30,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 31,
-    "code": 0,
-    "label": ""
+    ascii: 31,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 32,
-    "code": 44,
-    "label": "space"
+    ascii: 32,
+    code: 44,
+    label: 'space',
   },
   {
-    "ascii": 33,
-    "code": 30,
-    "label": "1"
+    ascii: 33,
+    code: 30,
+    label: '1',
   },
   {
-    "ascii": 34,
-    "code": 52,
-    "label": "'"
+    ascii: 34,
+    code: 52,
+    label: "'",
   },
   {
-    "ascii": 35,
-    "code": 32,
-    "label": "3"
+    ascii: 35,
+    code: 32,
+    label: '3',
   },
   {
-    "ascii": 36,
-    "code": 33,
-    "label": "4"
+    ascii: 36,
+    code: 33,
+    label: '4',
   },
   {
-    "ascii": 37,
-    "code": 34,
-    "label": "5"
+    ascii: 37,
+    code: 34,
+    label: '5',
   },
   {
-    "ascii": 38,
-    "code": 36,
-    "label": "7"
+    ascii: 38,
+    code: 36,
+    label: '7',
   },
   {
-    "ascii": 39,
-    "code": 52,
-    "label": "'"
+    ascii: 39,
+    code: 52,
+    label: "'",
   },
   {
-    "ascii": 40,
-    "code": 38,
-    "label": "9"
+    ascii: 40,
+    code: 38,
+    label: '9',
   },
   {
-    "ascii": 41,
-    "code": 39,
-    "label": "0"
+    ascii: 41,
+    code: 39,
+    label: '0',
   },
   {
-    "ascii": 42,
-    "code": 37,
-    "label": "8"
+    ascii: 42,
+    code: 37,
+    label: '8',
   },
   {
-    "ascii": 43,
-    "code": 46,
-    "label": "="
+    ascii: 43,
+    code: 46,
+    label: '=',
   },
   {
-    "ascii": 44,
-    "code": 54,
-    "label": ","
+    ascii: 44,
+    code: 54,
+    label: ',',
   },
   {
-    "ascii": 45,
-    "code": 45,
-    "label": "-"
+    ascii: 45,
+    code: 45,
+    label: '-',
   },
   {
-    "ascii": 46,
-    "code": 55,
-    "label": "."
+    ascii: 46,
+    code: 55,
+    label: '.',
   },
   {
-    "ascii": 47,
-    "code": 56,
-    "label": "/"
+    ascii: 47,
+    code: 56,
+    label: '/',
   },
   {
-    "ascii": 48,
-    "code": 39,
-    "label": "0"
+    ascii: 48,
+    code: 39,
+    label: '0',
   },
   {
-    "ascii": 49,
-    "code": 30,
-    "label": "1"
+    ascii: 49,
+    code: 30,
+    label: '1',
   },
   {
-    "ascii": 50,
-    "code": 31,
-    "label": "2"
+    ascii: 50,
+    code: 31,
+    label: '2',
   },
   {
-    "ascii": 51,
-    "code": 32,
-    "label": "3"
+    ascii: 51,
+    code: 32,
+    label: '3',
   },
   {
-    "ascii": 52,
-    "code": 33,
-    "label": "4"
+    ascii: 52,
+    code: 33,
+    label: '4',
   },
   {
-    "ascii": 53,
-    "code": 34,
-    "label": "5"
+    ascii: 53,
+    code: 34,
+    label: '5',
   },
   {
-    "ascii": 54,
-    "code": 35,
-    "label": "6"
+    ascii: 54,
+    code: 35,
+    label: '6',
   },
   {
-    "ascii": 55,
-    "code": 36,
-    "label": "7"
+    ascii: 55,
+    code: 36,
+    label: '7',
   },
   {
-    "ascii": 56,
-    "code": 37,
-    "label": "8"
+    ascii: 56,
+    code: 37,
+    label: '8',
   },
   {
-    "ascii": 57,
-    "code": 38,
-    "label": "9"
+    ascii: 57,
+    code: 38,
+    label: '9',
   },
   {
-    "ascii": 58,
-    "code": 19,
-    "label": ";"
+    ascii: 58,
+    code: 19,
+    label: ';',
   },
   {
-    "ascii": 59,
-    "code": 19,
-    "label": ";"
+    ascii: 59,
+    code: 19,
+    label: ';',
   },
   {
-    "ascii": 60,
-    "code": 54,
-    "label": ","
+    ascii: 60,
+    code: 54,
+    label: ',',
   },
   {
-    "ascii": 61,
-    "code": 46,
-    "label": "="
+    ascii: 61,
+    code: 46,
+    label: '=',
   },
   {
-    "ascii": 62,
-    "code": 55,
-    "label": "."
+    ascii: 62,
+    code: 55,
+    label: '.',
   },
   {
-    "ascii": 63,
-    "code": 56,
-    "label": "/"
+    ascii: 63,
+    code: 56,
+    label: '/',
   },
   {
-    "ascii": 64,
-    "code": 31,
-    "label": "2"
+    ascii: 64,
+    code: 31,
+    label: '2',
   },
   {
-    "ascii": 65,
-    "code": 4,
-    "label": "a"
+    ascii: 65,
+    code: 4,
+    label: 'a',
   },
   {
-    "ascii": 66,
-    "code": 23,
-    "label": "b"
+    ascii: 66,
+    code: 23,
+    label: 'b',
   },
   {
-    "ascii": 67,
-    "code": 25,
-    "label": "c"
+    ascii: 67,
+    code: 25,
+    label: 'c',
   },
   {
-    "ascii": 68,
-    "code": 26,
-    "label": "d"
+    ascii: 68,
+    code: 26,
+    label: 'd',
   },
   {
-    "ascii": 69,
-    "code": 14,
-    "label": "e"
+    ascii: 69,
+    code: 14,
+    label: 'e',
   },
   {
-    "ascii": 70,
-    "code": 24,
-    "label": "f"
+    ascii: 70,
+    code: 24,
+    label: 'f',
   },
   {
-    "ascii": 71,
-    "code": 10,
-    "label": "g"
+    ascii: 71,
+    code: 10,
+    label: 'g',
   },
   {
-    "ascii": 72,
-    "code": 7,
-    "label": "h"
+    ascii: 72,
+    code: 7,
+    label: 'h',
   },
   {
-    "ascii": 73,
-    "code": 51,
-    "label": "i"
+    ascii: 73,
+    code: 51,
+    label: 'i',
   },
   {
-    "ascii": 74,
-    "code": 28,
-    "label": "j"
+    ascii: 74,
+    code: 28,
+    label: 'j',
   },
   {
-    "ascii": 75,
-    "code": 17,
-    "label": "k"
+    ascii: 75,
+    code: 17,
+    label: 'k',
   },
   {
-    "ascii": 76,
-    "code": 16,
-    "label": "l"
+    ascii: 76,
+    code: 16,
+    label: 'l',
   },
   {
-    "ascii": 77,
-    "code": 6,
-    "label": "m"
+    ascii: 77,
+    code: 6,
+    label: 'm',
   },
   {
-    "ascii": 78,
-    "code": 13,
-    "label": "n"
+    ascii: 78,
+    code: 13,
+    label: 'n',
   },
   {
-    "ascii": 79,
-    "code": 15,
-    "label": "o"
+    ascii: 79,
+    code: 15,
+    label: 'o',
   },
   {
-    "ascii": 80,
-    "code": 18,
-    "label": "p"
+    ascii: 80,
+    code: 18,
+    label: 'p',
   },
   {
-    "ascii": 81,
-    "code": 20,
-    "label": "q"
+    ascii: 81,
+    code: 20,
+    label: 'q',
   },
   {
-    "ascii": 82,
-    "code": 8,
-    "label": "r"
+    ascii: 82,
+    code: 8,
+    label: 'r',
   },
   {
-    "ascii": 83,
-    "code": 22,
-    "label": "s"
+    ascii: 83,
+    code: 22,
+    label: 's',
   },
   {
-    "ascii": 84,
-    "code": 9,
-    "label": "t"
+    ascii: 84,
+    code: 9,
+    label: 't',
   },
   {
-    "ascii": 85,
-    "code": 12,
-    "label": "u"
+    ascii: 85,
+    code: 12,
+    label: 'u',
   },
   {
-    "ascii": 86,
-    "code": 5,
-    "label": "v"
+    ascii: 86,
+    code: 5,
+    label: 'v',
   },
   {
-    "ascii": 87,
-    "code": 21,
-    "label": "w"
+    ascii: 87,
+    code: 21,
+    label: 'w',
   },
   {
-    "ascii": 88,
-    "code": 27,
-    "label": "x"
+    ascii: 88,
+    code: 27,
+    label: 'x',
   },
   {
-    "ascii": 89,
-    "code": 11,
-    "label": "y"
+    ascii: 89,
+    code: 11,
+    label: 'y',
   },
   {
-    "ascii": 90,
-    "code": 29,
-    "label": "z"
+    ascii: 90,
+    code: 29,
+    label: 'z',
   },
   {
-    "ascii": 91,
-    "code": 47,
-    "label": "["
+    ascii: 91,
+    code: 47,
+    label: '[',
   },
   {
-    "ascii": 92,
-    "code": 49,
-    "label": "(backslash)"
+    ascii: 92,
+    code: 49,
+    label: '(backslash)',
   },
   {
-    "ascii": 93,
-    "code": 48,
-    "label": "]"
+    ascii: 93,
+    code: 48,
+    label: ']',
   },
   {
-    "ascii": 94,
-    "code": 35,
-    "label": "6"
+    ascii: 94,
+    code: 35,
+    label: '6',
   },
   {
-    "ascii": 95,
-    "code": 45,
-    "label": "-"
+    ascii: 95,
+    code: 45,
+    label: '-',
   },
   {
-    "ascii": 96,
-    "code": 53,
-    "label": "`"
+    ascii: 96,
+    code: 53,
+    label: '`',
   },
   {
-    "ascii": 97,
-    "code": 4,
-    "label": "a"
+    ascii: 97,
+    code: 4,
+    label: 'a',
   },
   {
-    "ascii": 98,
-    "code": 23,
-    "label": "b"
+    ascii: 98,
+    code: 23,
+    label: 'b',
   },
   {
-    "ascii": 99,
-    "code": 25,
-    "label": "c"
+    ascii: 99,
+    code: 25,
+    label: 'c',
   },
   {
-    "ascii": 100,
-    "code": 26,
-    "label": "d"
+    ascii: 100,
+    code: 26,
+    label: 'd',
   },
   {
-    "ascii": 101,
-    "code": 14,
-    "label": "e"
+    ascii: 101,
+    code: 14,
+    label: 'e',
   },
   {
-    "ascii": 102,
-    "code": 24,
-    "label": "f"
+    ascii: 102,
+    code: 24,
+    label: 'f',
   },
   {
-    "ascii": 103,
-    "code": 10,
-    "label": "g"
+    ascii: 103,
+    code: 10,
+    label: 'g',
   },
   {
-    "ascii": 104,
-    "code": 7,
-    "label": "h"
+    ascii: 104,
+    code: 7,
+    label: 'h',
   },
   {
-    "ascii": 105,
-    "code": 51,
-    "label": "i"
+    ascii: 105,
+    code: 51,
+    label: 'i',
   },
   {
-    "ascii": 106,
-    "code": 28,
-    "label": "j"
+    ascii: 106,
+    code: 28,
+    label: 'j',
   },
   {
-    "ascii": 107,
-    "code": 17,
-    "label": "k"
+    ascii: 107,
+    code: 17,
+    label: 'k',
   },
   {
-    "ascii": 108,
-    "code": 16,
-    "label": "l"
+    ascii: 108,
+    code: 16,
+    label: 'l',
   },
   {
-    "ascii": 109,
-    "code": 6,
-    "label": "m"
+    ascii: 109,
+    code: 6,
+    label: 'm',
   },
   {
-    "ascii": 110,
-    "code": 13,
-    "label": "n"
+    ascii: 110,
+    code: 13,
+    label: 'n',
   },
   {
-    "ascii": 111,
-    "code": 15,
-    "label": "o"
+    ascii: 111,
+    code: 15,
+    label: 'o',
   },
   {
-    "ascii": 112,
-    "code": 18,
-    "label": "p"
+    ascii: 112,
+    code: 18,
+    label: 'p',
   },
   {
-    "ascii": 113,
-    "code": 20,
-    "label": "q"
+    ascii: 113,
+    code: 20,
+    label: 'q',
   },
   {
-    "ascii": 114,
-    "code": 8,
-    "label": "r"
+    ascii: 114,
+    code: 8,
+    label: 'r',
   },
   {
-    "ascii": 115,
-    "code": 22,
-    "label": "s"
+    ascii: 115,
+    code: 22,
+    label: 's',
   },
   {
-    "ascii": 116,
-    "code": 9,
-    "label": "t"
+    ascii: 116,
+    code: 9,
+    label: 't',
   },
   {
-    "ascii": 117,
-    "code": 12,
-    "label": "u"
+    ascii: 117,
+    code: 12,
+    label: 'u',
   },
   {
-    "ascii": 118,
-    "code": 5,
-    "label": "v"
+    ascii: 118,
+    code: 5,
+    label: 'v',
   },
   {
-    "ascii": 119,
-    "code": 21,
-    "label": "w"
+    ascii: 119,
+    code: 21,
+    label: 'w',
   },
   {
-    "ascii": 120,
-    "code": 27,
-    "label": "x"
+    ascii: 120,
+    code: 27,
+    label: 'x',
   },
   {
-    "ascii": 121,
-    "code": 11,
-    "label": "y"
+    ascii: 121,
+    code: 11,
+    label: 'y',
   },
   {
-    "ascii": 122,
-    "code": 29,
-    "label": "z"
+    ascii: 122,
+    code: 29,
+    label: 'z',
   },
   {
-    "ascii": 123,
-    "code": 47,
-    "label": "["
+    ascii: 123,
+    code: 47,
+    label: '[',
   },
   {
-    "ascii": 124,
-    "code": 49,
-    "label": "(backslash)"
+    ascii: 124,
+    code: 49,
+    label: '(backslash)',
   },
   {
-    "ascii": 125,
-    "code": 48,
-    "label": "]"
+    ascii: 125,
+    code: 48,
+    label: ']',
   },
   {
-    "ascii": 126,
-    "code": 53,
-    "label": "`"
+    ascii: 126,
+    code: 53,
+    label: '`',
   },
   {
-    "ascii": 127,
-    "code": 76,
-    "label": "del"
-  }
+    ascii: 127,
+    code: 76,
+    label: 'del',
+  },
 ];
-    

--- a/src/services/labellang/AsciiLabelWorkman_zxcvm.ts
+++ b/src/services/labellang/AsciiLabelWorkman_zxcvm.ts
@@ -1,645 +1,644 @@
 import { AsciiLabel } from './AsciiLabel';
-        
+
 export const AsciiLabelWorkman_zxcvm: AsciiLabel[] = [
   {
-    "ascii": 0,
-    "code": 0,
-    "label": ""
+    ascii: 0,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 1,
-    "code": 0,
-    "label": ""
+    ascii: 1,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 2,
-    "code": 0,
-    "label": ""
+    ascii: 2,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 3,
-    "code": 0,
-    "label": ""
+    ascii: 3,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 4,
-    "code": 0,
-    "label": ""
+    ascii: 4,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 5,
-    "code": 0,
-    "label": ""
+    ascii: 5,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 6,
-    "code": 0,
-    "label": ""
+    ascii: 6,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 7,
-    "code": 0,
-    "label": ""
+    ascii: 7,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 8,
-    "code": 42,
-    "label": "back space"
+    ascii: 8,
+    code: 42,
+    label: 'back space',
   },
   {
-    "ascii": 9,
-    "code": 43,
-    "label": "tab"
+    ascii: 9,
+    code: 43,
+    label: 'tab',
   },
   {
-    "ascii": 10,
-    "code": 40,
-    "label": "enter"
+    ascii: 10,
+    code: 40,
+    label: 'enter',
   },
   {
-    "ascii": 11,
-    "code": 0,
-    "label": ""
+    ascii: 11,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 12,
-    "code": 0,
-    "label": ""
+    ascii: 12,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 13,
-    "code": 0,
-    "label": ""
+    ascii: 13,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 14,
-    "code": 0,
-    "label": ""
+    ascii: 14,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 15,
-    "code": 0,
-    "label": ""
+    ascii: 15,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 16,
-    "code": 0,
-    "label": ""
+    ascii: 16,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 17,
-    "code": 0,
-    "label": ""
+    ascii: 17,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 18,
-    "code": 0,
-    "label": ""
+    ascii: 18,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 19,
-    "code": 0,
-    "label": ""
+    ascii: 19,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 20,
-    "code": 0,
-    "label": ""
+    ascii: 20,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 21,
-    "code": 0,
-    "label": ""
+    ascii: 21,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 22,
-    "code": 0,
-    "label": ""
+    ascii: 22,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 23,
-    "code": 0,
-    "label": ""
+    ascii: 23,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 24,
-    "code": 0,
-    "label": ""
+    ascii: 24,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 25,
-    "code": 0,
-    "label": ""
+    ascii: 25,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 26,
-    "code": 0,
-    "label": ""
+    ascii: 26,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 27,
-    "code": 41,
-    "label": "esc"
+    ascii: 27,
+    code: 41,
+    label: 'esc',
   },
   {
-    "ascii": 28,
-    "code": 0,
-    "label": ""
+    ascii: 28,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 29,
-    "code": 0,
-    "label": ""
+    ascii: 29,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 30,
-    "code": 0,
-    "label": ""
+    ascii: 30,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 31,
-    "code": 0,
-    "label": ""
+    ascii: 31,
+    code: 0,
+    label: '',
   },
   {
-    "ascii": 32,
-    "code": 44,
-    "label": "space"
+    ascii: 32,
+    code: 44,
+    label: 'space',
   },
   {
-    "ascii": 33,
-    "code": 30,
-    "label": "1"
+    ascii: 33,
+    code: 30,
+    label: '1',
   },
   {
-    "ascii": 34,
-    "code": 52,
-    "label": "'"
+    ascii: 34,
+    code: 52,
+    label: "'",
   },
   {
-    "ascii": 35,
-    "code": 32,
-    "label": "3"
+    ascii: 35,
+    code: 32,
+    label: '3',
   },
   {
-    "ascii": 36,
-    "code": 33,
-    "label": "4"
+    ascii: 36,
+    code: 33,
+    label: '4',
   },
   {
-    "ascii": 37,
-    "code": 34,
-    "label": "5"
+    ascii: 37,
+    code: 34,
+    label: '5',
   },
   {
-    "ascii": 38,
-    "code": 36,
-    "label": "7"
+    ascii: 38,
+    code: 36,
+    label: '7',
   },
   {
-    "ascii": 39,
-    "code": 52,
-    "label": "'"
+    ascii: 39,
+    code: 52,
+    label: "'",
   },
   {
-    "ascii": 40,
-    "code": 38,
-    "label": "9"
+    ascii: 40,
+    code: 38,
+    label: '9',
   },
   {
-    "ascii": 41,
-    "code": 39,
-    "label": "0"
+    ascii: 41,
+    code: 39,
+    label: '0',
   },
   {
-    "ascii": 42,
-    "code": 37,
-    "label": "8"
+    ascii: 42,
+    code: 37,
+    label: '8',
   },
   {
-    "ascii": 43,
-    "code": 46,
-    "label": "="
+    ascii: 43,
+    code: 46,
+    label: '=',
   },
   {
-    "ascii": 44,
-    "code": 54,
-    "label": ","
+    ascii: 44,
+    code: 54,
+    label: ',',
   },
   {
-    "ascii": 45,
-    "code": 45,
-    "label": "-"
+    ascii: 45,
+    code: 45,
+    label: '-',
   },
   {
-    "ascii": 46,
-    "code": 55,
-    "label": "."
+    ascii: 46,
+    code: 55,
+    label: '.',
   },
   {
-    "ascii": 47,
-    "code": 56,
-    "label": "/"
+    ascii: 47,
+    code: 56,
+    label: '/',
   },
   {
-    "ascii": 48,
-    "code": 39,
-    "label": "0"
+    ascii: 48,
+    code: 39,
+    label: '0',
   },
   {
-    "ascii": 49,
-    "code": 30,
-    "label": "1"
+    ascii: 49,
+    code: 30,
+    label: '1',
   },
   {
-    "ascii": 50,
-    "code": 31,
-    "label": "2"
+    ascii: 50,
+    code: 31,
+    label: '2',
   },
   {
-    "ascii": 51,
-    "code": 32,
-    "label": "3"
+    ascii: 51,
+    code: 32,
+    label: '3',
   },
   {
-    "ascii": 52,
-    "code": 33,
-    "label": "4"
+    ascii: 52,
+    code: 33,
+    label: '4',
   },
   {
-    "ascii": 53,
-    "code": 34,
-    "label": "5"
+    ascii: 53,
+    code: 34,
+    label: '5',
   },
   {
-    "ascii": 54,
-    "code": 35,
-    "label": "6"
+    ascii: 54,
+    code: 35,
+    label: '6',
   },
   {
-    "ascii": 55,
-    "code": 36,
-    "label": "7"
+    ascii: 55,
+    code: 36,
+    label: '7',
   },
   {
-    "ascii": 56,
-    "code": 37,
-    "label": "8"
+    ascii: 56,
+    code: 37,
+    label: '8',
   },
   {
-    "ascii": 57,
-    "code": 38,
-    "label": "9"
+    ascii: 57,
+    code: 38,
+    label: '9',
   },
   {
-    "ascii": 58,
-    "code": 19,
-    "label": ";"
+    ascii: 58,
+    code: 19,
+    label: ';',
   },
   {
-    "ascii": 59,
-    "code": 19,
-    "label": ";"
+    ascii: 59,
+    code: 19,
+    label: ';',
   },
   {
-    "ascii": 60,
-    "code": 54,
-    "label": ","
+    ascii: 60,
+    code: 54,
+    label: ',',
   },
   {
-    "ascii": 61,
-    "code": 46,
-    "label": "="
+    ascii: 61,
+    code: 46,
+    label: '=',
   },
   {
-    "ascii": 62,
-    "code": 55,
-    "label": "."
+    ascii: 62,
+    code: 55,
+    label: '.',
   },
   {
-    "ascii": 63,
-    "code": 56,
-    "label": "/"
+    ascii: 63,
+    code: 56,
+    label: '/',
   },
   {
-    "ascii": 64,
-    "code": 31,
-    "label": "2"
+    ascii: 64,
+    code: 31,
+    label: '2',
   },
   {
-    "ascii": 65,
-    "code": 4,
-    "label": "a"
+    ascii: 65,
+    code: 4,
+    label: 'a',
   },
   {
-    "ascii": 66,
-    "code": 23,
-    "label": "b"
+    ascii: 66,
+    code: 23,
+    label: 'b',
   },
   {
-    "ascii": 67,
-    "code": 6,
-    "label": "c"
+    ascii: 67,
+    code: 6,
+    label: 'c',
   },
   {
-    "ascii": 68,
-    "code": 26,
-    "label": "d"
+    ascii: 68,
+    code: 26,
+    label: 'd',
   },
   {
-    "ascii": 69,
-    "code": 14,
-    "label": "e"
+    ascii: 69,
+    code: 14,
+    label: 'e',
   },
   {
-    "ascii": 70,
-    "code": 24,
-    "label": "f"
+    ascii: 70,
+    code: 24,
+    label: 'f',
   },
   {
-    "ascii": 71,
-    "code": 10,
-    "label": "g"
+    ascii: 71,
+    code: 10,
+    label: 'g',
   },
   {
-    "ascii": 72,
-    "code": 7,
-    "label": "h"
+    ascii: 72,
+    code: 7,
+    label: 'h',
   },
   {
-    "ascii": 73,
-    "code": 51,
-    "label": "i"
+    ascii: 73,
+    code: 51,
+    label: 'i',
   },
   {
-    "ascii": 74,
-    "code": 28,
-    "label": "j"
+    ascii: 74,
+    code: 28,
+    label: 'j',
   },
   {
-    "ascii": 75,
-    "code": 17,
-    "label": "k"
+    ascii: 75,
+    code: 17,
+    label: 'k',
   },
   {
-    "ascii": 76,
-    "code": 16,
-    "label": "l"
+    ascii: 76,
+    code: 16,
+    label: 'l',
   },
   {
-    "ascii": 77,
-    "code": 5,
-    "label": "m"
+    ascii: 77,
+    code: 5,
+    label: 'm',
   },
   {
-    "ascii": 78,
-    "code": 13,
-    "label": "n"
+    ascii: 78,
+    code: 13,
+    label: 'n',
   },
   {
-    "ascii": 79,
-    "code": 15,
-    "label": "o"
+    ascii: 79,
+    code: 15,
+    label: 'o',
   },
   {
-    "ascii": 80,
-    "code": 18,
-    "label": "p"
+    ascii: 80,
+    code: 18,
+    label: 'p',
   },
   {
-    "ascii": 81,
-    "code": 20,
-    "label": "q"
+    ascii: 81,
+    code: 20,
+    label: 'q',
   },
   {
-    "ascii": 82,
-    "code": 8,
-    "label": "r"
+    ascii: 82,
+    code: 8,
+    label: 'r',
   },
   {
-    "ascii": 83,
-    "code": 22,
-    "label": "s"
+    ascii: 83,
+    code: 22,
+    label: 's',
   },
   {
-    "ascii": 84,
-    "code": 9,
-    "label": "t"
+    ascii: 84,
+    code: 9,
+    label: 't',
   },
   {
-    "ascii": 85,
-    "code": 12,
-    "label": "u"
+    ascii: 85,
+    code: 12,
+    label: 'u',
   },
   {
-    "ascii": 86,
-    "code": 25,
-    "label": "v"
+    ascii: 86,
+    code: 25,
+    label: 'v',
   },
   {
-    "ascii": 87,
-    "code": 21,
-    "label": "w"
+    ascii: 87,
+    code: 21,
+    label: 'w',
   },
   {
-    "ascii": 88,
-    "code": 27,
-    "label": "x"
+    ascii: 88,
+    code: 27,
+    label: 'x',
   },
   {
-    "ascii": 89,
-    "code": 11,
-    "label": "y"
+    ascii: 89,
+    code: 11,
+    label: 'y',
   },
   {
-    "ascii": 90,
-    "code": 29,
-    "label": "z"
+    ascii: 90,
+    code: 29,
+    label: 'z',
   },
   {
-    "ascii": 91,
-    "code": 47,
-    "label": "["
+    ascii: 91,
+    code: 47,
+    label: '[',
   },
   {
-    "ascii": 92,
-    "code": 49,
-    "label": "(backslash)"
+    ascii: 92,
+    code: 49,
+    label: '(backslash)',
   },
   {
-    "ascii": 93,
-    "code": 48,
-    "label": "]"
+    ascii: 93,
+    code: 48,
+    label: ']',
   },
   {
-    "ascii": 94,
-    "code": 35,
-    "label": "6"
+    ascii: 94,
+    code: 35,
+    label: '6',
   },
   {
-    "ascii": 95,
-    "code": 45,
-    "label": "-"
+    ascii: 95,
+    code: 45,
+    label: '-',
   },
   {
-    "ascii": 96,
-    "code": 53,
-    "label": "`"
+    ascii: 96,
+    code: 53,
+    label: '`',
   },
   {
-    "ascii": 97,
-    "code": 4,
-    "label": "a"
+    ascii: 97,
+    code: 4,
+    label: 'a',
   },
   {
-    "ascii": 98,
-    "code": 23,
-    "label": "b"
+    ascii: 98,
+    code: 23,
+    label: 'b',
   },
   {
-    "ascii": 99,
-    "code": 6,
-    "label": "c"
+    ascii: 99,
+    code: 6,
+    label: 'c',
   },
   {
-    "ascii": 100,
-    "code": 26,
-    "label": "d"
+    ascii: 100,
+    code: 26,
+    label: 'd',
   },
   {
-    "ascii": 101,
-    "code": 14,
-    "label": "e"
+    ascii: 101,
+    code: 14,
+    label: 'e',
   },
   {
-    "ascii": 102,
-    "code": 24,
-    "label": "f"
+    ascii: 102,
+    code: 24,
+    label: 'f',
   },
   {
-    "ascii": 103,
-    "code": 10,
-    "label": "g"
+    ascii: 103,
+    code: 10,
+    label: 'g',
   },
   {
-    "ascii": 104,
-    "code": 7,
-    "label": "h"
+    ascii: 104,
+    code: 7,
+    label: 'h',
   },
   {
-    "ascii": 105,
-    "code": 51,
-    "label": "i"
+    ascii: 105,
+    code: 51,
+    label: 'i',
   },
   {
-    "ascii": 106,
-    "code": 28,
-    "label": "j"
+    ascii: 106,
+    code: 28,
+    label: 'j',
   },
   {
-    "ascii": 107,
-    "code": 17,
-    "label": "k"
+    ascii: 107,
+    code: 17,
+    label: 'k',
   },
   {
-    "ascii": 108,
-    "code": 16,
-    "label": "l"
+    ascii: 108,
+    code: 16,
+    label: 'l',
   },
   {
-    "ascii": 109,
-    "code": 5,
-    "label": "m"
+    ascii: 109,
+    code: 5,
+    label: 'm',
   },
   {
-    "ascii": 110,
-    "code": 13,
-    "label": "n"
+    ascii: 110,
+    code: 13,
+    label: 'n',
   },
   {
-    "ascii": 111,
-    "code": 15,
-    "label": "o"
+    ascii: 111,
+    code: 15,
+    label: 'o',
   },
   {
-    "ascii": 112,
-    "code": 18,
-    "label": "p"
+    ascii: 112,
+    code: 18,
+    label: 'p',
   },
   {
-    "ascii": 113,
-    "code": 20,
-    "label": "q"
+    ascii: 113,
+    code: 20,
+    label: 'q',
   },
   {
-    "ascii": 114,
-    "code": 8,
-    "label": "r"
+    ascii: 114,
+    code: 8,
+    label: 'r',
   },
   {
-    "ascii": 115,
-    "code": 22,
-    "label": "s"
+    ascii: 115,
+    code: 22,
+    label: 's',
   },
   {
-    "ascii": 116,
-    "code": 9,
-    "label": "t"
+    ascii: 116,
+    code: 9,
+    label: 't',
   },
   {
-    "ascii": 117,
-    "code": 12,
-    "label": "u"
+    ascii: 117,
+    code: 12,
+    label: 'u',
   },
   {
-    "ascii": 118,
-    "code": 25,
-    "label": "v"
+    ascii: 118,
+    code: 25,
+    label: 'v',
   },
   {
-    "ascii": 119,
-    "code": 21,
-    "label": "w"
+    ascii: 119,
+    code: 21,
+    label: 'w',
   },
   {
-    "ascii": 120,
-    "code": 27,
-    "label": "x"
+    ascii: 120,
+    code: 27,
+    label: 'x',
   },
   {
-    "ascii": 121,
-    "code": 11,
-    "label": "y"
+    ascii: 121,
+    code: 11,
+    label: 'y',
   },
   {
-    "ascii": 122,
-    "code": 29,
-    "label": "z"
+    ascii: 122,
+    code: 29,
+    label: 'z',
   },
   {
-    "ascii": 123,
-    "code": 47,
-    "label": "["
+    ascii: 123,
+    code: 47,
+    label: '[',
   },
   {
-    "ascii": 124,
-    "code": 49,
-    "label": "(backslash)"
+    ascii: 124,
+    code: 49,
+    label: '(backslash)',
   },
   {
-    "ascii": 125,
-    "code": 48,
-    "label": "]"
+    ascii: 125,
+    code: 48,
+    label: ']',
   },
   {
-    "ascii": 126,
-    "code": 53,
-    "label": "`"
+    ascii: 126,
+    code: 53,
+    label: '`',
   },
   {
-    "ascii": 127,
-    "code": 76,
-    "label": "del"
-  }
+    ascii: 127,
+    code: 76,
+    label: 'del',
+  },
 ];
-    


### PR DESCRIPTION
This pull request refomats source codes with Prettier (`yarn format`) automatically.