### PR TITLE
fix: Trim stale keycodes when keyboard.json layout shrinks

### DIFF
--- a/src/components/workbench/visualeditor/VisualKeymapEditor.tsx
+++ b/src/components/workbench/visualeditor/VisualKeymapEditor.tsx
@@ -242,13 +242,23 @@ export default function VisualKeymapEditor({
   }, [localKeymap, selectedLayer, layoutData]);
 
   // Apply a change to the local keymap and propagate to parent.
+  // Trims keycodeNames to match the keyboard.json layout key count so that
+  // deleted keys do not leave stale keycodes in the generated keymap.c.
   const applyKeymapUpdate = useCallback(
     (updatedKeymap: ParsedKeymap) => {
-      setLocalKeymap(updatedKeymap);
-      const newCode = generateKeymapC(
-        updatedKeymap,
-        layoutData?.keysPerRow
-      );
+      const layoutKeyCount = layoutData?.keyModels.length;
+      const trimmedKeymap =
+        layoutKeyCount != null
+          ? {
+              ...updatedKeymap,
+              layers: updatedKeymap.layers.map((layer) => ({
+                ...layer,
+                keycodeNames: layer.keycodeNames.slice(0, layoutKeyCount),
+              })),
+            }
+          : updatedKeymap;
+      setLocalKeymap(trimmedKeymap);
+      const newCode = generateKeymapC(trimmedKeymap, layoutData?.keysPerRow);
       // Update the ref so the useEffect won't re-parse when this code
       // comes back from the parent via props.
       prevKeymapCodeRef.current = newCode;


### PR DESCRIPTION
## Summary
- When a key is removed from `keyboard.json`, subsequent Visual Editor edits previously left the deleted keycodes behind in `keymap.c` because `localKeymap` still held the original `keycodeNames` array.
- `applyKeymapUpdate` now trims each layer's `keycodeNames` to the current layout key count, so every edit path (key change, layer add/delete) keeps `keymap.c` in sync with the layout.

## Test plan
- [x] `npm run type-check` passes
- [x] `npm run lint` (no new errors from this change)
- [x] `npm test -- --run src/services/workbench src/components/workbench` (173 tests pass)
- [x] Manual: shrink a keyboard.json layout, then edit via Visual Editor and confirm stale keycodes no longer appear in keymap.c

🤖 Generated with [Claude Code](https://claude.com/claude-code)