### PR TITLE
fix: Remove unused imports to resolve ESLint warnings

### DIFF
--- a/src/actions/workbench.action.ts
+++ b/src/actions/workbench.action.ts
@@ -1,17 +1,11 @@
 import { ThunkAction, ThunkDispatch } from 'redux-thunk';
-import {
-  IUserInformation,
-  IWorkbenchPhase,
-  RootState,
-  WorkbenchPhase,
-} from '../store/state';
+import { IWorkbenchPhase, RootState, WorkbenchPhase } from '../store/state';
 import { AppActions, NotificationActions } from './actions';
 import { StorageActions } from './storage.action';
-import { errorResultOf, IEmptyResult, isError, successResult } from '../types';
+import { isError } from '../types';
 import {
   IBuildableFirmwareFileType,
   IFirmwareBuildingTask,
-  IStorage,
   IUserPurchaseHistory,
   IWorkbenchProject,
   IWorkbenchProjectFile,

--- a/src/components/workbench/dialogs/RemainingBuildPurchaseHistoryDialog.container.tsx
+++ b/src/components/workbench/dialogs/RemainingBuildPurchaseHistoryDialog.container.tsx
@@ -1,7 +1,6 @@
 import { connect } from 'react-redux';
 import { RootState } from '../../../store/state';
 import RemainingBuildPurchaseHistoryDialog from './RemainingBuildPurchaseHistoryDialog';
-import { clear } from 'console';
 import { WorkbenchAppActions } from '../../../actions/workbench.action';
 
 // eslint-disable-next-line no-unused-vars


### PR DESCRIPTION
$(cat <<'EOF'
## Summary
- Remove unused imports from workbench.action.ts (IUserInformation, errorResultOf, IEmptyResult, successResult, IStorage)
- Remove unused import from RemainingBuildPurchaseHistoryDialog.container.tsx (clear from console)
- Fixes all ESLint unused variable warnings found during yarn lint

## Test plan
- [x] Run `yarn lint` - no more unused import warnings
- [x] Run `yarn format` - code properly formatted
- [x] Run `yarn type-check` - no type errors

🤖 Generated with [Claude Code](https://claude.ai/code)
EOF
)