### PR TITLE
feat: Add QMK Firmware 0.32.8 as a supported build version

### DIFF
--- a/src/services/storage/Storage.ts
+++ b/src/services/storage/Storage.ts
@@ -238,6 +238,7 @@ export type IFetchOrganizationMembersResult = IResult<{
 export const BUILDABLE_FIRMWARE_QMK_FIRMWARE_VERSION = [
   '0.22.14',
   '0.28.3',
+  '0.32.8',
 ] as const;
 type buildableFirmwareQmkFirmwareVersionTuple =
   typeof BUILDABLE_FIRMWARE_QMK_FIRMWARE_VERSION;


### PR DESCRIPTION
## Summary
- Add QMK Firmware `0.32.8` to the supported build versions list
- New projects will default to `0.32.8` (latest entry in the version array)

## Test plan
- [x] Create a new workbench project → verify QMK Firmware version defaults to 0.32.8
- [x] Verify 0.32.8 appears in the version selector dropdown
- [x] Verify existing projects with 0.22.14 or 0.28.3 continue to work

🤖 Generated with [Claude Code](https://claude.com/claude-code)