### PR TITLE
feat: Move audio driver setting from config.h to keyboard.json Form Editor

### DIFF
--- a/src/components/workbench/dialogs/ConfigHSettingsPanel.tsx
+++ b/src/components/workbench/dialogs/ConfigHSettingsPanel.tsx
@@ -6,7 +6,6 @@ import React, {
   useMemo,
 } from 'react';
 import {
-  Autocomplete,
   FormControlLabel,
   Stack,
   Switch,
@@ -148,7 +147,6 @@ export function ConfigHSettingsPanel(props: ConfigHSettingsPanelProps) {
   // --- Audio ---
   const [audioPin, setAudioPin] = useState('');
   const [audioPinAlt, setAudioPinAlt] = useState('');
-  const [audioDriver, setAudioDriver] = useState('');
   const [audioVoices, setAudioVoices] = useState(false);
   const [audioInitDelay, setAudioInitDelay] = useState(false);
 
@@ -224,7 +222,6 @@ export function ConfigHSettingsPanel(props: ConfigHSettingsPanelProps) {
       // Audio
       setAudioPin(getNumeric(defines, 'AUDIO_PIN'));
       setAudioPinAlt(getNumeric(defines, 'AUDIO_PIN_ALT'));
-      setAudioDriver(getNumeric(defines, 'AUDIO_DRIVER'));
       setAudioVoices(getFlag(defines, 'AUDIO_VOICES'));
       setAudioInitDelay(getFlag(defines, 'AUDIO_INIT_DELAY'));
     } catch {
@@ -314,7 +311,6 @@ export function ConfigHSettingsPanel(props: ConfigHSettingsPanelProps) {
       // Audio
       setStr('AUDIO_PIN', audioPin);
       setStr('AUDIO_PIN_ALT', audioPinAlt);
-      setStr('AUDIO_DRIVER', audioDriver);
       setBool('AUDIO_VOICES', audioVoices);
       setBool('AUDIO_INIT_DELAY', audioInitDelay);
 
@@ -359,7 +355,6 @@ export function ConfigHSettingsPanel(props: ConfigHSettingsPanelProps) {
     usbVbusPin,
     audioPin,
     audioPinAlt,
-    audioDriver,
     audioVoices,
     audioInitDelay,
   ]);
@@ -941,28 +936,6 @@ export function ConfigHSettingsPanel(props: ConfigHSettingsPanelProps) {
                     placeholder="B5"
                     helperText={t(
                       'Secondary audio output pin for stereo or alternative output'
-                    )}
-                  />
-                  <Autocomplete
-                    size="small"
-                    freeSolo
-                    options={[
-                      'pwm_hardware',
-                      'pwm_software',
-                      'dac_basic',
-                      'dac_additive',
-                    ]}
-                    value={audioDriver}
-                    onInputChange={(_e, value) => setAudioDriver(value)}
-                    renderInput={(params) => (
-                      <TextField
-                        {...params}
-                        label="AUDIO_DRIVER"
-                        placeholder="pwm_hardware"
-                        helperText={t(
-                          'Audio driver (pwm_hardware, pwm_software, dac_basic, dac_additive)'
-                        )}
-                      />
                     )}
                   />
                   <SwitchField

--- a/src/components/workbench/dialogs/KeyboardJsonEditorDialog.tsx
+++ b/src/components/workbench/dialogs/KeyboardJsonEditorDialog.tsx
@@ -177,6 +177,9 @@ export function KeyboardJsonSettingsPanel(
     Record<string, boolean>
   >({});
 
+  // Audio
+  const [audioDriver, setAudioDriver] = useState('');
+
   // Encoder
   const [encoderRotary, setEncoderRotary] = useState<EncoderEntry[]>([]);
 
@@ -301,6 +304,9 @@ export function KeyboardJsonSettingsPanel(
           ? { ...json.rgblight.animations }
           : {}
       );
+
+      // Audio
+      setAudioDriver(json.audio?.driver ?? '');
 
       // Encoder
       if (Array.isArray(json.encoder?.rotary)) {
@@ -560,6 +566,17 @@ export function KeyboardJsonSettingsPanel(
       }
     }
 
+    // Audio
+    if (audioDriver) {
+      json.audio = json.audio || {};
+      json.audio.driver = audioDriver;
+    } else if (json.audio) {
+      delete json.audio.driver;
+      if (Object.keys(json.audio).length === 0) {
+        delete json.audio;
+      }
+    }
+
     // Encoder
     if (encoderRotary.length > 0) {
       json.encoder = json.encoder || {};
@@ -618,6 +635,7 @@ export function KeyboardJsonSettingsPanel(
     rgblightBriSteps,
     rgblightMaxBrightness,
     rgblightAnimations,
+    audioDriver,
     encoderRotary,
     features,
   ]);
@@ -745,6 +763,15 @@ export function KeyboardJsonSettingsPanel(
           />
           <Tab
             label={t('Lighting')}
+            sx={{
+              minHeight: 36,
+              py: 0.5,
+              textTransform: 'none',
+              alignItems: 'flex-start',
+            }}
+          />
+          <Tab
+            label={t('Audio')}
             sx={{
               minHeight: 36,
               py: 0.5,
@@ -1372,8 +1399,41 @@ export function KeyboardJsonSettingsPanel(
             </Stack>
           )}
 
-          {/* === Encoder Tab === */}
+          {/* === Audio Tab === */}
           {activeTab === 5 && (
+            <Stack spacing={3}>
+              <div>
+                <SectionHeader>{t('Audio')}</SectionHeader>
+                <Stack spacing={2} sx={{ mt: 1 }}>
+                  <Autocomplete
+                    size="small"
+                    freeSolo
+                    options={[
+                      'pwm_hardware',
+                      'pwm_software',
+                      'dac_basic',
+                      'dac_additive',
+                    ]}
+                    value={audioDriver}
+                    onInputChange={(_e, value) => setAudioDriver(value)}
+                    renderInput={(params) => (
+                      <TextField
+                        {...params}
+                        label={t('Driver')}
+                        placeholder="pwm_hardware"
+                        helperText={t(
+                          'Audio driver (pwm_hardware, pwm_software, dac_basic, dac_additive)'
+                        )}
+                      />
+                    )}
+                  />
+                </Stack>
+              </div>
+            </Stack>
+          )}
+
+          {/* === Encoder Tab === */}
+          {activeTab === 6 && (
             <Stack spacing={3}>
               {/* Encoder Section */}
               <div>


### PR DESCRIPTION
## Summary
- Remove `AUDIO_DRIVER` from config.h Form Editor (QMK ignores it in config.h)
- Add **Audio** tab to keyboard.json Form Editor with `audio.driver` selection
  - FreeSolo autocomplete: select from pwm_hardware, pwm_software, dac_basic, dac_additive or type a custom value
- Tab order: General → USB/MCU → Hardware → Features → Lighting → **Audio** → Encoder

## Test plan
- [x] Open config.h → Form Editor → Audio tab → verify AUDIO_DRIVER field is gone
- [x] Open keyboard.json → Form Editor → verify Audio tab exists between Lighting and Encoder
- [x] Select "pwm_hardware" from dropdown → switch to Code Editor → verify `"audio": { "driver": "pwm_hardware" }` in JSON
- [x] Type custom driver value → verify it appears in JSON
- [x] Clear driver value → verify `audio` object is removed from JSON
- [x] Verify Encoder tab still works at index 6

🤖 Generated with [Claude Code](https://claude.com/claude-code)