### PR TITLE
Support keyboard with encoder and ENCODER_MAP_ENABLE=no

### DIFF
--- a/src/components/configure/keycap/Keycap.container.ts
+++ b/src/components/configure/keycap/Keycap.container.ts
@@ -103,6 +103,9 @@ const mapDispatchToProps = (_dispatch: any) => {
       isSelectedKey: boolean,
       orgKey: Key
     ) => {
+      if (orgKey.keymap.unavailable) {
+        return;
+      }
       if (draggingKey.keymap.code === orgKey.keymap.code) {
         if (isSelectedKey) {
           // clear diff display

--- a/src/components/configure/keycap/Keycap.tsx
+++ b/src/components/configure/keycap/Keycap.tsx
@@ -90,6 +90,7 @@ export default class Keycap extends React.Component<
       orgKey,
       dstKey
     );
+    if (orgKey.keymap.unavailable) return;
     if (!this.props.isCustomKeyOpen && this.props.onClick) {
       this.props.onClick(
         model.pos,

--- a/src/components/configure/keymap/Keymap.container.ts
+++ b/src/components/configure/keymap/Keymap.container.ts
@@ -134,6 +134,9 @@ const mapDispatchToProps = (_dispatch: any) => {
       encoderId: number | null,
       keySwitchOperation: IKeySwitchOperation
     ) => {
+      if (oldKeymap.unavailable) {
+        return;
+      }
       if (newKey.keymap.code === oldKeymap.code) {
         _dispatch(KeydiffActions.clearKeydiff());
         if (keySwitchOperation === 'click') {

--- a/src/services/hid/Hid.ts
+++ b/src/services/hid/Hid.ts
@@ -67,6 +67,7 @@ export interface IKeymap {
   isAny: boolean;
   isAscii?: boolean;
   code: number;
+  unavailable?: boolean;
   kinds: KeymapCategory[];
   direction: IModDirection;
   modifiers: IMod[]; // Modifiers

--- a/src/services/hid/KeycodeList.ts
+++ b/src/services/hid/KeycodeList.ts
@@ -1,4 +1,5 @@
 import { ICustomKeycode, IKeymap } from './Hid';
+import { MOD_LEFT } from './Constraints';
 import {
   IKeycodeCompositionKind,
   KeycodeCompositionFactory,
@@ -175,10 +176,26 @@ export class KeycodeList {
   }
 
   static getKeymap(
-    code: number,
+    code: number | null,
     labelLang: KeyboardLabelLang,
     customKeycodes: ICustomKeycode[] | undefined
   ): IKeymap {
+    if (code === null) {
+      return {
+        isAny: false,
+        code: 0,
+        unavailable: true,
+        kinds: [],
+        direction: MOD_LEFT,
+        modifiers: [],
+        keycodeInfo: {
+          label: 'N/A',
+          code: 0,
+          name: { long: '', short: '' },
+          keywords: [],
+        },
+      };
+    }
     const { value, holdKey, tapKey } = KeycodeList.getKeymaps(
       code,
       labelLang,

--- a/src/services/hid/WebHid.ts
+++ b/src/services/hid/WebHid.ts
@@ -220,12 +220,12 @@ export class Keyboard implements IKeyboard {
         const counterclockwiseResponse = responses[i++];
         keymap[encoderId] = {
           clockwise: KeycodeList.getKeymap(
-            clockwiseResponse.code!,
+            clockwiseResponse.code,
             labelLang,
             customKeycodes
           ),
           counterclockwise: KeycodeList.getKeymap(
-            counterclockwiseResponse.code!,
+            counterclockwiseResponse.code,
             labelLang,
             customKeycodes
           ),


### PR DESCRIPTION
If a firmware is built with ENCODER_MAP_ENABLE=no, id_dynamic_keymap_get_encoder won't be handled and https://remap-keys.app/configure will not go beyond "Opening keyboard".

This PR modifies remap-keys.app to handle unhandled errors for that command.

When ENCODER_MAP_ENABLED=no, we can't remap cw/ccw.
So we show them with a label "N/A" and make them uneditable.

fixes https://github.com/remap-keys/remap/issues/867

<img width="1459" alt="スクリーンショット 2025-03-22 0 52 37" src="https://github.com/user-attachments/assets/98ea299c-e832-413c-a6e1-50f3bbed14cf" />
