### PR TITLE
fix: Prevent input content reset in Breadboard editor

### DIFF
--- a/src/components/workbench/breadboard/Breadboard.tsx
+++ b/src/components/workbench/breadboard/Breadboard.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useState, useRef } from 'react';
 import {
   BreadboardActionsType,
   BreadboardStateType,
@@ -500,13 +500,19 @@ type WorkbenchSourceCodeEditorProps = {
 
 function WorkbenchSourceCodeEditor(props: WorkbenchSourceCodeEditorProps) {
   const [code, setCode] = useState<string | undefined>(undefined);
+  const currentFileRef = useRef<string | undefined>(undefined);
 
   useEffect(() => {
     if (props.project === undefined || props.file === undefined) {
       setCode(undefined);
+      currentFileRef.current = undefined;
       return;
     }
-    setCode(props.file.code);
+    // Only update local state when file changes (different file selected)
+    if (currentFileRef.current !== props.file.id) {
+      setCode(props.file.code);
+      currentFileRef.current = props.file.id;
+    }
   }, [props.project, props.file]);
 
   const debounceCode = useDebounce(code, props.file, 1000);


### PR DESCRIPTION
$(cat <<'EOF'
## Summary
- Fix input content reset issue in Breadboard editor component
- Add useRef to track current file ID for proper state management
- Prevent unnecessary local state updates during Redux state synchronization

## Problem
Users experienced input content disappearing while typing in the Breadboard editor. This occurred due to:
1. Local state being reset when Redux state updated
2. Timing conflicts between user input and debounced save operations
3. Monaco Editor's controlled component behavior causing content loss

## Solution
- Added `currentFileRef` to track the currently selected file ID
- Modified `useEffect` to only update local state when a different file is selected
- Preserved user input during same-file editing sessions
- Maintained existing debounced save functionality

## Test plan
- [ ] Verify typing in editor no longer causes content to disappear
- [ ] Confirm file switching still works correctly
- [ ] Test debounced save functionality remains intact
- [ ] Check multiple rapid file switches work properly

🤖 Generated with [Claude Code](https://claude.ai/code)
EOF
)