### PR TITLE
Add a new support version of QMK Firmware: 0.28.3

### DIFF
--- a/src/services/storage/Storage.ts
+++ b/src/services/storage/Storage.ts
@@ -270,7 +270,10 @@ export type IFetchOrganizationMembersResult = IResult<{
   members: IOrganizationMember[];
 }>;
 
-export const BUILDABLE_FIRMWARE_QMK_FIRMWARE_VERSION = ['0.22.14'] as const;
+export const BUILDABLE_FIRMWARE_QMK_FIRMWARE_VERSION = [
+  '0.22.14',
+  '0.28.3',
+] as const;
 type buildableFirmwareQmkFirmwareVersionTuple =
   typeof BUILDABLE_FIRMWARE_QMK_FIRMWARE_VERSION;
 export type IBuildableFirmwareQmkFirmwareVersion =


### PR DESCRIPTION
This pull request adds a new support version of QMK Firmware 0.28.3 so that keyboard owners can specify the version to build a firmware by users.